### PR TITLE
feat(#40 Fix2 Stage1): owner-authorization gate on /signature/sign

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "ws": "^8.18.3"
       },
       "devDependencies": {
+        "@jest/globals": "^30.4.1",
         "@types/express": "^5.0.6",
         "@types/jest": "^30.0.0",
         "@typescript-eslint/eslint-plugin": "^8.44.1",
@@ -1710,19 +1711,447 @@
       }
     },
     "node_modules/@jest/globals": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
-      "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmmirror.com/@jest/globals/-/globals-30.4.1.tgz",
+      "integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.2.0",
-        "@jest/expect": "30.2.0",
-        "@jest/types": "30.2.0",
-        "jest-mock": "30.2.0"
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/types": "30.4.1",
+        "jest-mock": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmmirror.com/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/@jest/environment": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmmirror.com/@jest/environment/-/environment-30.4.1.tgz",
+      "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-mock": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/@jest/expect": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmmirror.com/@jest/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "30.4.1",
+        "jest-snapshot": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/@jest/expect-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmmirror.com/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/@jest/fake-timers": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmmirror.com/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+      "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@sinonjs/fake-timers": "^15.4.0",
+        "@types/node": "*",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmmirror.com/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmmirror.com/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/@jest/snapshot-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmmirror.com/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+      "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/@jest/transform": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmmirror.com/@jest/transform/-/transform-30.4.1.tgz",
+      "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/types": "30.4.1",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "babel-plugin-istanbul": "^7.0.1",
+        "chalk": "^4.1.2",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "pirates": "^4.0.7",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/@jest/types": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmmirror.com/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/@sinonjs/fake-timers": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmmirror.com/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/expect": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmmirror.com/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/jest-diff": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmmirror.com/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/jest-haste-map": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmmirror.com/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+      "integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "anymatch": "^3.1.3",
+        "fb-watchman": "^2.0.2",
+        "graceful-fs": "^4.2.11",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
+        "picomatch": "^4.0.3",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.3"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/jest-matcher-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmmirror.com/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/jest-message-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmmirror.com/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.4.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/jest-mock": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmmirror.com/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/jest-regex-util": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmmirror.com/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/jest-snapshot": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmmirror.com/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+      "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@babel/generator": "^7.27.5",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1",
+        "@babel/types": "^7.27.3",
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "@jest/snapshot-utils": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-preset-current-node-syntax": "^1.2.0",
+        "chalk": "^4.1.2",
+        "expect": "30.4.1",
+        "graceful-fs": "^4.2.11",
+        "jest-diff": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1",
+        "semver": "^7.7.2",
+        "synckit": "^0.11.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/jest-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmmirror.com/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/jest-worker": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmmirror.com/jest-worker/-/jest-worker-30.4.1.tgz",
+      "integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@ungap/structured-clone": "^1.3.0",
+        "jest-util": "30.4.1",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmmirror.com/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmmirror.com/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/@jest/pattern": {
@@ -7093,6 +7522,22 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-runtime/node_modules/@jest/globals": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmmirror.com/@jest/globals/-/globals-30.2.0.tgz",
+      "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.2.0",
+        "@jest/expect": "30.2.0",
+        "@jest/types": "30.2.0",
+        "jest-mock": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/jest-runtime/node_modules/strip-bom": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
@@ -8374,6 +8819,22 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmmirror.com/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmmirror.com/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "lint:check": "eslint \"{src,apps,libs,test}/**/*.ts\"",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
-    "test": "jest --passWithNoTests",
-    "test:ci": "jest --ci --coverage --maxWorkers=2 --passWithNoTests",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests",
+    "test:ci": "NODE_OPTIONS=--experimental-vm-modules jest --ci --coverage --maxWorkers=2 --passWithNoTests",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
@@ -66,6 +66,7 @@
   "author": "YetAnotherAA Contributors",
   "license": "MIT",
   "devDependencies": {
+    "@jest/globals": "^30.4.1",
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",
     "@typescript-eslint/eslint-plugin": "^8.44.1",

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -28,6 +28,10 @@ export default () => {
     ethRpcUrl: process.env.ETH_RPC_URL,
     ethPrivateKey: process.env.ETH_PRIVATE_KEY,
     validatorContractAddress: process.env.VALIDATOR_CONTRACT_ADDRESS,
+    // Canonical ERC-4337 v0.7 EntryPoint (same address across chains). Used to
+    // derive the authoritative userOpHash for the Fix 2 Stage 1 owner-auth gate.
+    entryPointAddress:
+      process.env.ENTRY_POINT_ADDRESS || "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
 
     // Gossip Network
     gossipPublicUrl: process.env.GOSSIP_PUBLIC_URL || `ws://localhost:${port}/ws`,

--- a/src/dto/sign.dto.ts
+++ b/src/dto/sign.dto.ts
@@ -1,11 +1,4 @@
-import {
-  IsString,
-  IsNotEmpty,
-  IsEthereumAddress,
-  ValidateNested,
-  IsOptional,
-} from "class-validator";
-import { Type } from "class-transformer";
+import { IsOptional, IsObject } from "class-validator";
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 
 /**
@@ -16,59 +9,50 @@ import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
  * caller-supplied hash. This binds the signed hash to `sender`, the EntryPoint,
  * and chainId — closing the cross-account oracle hole (an attacker can no longer
  * pair their own account's owner signature with a victim's userOpHash).
+ *
+ * NOTE: the individual fields are intentionally NOT shape-validated by the DTO.
+ * A malformed userOp must surface as 403 from the authorization gate (which
+ * validates `sender` and lets `EntryPoint.getUserOpHash` reject the rest),
+ * keeping the entire /signature/sign endpoint uniformly fail-closed with 403
+ * rather than mixing 400 (validation) and 403 (authorization). This is purely
+ * about the shape of a *signing request* — there is no signing-leak path either
+ * way, since signing only happens after the gate passes.
  */
 export class PackedUserOperationDto {
   @ApiProperty({
     description: "Account that the UserOperation is for (becomes the authorized account)",
     example: "0x08923CE682336DF2f238C034B4add5Bf73d4028A",
   })
-  @IsString()
-  @IsNotEmpty()
-  @IsEthereumAddress({ message: "userOp.sender must be a valid Ethereum address" })
   sender: string;
 
   @ApiProperty({ description: "Nonce (uint256, decimal or 0x-hex)", example: "0" })
-  @IsString()
-  @IsNotEmpty()
   nonce: string;
 
   @ApiProperty({
     description: "Account init code (0x for already-deployed accounts)",
     example: "0x",
   })
-  @IsString()
-  @IsNotEmpty()
   initCode: string;
 
   @ApiProperty({ description: "Call data", example: "0x" })
-  @IsString()
-  @IsNotEmpty()
   callData: string;
 
   @ApiProperty({
     description: "Packed verificationGasLimit + callGasLimit (bytes32)",
     example: "0x" + "00".repeat(32),
   })
-  @IsString()
-  @IsNotEmpty()
   accountGasLimits: string;
 
   @ApiProperty({ description: "preVerificationGas (uint256)", example: "0" })
-  @IsString()
-  @IsNotEmpty()
   preVerificationGas: string;
 
   @ApiProperty({
     description: "Packed maxPriorityFeePerGas + maxFeePerGas (bytes32)",
     example: "0x" + "00".repeat(32),
   })
-  @IsString()
-  @IsNotEmpty()
   gasFees: string;
 
   @ApiProperty({ description: "Paymaster and data (0x if none)", example: "0x" })
-  @IsString()
-  @IsNotEmpty()
   paymasterAndData: string;
 
   @ApiPropertyOptional({
@@ -77,8 +61,6 @@ export class PackedUserOperationDto {
       "does not affect getUserOpHash in v0.7. Defaults to 0x.",
     example: "0x",
   })
-  @IsString()
-  @IsOptional()
   signature?: string;
 }
 
@@ -93,26 +75,24 @@ export class PackedUserOperationDto {
  * obtain a DVT co-sign for someone else's userOpHash. It does NOT defend
  * against owner-key compromise — that is Stage 2 (issue #40).
  *
- * `ownerAuth` shape is intentionally NOT regex-validated here: all
- * owner-authorization failures (missing/malformed/mismatched) must surface as
- * 403 from the authorization gate, not as a 400 from the ValidationPipe.
+ * Uniform fail-closed contract: EVERY rejected request returns 403 from the
+ * authorization gate, never a 400 from the ValidationPipe. The DTO therefore
+ * does only the minimum shape check (`userOp` is an object); all field-level
+ * and signature validation happens inside the gate → 403.
  */
 export class SignMessageDto {
   @ApiProperty({
     description: "The full ERC-4337 v0.7 PackedUserOperation to co-sign",
     type: PackedUserOperationDto,
   })
-  @ValidateNested()
-  @Type(() => PackedUserOperationDto)
-  @IsNotEmpty()
+  @IsObject()
   userOp: PackedUserOperationDto;
 
   @ApiProperty({
     description:
       "Account-owner ECDSA signature (EIP-191) over the EntryPoint-derived userOpHash. " +
       "Reuse the same owner signature that signs the UserOperation. 65-byte hex, 0x-prefixed. " +
-      "Intentionally not shape-validated: malformed/missing values are rejected with 403 by " +
-      "the authorization gate (consistent owner-auth-failure contract), not 400.",
+      "Malformed/missing values are rejected with 403 by the authorization gate, not 400.",
     example: "0x" + "ab".repeat(65),
     required: false,
   })

--- a/src/dto/sign.dto.ts
+++ b/src/dto/sign.dto.ts
@@ -1,32 +1,49 @@
-import { IsString, IsNotEmpty, IsArray, ArrayMinSize } from "class-validator";
+import { IsString, IsNotEmpty, Matches, IsEthereumAddress } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger";
 
+/**
+ * Request to have this DVT node co-sign a userOpHash.
+ *
+ * Fix 2 Stage 1 (owner-authorization gate): the node will ONLY co-sign when the
+ * request carries a valid account-owner signature (`ownerAuth`) over `userOpHash`.
+ * This closes the open-oracle hole (a network-reachable attacker without the owner
+ * key can no longer obtain a DVT co-sign). It does NOT defend against owner-key
+ * compromise — that is Stage 2, tracked in YetAnotherAA-Validator issue #40.
+ *
+ * The value actually BLS-signed by the node remains `hashToCurve(userOpHash)`;
+ * `account` and `ownerAuth` are used solely for the authorization check.
+ */
 export class SignMessageDto {
   @ApiProperty({
-    description: "The message to be signed",
-    example: "Hello, World!",
+    description: "The ERC-4337 userOpHash to be BLS co-signed (32-byte hex, 0x-prefixed)",
+    example: "0x8bb1b199f427dfc49e5fe40f2f3278cb1a48587824b78263051c8c4d81d77a81",
   })
   @IsString()
   @IsNotEmpty()
-  message: string;
-}
+  @Matches(/^0x[0-9a-fA-F]{64}$/, {
+    message: "userOpHash must be a 0x-prefixed 32-byte hex string",
+  })
+  userOpHash: string;
 
-export class AggregateSignatureDto {
   @ApiProperty({
-    description: "The message to be signed by multiple nodes",
-    example: "Hello, World!",
+    description: "The AirAccount address whose owner authorizes this co-sign request",
+    example: "0x08923CE682336DF2f238C034B4add5Bf73d4028A",
   })
   @IsString()
   @IsNotEmpty()
-  message: string;
+  @IsEthereumAddress({ message: "account must be a valid Ethereum address" })
+  account: string;
 
   @ApiProperty({
-    description: "Array of node IDs that should sign the message",
-    example: ["node1", "node2", "node3"],
-    type: [String],
+    description:
+      "Account-owner ECDSA signature (EIP-191) over userOpHash. Reuse the same owner " +
+      "signature that signs the UserOperation. 65-byte hex, 0x-prefixed.",
+    example: "0x" + "ab".repeat(65),
   })
-  @IsArray()
-  @ArrayMinSize(1)
-  @IsString({ each: true })
-  nodeIds: string[];
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^0x[0-9a-fA-F]+$/, {
+    message: "ownerAuth must be a 0x-prefixed hex string",
+  })
+  ownerAuth: string;
 }

--- a/src/dto/sign.dto.ts
+++ b/src/dto/sign.dto.ts
@@ -1,49 +1,121 @@
-import { IsString, IsNotEmpty, Matches, IsEthereumAddress } from "class-validator";
-import { ApiProperty } from "@nestjs/swagger";
+import {
+  IsString,
+  IsNotEmpty,
+  IsEthereumAddress,
+  ValidateNested,
+  IsOptional,
+} from "class-validator";
+import { Type } from "class-transformer";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 
 /**
- * Request to have this DVT node co-sign a userOpHash.
+ * ERC-4337 v0.7 PackedUserOperation.
  *
- * Fix 2 Stage 1 (owner-authorization gate): the node will ONLY co-sign when the
- * request carries a valid account-owner signature (`ownerAuth`) over `userOpHash`.
- * This closes the open-oracle hole (a network-reachable attacker without the owner
- * key can no longer obtain a DVT co-sign). It does NOT defend against owner-key
- * compromise — that is Stage 2, tracked in YetAnotherAA-Validator issue #40.
- *
- * The value actually BLS-signed by the node remains `hashToCurve(userOpHash)`;
- * `account` and `ownerAuth` are used solely for the authorization check.
+ * Carries the FULL UserOperation so the node can derive the authoritative
+ * userOpHash itself (via EntryPoint.getUserOpHash) rather than trusting a
+ * caller-supplied hash. This binds the signed hash to `sender`, the EntryPoint,
+ * and chainId — closing the cross-account oracle hole (an attacker can no longer
+ * pair their own account's owner signature with a victim's userOpHash).
  */
-export class SignMessageDto {
+export class PackedUserOperationDto {
   @ApiProperty({
-    description: "The ERC-4337 userOpHash to be BLS co-signed (32-byte hex, 0x-prefixed)",
-    example: "0x8bb1b199f427dfc49e5fe40f2f3278cb1a48587824b78263051c8c4d81d77a81",
-  })
-  @IsString()
-  @IsNotEmpty()
-  @Matches(/^0x[0-9a-fA-F]{64}$/, {
-    message: "userOpHash must be a 0x-prefixed 32-byte hex string",
-  })
-  userOpHash: string;
-
-  @ApiProperty({
-    description: "The AirAccount address whose owner authorizes this co-sign request",
+    description: "Account that the UserOperation is for (becomes the authorized account)",
     example: "0x08923CE682336DF2f238C034B4add5Bf73d4028A",
   })
   @IsString()
   @IsNotEmpty()
-  @IsEthereumAddress({ message: "account must be a valid Ethereum address" })
-  account: string;
+  @IsEthereumAddress({ message: "userOp.sender must be a valid Ethereum address" })
+  sender: string;
+
+  @ApiProperty({ description: "Nonce (uint256, decimal or 0x-hex)", example: "0" })
+  @IsString()
+  @IsNotEmpty()
+  nonce: string;
 
   @ApiProperty({
-    description:
-      "Account-owner ECDSA signature (EIP-191) over userOpHash. Reuse the same owner " +
-      "signature that signs the UserOperation. 65-byte hex, 0x-prefixed.",
-    example: "0x" + "ab".repeat(65),
+    description: "Account init code (0x for already-deployed accounts)",
+    example: "0x",
   })
   @IsString()
   @IsNotEmpty()
-  @Matches(/^0x[0-9a-fA-F]+$/, {
-    message: "ownerAuth must be a 0x-prefixed hex string",
+  initCode: string;
+
+  @ApiProperty({ description: "Call data", example: "0x" })
+  @IsString()
+  @IsNotEmpty()
+  callData: string;
+
+  @ApiProperty({
+    description: "Packed verificationGasLimit + callGasLimit (bytes32)",
+    example: "0x" + "00".repeat(32),
   })
-  ownerAuth: string;
+  @IsString()
+  @IsNotEmpty()
+  accountGasLimits: string;
+
+  @ApiProperty({ description: "preVerificationGas (uint256)", example: "0" })
+  @IsString()
+  @IsNotEmpty()
+  preVerificationGas: string;
+
+  @ApiProperty({
+    description: "Packed maxPriorityFeePerGas + maxFeePerGas (bytes32)",
+    example: "0x" + "00".repeat(32),
+  })
+  @IsString()
+  @IsNotEmpty()
+  gasFees: string;
+
+  @ApiProperty({ description: "Paymaster and data (0x if none)", example: "0x" })
+  @IsString()
+  @IsNotEmpty()
+  paymasterAndData: string;
+
+  @ApiPropertyOptional({
+    description:
+      "UserOperation signature field. Not used for authorization (ownerAuth is) and " +
+      "does not affect getUserOpHash in v0.7. Defaults to 0x.",
+    example: "0x",
+  })
+  @IsString()
+  @IsOptional()
+  signature?: string;
+}
+
+/**
+ * Request to have this DVT node co-sign a UserOperation.
+ *
+ * Fix 2 Stage 1 (owner-authorization gate): the node co-signs ONLY when the
+ * request carries a valid account-owner signature (`ownerAuth`) over the
+ * userOpHash DERIVED from the full `userOp` (never a caller-supplied hash).
+ * This closes the open-oracle hole — a network-reachable attacker without the
+ * owner key, and an attacker who owns a *different* account, can no longer
+ * obtain a DVT co-sign for someone else's userOpHash. It does NOT defend
+ * against owner-key compromise — that is Stage 2 (issue #40).
+ *
+ * `ownerAuth` shape is intentionally NOT regex-validated here: all
+ * owner-authorization failures (missing/malformed/mismatched) must surface as
+ * 403 from the authorization gate, not as a 400 from the ValidationPipe.
+ */
+export class SignMessageDto {
+  @ApiProperty({
+    description: "The full ERC-4337 v0.7 PackedUserOperation to co-sign",
+    type: PackedUserOperationDto,
+  })
+  @ValidateNested()
+  @Type(() => PackedUserOperationDto)
+  @IsNotEmpty()
+  userOp: PackedUserOperationDto;
+
+  @ApiProperty({
+    description:
+      "Account-owner ECDSA signature (EIP-191) over the EntryPoint-derived userOpHash. " +
+      "Reuse the same owner signature that signs the UserOperation. 65-byte hex, 0x-prefixed. " +
+      "Intentionally not shape-validated: malformed/missing values are rejected with 403 by " +
+      "the authorization gate (consistent owner-auth-failure contract), not 400.",
+    example: "0x" + "ab".repeat(65),
+    required: false,
+  })
+  @IsOptional()
+  ownerAuth?: string;
 }

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -209,6 +209,31 @@ export class BlockchainService {
     }
   }
 
+  /**
+   * Read the on-chain owner of an AirAccount.
+   *
+   * Used by the Fix 2 Stage 1 owner-authorization gate. The v0.18 account exposes
+   * `address public owner` (see AAStarAirAccountBase.sol), which Solidity surfaces as
+   * a `owner() view returns (address)` getter. Uses the read-only provider (no wallet
+   * required), so it works on nodes that have no ETH_PRIVATE_KEY configured.
+   */
+  async getAccountOwner(account: string): Promise<string> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+
+    const abi = ["function owner() view returns (address)"];
+    const contract = new ethers.Contract(account, abi, this.provider);
+
+    try {
+      const owner: string = await contract.owner();
+      return ethers.getAddress(owner);
+    } catch (error: any) {
+      this.logger.error(`Failed to read owner() for account ${account}: ${error.message}`);
+      throw error;
+    }
+  }
+
   async getRegisteredNodes(
     contractAddress: string,
     offset: number,

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -2,6 +2,19 @@ import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { ethers } from "ethers";
 
+/** ERC-4337 v0.7 PackedUserOperation (the exact tuple EntryPoint.getUserOpHash takes). */
+export interface PackedUserOp {
+  sender: string;
+  nonce: ethers.BigNumberish;
+  initCode: string;
+  callData: string;
+  accountGasLimits: string;
+  preVerificationGas: ethers.BigNumberish;
+  gasFees: string;
+  paymasterAndData: string;
+  signature: string;
+}
+
 @Injectable()
 export class BlockchainService {
   private readonly logger = new Logger(BlockchainService.name);
@@ -230,6 +243,52 @@ export class BlockchainService {
       return ethers.getAddress(owner);
     } catch (error: any) {
       this.logger.error(`Failed to read owner() for account ${account}: ${error.message}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Derive the authoritative ERC-4337 v0.7 userOpHash for a full UserOperation by
+   * calling `getUserOpHash` on the canonical EntryPoint via the read-only provider.
+   *
+   * This is the binding step of the Fix 2 Stage 1 owner-authorization gate: the
+   * EntryPoint computes the hash from `userOp.sender`, chainId, and the EntryPoint
+   * address itself, so the resulting hash cannot be detached from its account.
+   * A caller therefore cannot pair a signature over their own account's hash with
+   * a victim's UserOperation.
+   */
+  async getUserOpHash(userOp: PackedUserOp): Promise<string> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+
+    const entryPoint = this.configService.get<string>("entryPointAddress");
+    if (!entryPoint) {
+      throw new Error("EntryPoint address not configured");
+    }
+
+    const abi = [
+      "function getUserOpHash((address sender,uint256 nonce,bytes initCode,bytes callData,bytes32 accountGasLimits,uint256 preVerificationGas,bytes32 gasFees,bytes paymasterAndData,bytes signature) userOp) view returns (bytes32)",
+    ];
+    const contract = new ethers.Contract(entryPoint, abi, this.provider);
+
+    try {
+      const hash: string = await contract.getUserOpHash({
+        sender: userOp.sender,
+        nonce: userOp.nonce,
+        initCode: userOp.initCode,
+        callData: userOp.callData,
+        accountGasLimits: userOp.accountGasLimits,
+        preVerificationGas: userOp.preVerificationGas,
+        gasFees: userOp.gasFees,
+        paymasterAndData: userOp.paymasterAndData,
+        signature: userOp.signature,
+      });
+      return hash;
+    } catch (error: any) {
+      this.logger.error(
+        `Failed to derive userOpHash via EntryPoint ${entryPoint}: ${error.message}`
+      );
       throw error;
     }
   }

--- a/src/modules/bls/bls.module.ts
+++ b/src/modules/bls/bls.module.ts
@@ -1,7 +1,9 @@
 import { Module } from "@nestjs/common";
 import { BlsService } from "./bls.service.js";
+import { BlockchainModule } from "../blockchain/blockchain.module.js";
 
 @Module({
+  imports: [BlockchainModule],
   providers: [BlsService],
   exports: [BlsService],
 })

--- a/src/modules/bls/bls.service.spec.ts
+++ b/src/modules/bls/bls.service.spec.ts
@@ -180,6 +180,33 @@ describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
     ).rejects.toBeInstanceOf(ForbiddenException);
   });
 
+  it("rejects (403, not 400) when userOp.sender is not a valid address", async () => {
+    getUserOpHash.mockResolvedValue(derivedHash);
+    getAccountOwner.mockResolvedValue(ownerWallet.address);
+    const ownerAuth = await signEip191(ownerWallet, derivedHash);
+    const bad = { ...makeUserOp(victimAccount), sender: "not-an-address" };
+
+    await expect(service.signMessage(bad, ownerAuth, node)).rejects.toBeInstanceOf(
+      ForbiddenException
+    );
+    // Shape rejected before any chain read.
+    expect(getUserOpHash).not.toHaveBeenCalled();
+    expect(getAccountOwner).not.toHaveBeenCalled();
+  });
+
+  it("rejects (403, not 400) when a required userOp field is missing", async () => {
+    getUserOpHash.mockResolvedValue(derivedHash);
+    getAccountOwner.mockResolvedValue(ownerWallet.address);
+    const ownerAuth = await signEip191(ownerWallet, derivedHash);
+    const bad = { ...makeUserOp(victimAccount) } as Partial<PackedUserOp>;
+    delete bad.callData;
+
+    await expect(service.signMessage(bad as PackedUserOp, ownerAuth, node)).rejects.toBeInstanceOf(
+      ForbiddenException
+    );
+    expect(getUserOpHash).not.toHaveBeenCalled();
+  });
+
   it("rejects (403) fail-closed for a P256/passkey-only account (owner == zero address)", async () => {
     getUserOpHash.mockResolvedValue(derivedHash);
     getAccountOwner.mockResolvedValue(ethers.ZeroAddress);

--- a/src/modules/bls/bls.service.spec.ts
+++ b/src/modules/bls/bls.service.spec.ts
@@ -1,0 +1,143 @@
+import { jest } from "@jest/globals";
+import { ForbiddenException } from "@nestjs/common";
+import { ethers } from "ethers";
+
+// Mock the BLS primitives (@noble/curves) so the unit test focuses on the
+// owner-authorization gate without pulling in the ESM-only curve library.
+// The gate runs BEFORE any of these are invoked; on the success path we only
+// assert that signing was reached and produced a stubbed signature.
+jest.unstable_mockModule("../../utils/bls.util.js", () => {
+  const fakeG2Point = { toHex: () => "ab".repeat(96) };
+  const fakeG1Point = { toHex: () => "cd".repeat(48) };
+  return {
+    BLS_DST: "TEST_DST",
+    bls: {
+      G2: { hashToCurve: jest.fn(async () => fakeG2Point) },
+      G1: { Point: { fromHex: () => fakeG1Point } },
+    },
+    sigs: {
+      getPublicKey: () => fakeG1Point,
+      sign: jest.fn(async () => fakeG2Point),
+    },
+    encodeG2Point: () => new Uint8Array(256),
+  };
+});
+
+const { BlsService } = await import("./bls.service.js");
+const { BlockchainService } = await import("../blockchain/blockchain.service.js");
+type BlockchainService = InstanceType<typeof BlockchainService>;
+import type { NodeKeyPair } from "../../interfaces/node.interface.js";
+
+/**
+ * Fix 2 Stage 1 — owner-authorization gate tests.
+ *
+ * Verifies that the DVT node co-signs ONLY when the request carries a valid
+ * account-owner ECDSA signature (EIP-191) over the userOpHash, matching the
+ * v0.18 account's `_validateECDSA` convention. BlockchainService.getAccountOwner
+ * is mocked so no chain access is needed.
+ */
+describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
+  // A valid BLS12-381 private key scalar (non-zero, < curve order). 0x...01.
+  const node: NodeKeyPair = {
+    nodeId: "node_test",
+    nodeName: "test",
+    privateKey: "0x" + "00".repeat(31) + "01",
+    publicKey: "0x",
+    description: "test node",
+  };
+
+  const account = "0x08923CE682336DF2f238C034B4add5Bf73d4028A";
+  // userOpHash to be co-signed.
+  const userOpHash = "0x8bb1b199f427dfc49e5fe40f2f3278cb1a48587824b78263051c8c4d81d77a81";
+
+  // The account owner (EOA). The contract recovers an EIP-191 sig over userOpHash
+  // and compares to `owner`. We reproduce the same with ethers.
+  const ownerWallet = new ethers.Wallet(
+    "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+  );
+
+  let service: InstanceType<typeof BlsService>;
+  let getAccountOwner: jest.Mock<(account: string) => Promise<string>>;
+
+  // Sign userOpHash exactly the way the account owner signs the UserOperation:
+  // EIP-191 prefix over the raw 32-byte hash.
+  async function signAsOwner(wallet: ethers.Wallet, hash: string): Promise<string> {
+    return wallet.signMessage(ethers.getBytes(hash));
+  }
+
+  beforeEach(() => {
+    getAccountOwner = jest.fn<(account: string) => Promise<string>>();
+    const blockchain = { getAccountOwner } as unknown as BlockchainService;
+    service = new BlsService(blockchain);
+  });
+
+  it("signs and returns a signature when ownerAuth recovers to the on-chain owner", async () => {
+    getAccountOwner.mockResolvedValue(ownerWallet.address);
+    const ownerAuth = await signAsOwner(ownerWallet, userOpHash);
+
+    const result = await service.signMessage(userOpHash, account, ownerAuth, node);
+
+    expect(getAccountOwner).toHaveBeenCalledWith(account);
+    expect(result.nodeId).toBe(node.nodeId);
+    expect(result.signature).toMatch(/^0x[0-9a-f]+$/);
+    expect(result.signatureCompact).toBeTruthy();
+    expect(result.message).toBe(userOpHash);
+  });
+
+  it("rejects (403) when ownerAuth is signed by the wrong signer", async () => {
+    getAccountOwner.mockResolvedValue(ownerWallet.address);
+    const attacker = ethers.Wallet.createRandom();
+    const ownerAuth = await signAsOwner(attacker as unknown as ethers.Wallet, userOpHash);
+
+    await expect(service.signMessage(userOpHash, account, ownerAuth, node)).rejects.toBeInstanceOf(
+      ForbiddenException
+    );
+  });
+
+  it("rejects (403) when ownerAuth is over a tampered userOpHash", async () => {
+    getAccountOwner.mockResolvedValue(ownerWallet.address);
+    const otherHash = "0x" + "11".repeat(32);
+    // Owner signed a different hash than the one being requested.
+    const ownerAuth = await signAsOwner(ownerWallet, otherHash);
+
+    await expect(service.signMessage(userOpHash, account, ownerAuth, node)).rejects.toBeInstanceOf(
+      ForbiddenException
+    );
+  });
+
+  it("rejects (403) when ownerAuth is malformed / not a real signature", async () => {
+    getAccountOwner.mockResolvedValue(ownerWallet.address);
+    const ownerAuth = "0xdeadbeef";
+
+    await expect(service.signMessage(userOpHash, account, ownerAuth, node)).rejects.toBeInstanceOf(
+      ForbiddenException
+    );
+  });
+
+  it("rejects (403) fail-closed for a P256/passkey-only account (owner == zero address)", async () => {
+    getAccountOwner.mockResolvedValue(ethers.ZeroAddress);
+    const ownerAuth = await signAsOwner(ownerWallet, userOpHash);
+
+    await expect(service.signMessage(userOpHash, account, ownerAuth, node)).rejects.toBeInstanceOf(
+      ForbiddenException
+    );
+  });
+
+  it("rejects (403) fail-closed when the on-chain owner read fails", async () => {
+    getAccountOwner.mockRejectedValue(new Error("rpc down"));
+    const ownerAuth = await signAsOwner(ownerWallet, userOpHash);
+
+    await expect(service.signMessage(userOpHash, account, ownerAuth, node)).rejects.toBeInstanceOf(
+      ForbiddenException
+    );
+  });
+
+  it("matches owner regardless of address checksum casing", async () => {
+    // Chain read returns lowercase; gate must still match.
+    getAccountOwner.mockResolvedValue(ethers.getAddress(ownerWallet.address));
+    const ownerAuth = await signAsOwner(ownerWallet, userOpHash);
+
+    const result = await service.signMessage(userOpHash, account, ownerAuth, node);
+    expect(result.nodeId).toBe(node.nodeId);
+  });
+});

--- a/src/modules/bls/bls.service.spec.ts
+++ b/src/modules/bls/bls.service.spec.ts
@@ -205,6 +205,7 @@ describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
       ForbiddenException
     );
     expect(getUserOpHash).not.toHaveBeenCalled();
+    expect(getAccountOwner).not.toHaveBeenCalled();
   });
 
   it("rejects (403) fail-closed for a P256/passkey-only account (owner == zero address)", async () => {

--- a/src/modules/bls/bls.service.spec.ts
+++ b/src/modules/bls/bls.service.spec.ts
@@ -26,15 +26,16 @@ jest.unstable_mockModule("../../utils/bls.util.js", () => {
 const { BlsService } = await import("./bls.service.js");
 const { BlockchainService } = await import("../blockchain/blockchain.service.js");
 type BlockchainService = InstanceType<typeof BlockchainService>;
+import type { PackedUserOp } from "../blockchain/blockchain.service.js";
 import type { NodeKeyPair } from "../../interfaces/node.interface.js";
 
 /**
  * Fix 2 Stage 1 — owner-authorization gate tests.
  *
- * Verifies that the DVT node co-signs ONLY when the request carries a valid
- * account-owner ECDSA signature (EIP-191) over the userOpHash, matching the
- * v0.18 account's `_validateECDSA` convention. BlockchainService.getAccountOwner
- * is mocked so no chain access is needed.
+ * The node co-signs ONLY when the request carries the FULL UserOperation plus a
+ * valid owner ECDSA signature (EIP-191) over the AUTHORITATIVE userOpHash, which
+ * is DERIVED from the userOp via EntryPoint.getUserOpHash (never caller-supplied).
+ * BlockchainService.getUserOpHash + getAccountOwner are mocked.
  */
 describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
   // A valid BLS12-381 private key scalar (non-zero, < curve order). 0x...01.
@@ -46,98 +47,165 @@ describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
     description: "test node",
   };
 
-  const account = "0x08923CE682336DF2f238C034B4add5Bf73d4028A";
-  // userOpHash to be co-signed.
-  const userOpHash = "0x8bb1b199f427dfc49e5fe40f2f3278cb1a48587824b78263051c8c4d81d77a81";
-
-  // The account owner (EOA). The contract recovers an EIP-191 sig over userOpHash
-  // and compares to `owner`. We reproduce the same with ethers.
+  // The victim account owner (EOA). The gate recovers an EIP-191 sig over the
+  // derived userOpHash and compares to this account's on-chain owner.
   const ownerWallet = new ethers.Wallet(
     "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
   );
+  const victimAccount = "0x08923CE682336DF2f238C034B4add5Bf73d4028A";
+
+  // The authoritative hash that EntryPoint.getUserOpHash returns for the userOp.
+  const derivedHash = "0x8bb1b199f427dfc49e5fe40f2f3278cb1a48587824b78263051c8c4d81d77a81";
+
+  // A well-formed v0.7 PackedUserOperation for the victim account.
+  function makeUserOp(sender: string): PackedUserOp {
+    return {
+      sender,
+      nonce: "0",
+      initCode: "0x",
+      callData: "0x",
+      accountGasLimits: "0x" + "00".repeat(32),
+      preVerificationGas: "0",
+      gasFees: "0x" + "00".repeat(32),
+      paymasterAndData: "0x",
+      signature: "0x",
+    };
+  }
 
   let service: InstanceType<typeof BlsService>;
   let getAccountOwner: jest.Mock<(account: string) => Promise<string>>;
+  let getUserOpHash: jest.Mock<(userOp: PackedUserOp) => Promise<string>>;
 
-  // Sign userOpHash exactly the way the account owner signs the UserOperation:
+  // Sign a hash exactly the way the account owner signs the UserOperation:
   // EIP-191 prefix over the raw 32-byte hash.
-  async function signAsOwner(wallet: ethers.Wallet, hash: string): Promise<string> {
+  async function signEip191(wallet: ethers.Wallet, hash: string): Promise<string> {
     return wallet.signMessage(ethers.getBytes(hash));
   }
 
   beforeEach(() => {
     getAccountOwner = jest.fn<(account: string) => Promise<string>>();
-    const blockchain = { getAccountOwner } as unknown as BlockchainService;
+    getUserOpHash = jest.fn<(userOp: PackedUserOp) => Promise<string>>();
+    const blockchain = { getAccountOwner, getUserOpHash } as unknown as BlockchainService;
     service = new BlsService(blockchain);
   });
 
-  it("signs and returns a signature when ownerAuth recovers to the on-chain owner", async () => {
+  it("signs and returns a signature when ownerAuth recovers to the derived-hash owner", async () => {
+    getUserOpHash.mockResolvedValue(derivedHash);
     getAccountOwner.mockResolvedValue(ownerWallet.address);
-    const ownerAuth = await signAsOwner(ownerWallet, userOpHash);
+    const ownerAuth = await signEip191(ownerWallet, derivedHash);
 
-    const result = await service.signMessage(userOpHash, account, ownerAuth, node);
+    const result = await service.signMessage(makeUserOp(victimAccount), ownerAuth, node);
 
-    expect(getAccountOwner).toHaveBeenCalledWith(account);
+    // account must be derived from userOp.sender, not caller-claimed.
+    expect(getAccountOwner).toHaveBeenCalledWith(victimAccount);
+    expect(getUserOpHash).toHaveBeenCalledTimes(1);
     expect(result.nodeId).toBe(node.nodeId);
     expect(result.signature).toMatch(/^0x[0-9a-f]+$/);
     expect(result.signatureCompact).toBeTruthy();
-    expect(result.message).toBe(userOpHash);
+    // The signed hash is the EntryPoint-derived one.
+    expect(result.message).toBe(derivedHash);
   });
 
-  it("rejects (403) when ownerAuth is signed by the wrong signer", async () => {
+  // ── CRITICAL regression (the Codex finding) ──────────────────────────────
+  // An attacker who OWNS account A cannot get the node to co-sign a userOp for
+  // victim account B by supplying B's userOp + A-owner's signature. Because:
+  //   - account = userOp.sender = B  (derived, attacker cannot lie)
+  //   - userOpHash is derived from B's userOp via EntryPoint
+  //   - the gate requires B's on-chain owner to have signed that hash
+  // The attacker's signature recovers to A's owner != B's owner → 403.
+  it("CRITICAL: rejects (403) cross-account oracle — attacker owns a different account", async () => {
+    const attackerWallet = ethers.Wallet.createRandom();
+    // The node always derives the hash from the submitted userOp (the victim's).
+    getUserOpHash.mockResolvedValue(derivedHash);
+    // The submitted userOp is the VICTIM's account; its on-chain owner is ownerWallet.
     getAccountOwner.mockResolvedValue(ownerWallet.address);
-    const attacker = ethers.Wallet.createRandom();
-    const ownerAuth = await signAsOwner(attacker as unknown as ethers.Wallet, userOpHash);
+    // Attacker signs the (derived) victim hash with their OWN key — they own a
+    // different account, not the victim's.
+    const ownerAuth = await signEip191(attackerWallet as unknown as ethers.Wallet, derivedHash);
 
-    await expect(service.signMessage(userOpHash, account, ownerAuth, node)).rejects.toBeInstanceOf(
-      ForbiddenException
-    );
+    await expect(
+      service.signMessage(makeUserOp(victimAccount), ownerAuth, node)
+    ).rejects.toBeInstanceOf(ForbiddenException);
   });
 
-  it("rejects (403) when ownerAuth is over a tampered userOpHash", async () => {
+  it("rejects (403) when userOp.sender's owner != ownerAuth signer", async () => {
+    getUserOpHash.mockResolvedValue(derivedHash);
+    getAccountOwner.mockResolvedValue(ownerWallet.address);
+    const wrongSigner = ethers.Wallet.createRandom();
+    const ownerAuth = await signEip191(wrongSigner as unknown as ethers.Wallet, derivedHash);
+
+    await expect(
+      service.signMessage(makeUserOp(victimAccount), ownerAuth, node)
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it("attacker cannot substitute a different hash — only the EntryPoint-derived hash is signed", async () => {
+    // Owner signs SOME OTHER hash; the node only ever derives & checks against the
+    // EntryPoint hash, so a sig over an unrelated hash never authorizes.
+    getUserOpHash.mockResolvedValue(derivedHash);
     getAccountOwner.mockResolvedValue(ownerWallet.address);
     const otherHash = "0x" + "11".repeat(32);
-    // Owner signed a different hash than the one being requested.
-    const ownerAuth = await signAsOwner(ownerWallet, otherHash);
+    const ownerAuth = await signEip191(ownerWallet, otherHash);
 
-    await expect(service.signMessage(userOpHash, account, ownerAuth, node)).rejects.toBeInstanceOf(
-      ForbiddenException
-    );
+    await expect(
+      service.signMessage(makeUserOp(victimAccount), ownerAuth, node)
+    ).rejects.toBeInstanceOf(ForbiddenException);
   });
 
-  it("rejects (403) when ownerAuth is malformed / not a real signature", async () => {
+  it("rejects (403) when EntryPoint.getUserOpHash reverts", async () => {
+    getUserOpHash.mockRejectedValue(new Error("execution reverted"));
     getAccountOwner.mockResolvedValue(ownerWallet.address);
-    const ownerAuth = "0xdeadbeef";
+    const ownerAuth = await signEip191(ownerWallet, derivedHash);
 
-    await expect(service.signMessage(userOpHash, account, ownerAuth, node)).rejects.toBeInstanceOf(
-      ForbiddenException
-    );
+    await expect(
+      service.signMessage(makeUserOp(victimAccount), ownerAuth, node)
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it("rejects (403, not 400) when ownerAuth is malformed", async () => {
+    getUserOpHash.mockResolvedValue(derivedHash);
+    getAccountOwner.mockResolvedValue(ownerWallet.address);
+
+    await expect(
+      service.signMessage(makeUserOp(victimAccount), "0xdeadbeef", node)
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it("rejects (403, not 400) when ownerAuth is missing/undefined", async () => {
+    getUserOpHash.mockResolvedValue(derivedHash);
+    getAccountOwner.mockResolvedValue(ownerWallet.address);
+
+    await expect(
+      service.signMessage(makeUserOp(victimAccount), undefined, node)
+    ).rejects.toBeInstanceOf(ForbiddenException);
   });
 
   it("rejects (403) fail-closed for a P256/passkey-only account (owner == zero address)", async () => {
+    getUserOpHash.mockResolvedValue(derivedHash);
     getAccountOwner.mockResolvedValue(ethers.ZeroAddress);
-    const ownerAuth = await signAsOwner(ownerWallet, userOpHash);
+    const ownerAuth = await signEip191(ownerWallet, derivedHash);
 
-    await expect(service.signMessage(userOpHash, account, ownerAuth, node)).rejects.toBeInstanceOf(
-      ForbiddenException
-    );
+    await expect(
+      service.signMessage(makeUserOp(victimAccount), ownerAuth, node)
+    ).rejects.toBeInstanceOf(ForbiddenException);
   });
 
   it("rejects (403) fail-closed when the on-chain owner read fails", async () => {
+    getUserOpHash.mockResolvedValue(derivedHash);
     getAccountOwner.mockRejectedValue(new Error("rpc down"));
-    const ownerAuth = await signAsOwner(ownerWallet, userOpHash);
+    const ownerAuth = await signEip191(ownerWallet, derivedHash);
 
-    await expect(service.signMessage(userOpHash, account, ownerAuth, node)).rejects.toBeInstanceOf(
-      ForbiddenException
-    );
+    await expect(
+      service.signMessage(makeUserOp(victimAccount), ownerAuth, node)
+    ).rejects.toBeInstanceOf(ForbiddenException);
   });
 
   it("matches owner regardless of address checksum casing", async () => {
-    // Chain read returns lowercase; gate must still match.
+    getUserOpHash.mockResolvedValue(derivedHash);
     getAccountOwner.mockResolvedValue(ethers.getAddress(ownerWallet.address));
-    const ownerAuth = await signAsOwner(ownerWallet, userOpHash);
+    const ownerAuth = await signEip191(ownerWallet, derivedHash);
 
-    const result = await service.signMessage(userOpHash, account, ownerAuth, node);
+    const result = await service.signMessage(makeUserOp(victimAccount), ownerAuth, node);
     expect(result.nodeId).toBe(node.nodeId);
   });
 });

--- a/src/modules/bls/bls.service.ts
+++ b/src/modules/bls/bls.service.ts
@@ -48,8 +48,34 @@ export class BlsService {
     userOp: PackedUserOp,
     ownerAuth: string | undefined
   ): Promise<string> {
-    // account is the UserOperation sender — derived, never caller-claimed.
-    const account = userOp.sender;
+    // Fail-closed shape check (→ 403, never 400): a malformed signing request is
+    // rejected by the same authorization gate as a bad signature, keeping the
+    // endpoint uniformly fail-closed. `sender` must be a valid address (it becomes
+    // the authorized account); the remaining fields must be present so
+    // EntryPoint.getUserOpHash can ABI-encode them (any encoding failure also → 403).
+    let account: string;
+    try {
+      if (!userOp || typeof userOp.sender !== "string") {
+        throw new Error("malformed userOp");
+      }
+      account = ethers.getAddress(userOp.sender); // throws on non-address → 403
+      const requiredFields: (keyof PackedUserOp)[] = [
+        "nonce",
+        "initCode",
+        "callData",
+        "accountGasLimits",
+        "preVerificationGas",
+        "gasFees",
+        "paymasterAndData",
+      ];
+      for (const f of requiredFields) {
+        if (userOp[f] === undefined || userOp[f] === null) {
+          throw new Error(`malformed userOp: missing ${String(f)}`);
+        }
+      }
+    } catch {
+      throw new ForbiddenException("owner authorization required");
+    }
 
     // Derive the authoritative userOpHash on-chain. This binds the hash to the
     // sender, chainId, and EntryPoint — a caller cannot substitute another hash.

--- a/src/modules/bls/bls.service.ts
+++ b/src/modules/bls/bls.service.ts
@@ -1,13 +1,88 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, ForbiddenException, Logger } from "@nestjs/common";
 import { ethers } from "ethers";
 import { bls, sigs, BLS_DST, encodeG2Point } from "../../utils/bls.util.js";
 import { SignatureResult } from "../../interfaces/signature.interface.js";
 import { NodeKeyPair } from "../../interfaces/node.interface.js";
+import { BlockchainService } from "../blockchain/blockchain.service.js";
 
 @Injectable()
 export class BlsService {
-  async signMessage(message: string, node: NodeKeyPair): Promise<SignatureResult> {
-    const messageBytes = ethers.getBytes(message);
+  private readonly logger = new Logger(BlsService.name);
+
+  constructor(private readonly blockchainService: BlockchainService) {}
+
+  /**
+   * Fix 2 Stage 1 — owner-authorization gate.
+   *
+   * Before this node co-signs `userOpHash`, verify the caller holds a valid
+   * account-owner ECDSA signature over that exact hash. This must match how the
+   * v0.18 account verifies an owner signature, so any signature the account accepts
+   * also passes here.
+   *
+   * Contract convention (AAStarAirAccountBase.sol `_validateECDSA`, line 665):
+   *   bytes32 hash = userOpHash.toEthSignedMessageHash();   // EIP-191 prefix
+   *   address recovered = ecrecover(hash, v, r, s);
+   *   return recovered == owner ? 0 : 1;                    // `address public owner`
+   * EIP-191 = `\x19Ethereum Signed Message:\n32` || userOpHash, exactly what ethers'
+   * `verifyMessage(getBytes(userOpHash), sig)` reproduces.
+   *
+   * Stage 1 handles the ECDSA-owner case only. A P256/passkey-only account has no
+   * recoverable ECDSA owner, so this gate FAILS CLOSED for it (see #40 for Stage 2
+   * P256-owner support) — it must never silently sign.
+   *
+   * @throws ForbiddenException when authorization is missing/malformed/mismatched.
+   */
+  private async assertOwnerAuthorized(
+    userOpHash: string,
+    account: string,
+    ownerAuth: string
+  ): Promise<void> {
+    let owner: string;
+    try {
+      owner = await this.blockchainService.getAccountOwner(account);
+    } catch {
+      // Cannot establish authority → fail closed.
+      throw new ForbiddenException("owner authorization required");
+    }
+
+    // An ECDSA owner recovers to a non-zero EOA. The zero address indicates a
+    // P256/passkey-only account with no ECDSA owner — Stage 1 cannot authorize it.
+    // TODO(#40): add P256-owner authorization for passkey-only accounts (Stage 2).
+    if (owner === ethers.ZeroAddress) {
+      throw new ForbiddenException(
+        "owner authorization required: account has no ECDSA owner (P256/passkey-only is not supported in Stage 1, see #40)"
+      );
+    }
+
+    let recovered: string;
+    try {
+      // Match the contract's EIP-191 convention exactly: prefix over the raw
+      // 32-byte userOpHash, then ecrecover.
+      recovered = ethers.verifyMessage(ethers.getBytes(userOpHash), ownerAuth);
+    } catch {
+      throw new ForbiddenException("owner authorization required");
+    }
+
+    if (ethers.getAddress(recovered) !== owner) {
+      this.logger.warn(
+        `Owner-auth rejected for account ${account}: recovered ${recovered}, expected owner ${owner}`
+      );
+      throw new ForbiddenException("owner authorization required");
+    }
+  }
+
+  async signMessage(
+    userOpHash: string,
+    account: string,
+    ownerAuth: string,
+    node: NodeKeyPair
+  ): Promise<SignatureResult> {
+    // Authorization gate (Fix 2 Stage 1): reject unless a valid owner signature
+    // over userOpHash accompanies the request. Closes the open-oracle hole.
+    await this.assertOwnerAuthorized(userOpHash, account, ownerAuth);
+
+    // The value actually signed remains hashToCurve(userOpHash).
+    const messageBytes = ethers.getBytes(userOpHash);
     const messagePoint = await bls.G2.hashToCurve(messageBytes, {
       DST: BLS_DST,
     });
@@ -22,7 +97,7 @@ export class BlsService {
       signature: this.encodeToEIP2537(signature), // Use EIP-2537 format as default
       signatureCompact: signature.toHex(), // Keep compact format for backward compatibility
       publicKey: publicKey.toHex(),
-      message: message,
+      message: userOpHash,
     };
   }
 

--- a/src/modules/bls/bls.service.ts
+++ b/src/modules/bls/bls.service.ts
@@ -3,7 +3,7 @@ import { ethers } from "ethers";
 import { bls, sigs, BLS_DST, encodeG2Point } from "../../utils/bls.util.js";
 import { SignatureResult } from "../../interfaces/signature.interface.js";
 import { NodeKeyPair } from "../../interfaces/node.interface.js";
-import { BlockchainService } from "../blockchain/blockchain.service.js";
+import { BlockchainService, PackedUserOp } from "../blockchain/blockchain.service.js";
 
 @Injectable()
 export class BlsService {
@@ -14,39 +14,60 @@ export class BlsService {
   /**
    * Fix 2 Stage 1 — owner-authorization gate.
    *
-   * Before this node co-signs `userOpHash`, verify the caller holds a valid
-   * account-owner ECDSA signature over that exact hash. This must match how the
-   * v0.18 account verifies an owner signature, so any signature the account accepts
-   * also passes here.
+   * The node co-signs ONLY when the request carries a valid account-owner ECDSA
+   * signature over the AUTHORITATIVE userOpHash, which is DERIVED from the full
+   * UserOperation (never trusted from the caller). The flow:
    *
-   * Contract convention (AAStarAirAccountBase.sol `_validateECDSA`, line 665):
-   *   bytes32 hash = userOpHash.toEthSignedMessageHash();   // EIP-191 prefix
-   *   address recovered = ecrecover(hash, v, r, s);
-   *   return recovered == owner ? 0 : 1;                    // `address public owner`
-   * EIP-191 = `\x19Ethereum Signed Message:\n32` || userOpHash, exactly what ethers'
-   * `verifyMessage(getBytes(userOpHash), sig)` reproduces.
+   *   account     = userOp.sender                                 (derived, not claimed)
+   *   userOpHash  = EntryPoint.getUserOpHash(userOp)              (binds hash↔sender/chain)
+   *   owner       = account.owner()
+   *   require verifyMessage(getBytes(userOpHash), ownerAuth) == owner
+   *   then BLS-sign hashToCurve(userOpHash)  — the SAME derived hash (no TOCTOU)
    *
-   * Stage 1 handles the ECDSA-owner case only. A P256/passkey-only account has no
-   * recoverable ECDSA owner, so this gate FAILS CLOSED for it (see #40 for Stage 2
-   * P256-owner support) — it must never silently sign.
+   * Deriving the hash on-chain is what closes the cross-account oracle hole: an
+   * attacker who owns account A cannot get the node to sign account B's userOpHash,
+   * because the hash is computed from `userOp.sender` (= B) and getUserOpHash binds
+   * it to B, chainId, and the EntryPoint. The owner check then requires B's owner.
    *
-   * @throws ForbiddenException when authorization is missing/malformed/mismatched.
+   * Owner-signature convention matches AAStarAirAccountBase.sol `_validateECDSA`:
+   *   bytes32 hash = userOpHash.toEthSignedMessageHash();  // EIP-191 prefix
+   *   ecrecover(hash, v, r, s) == owner                    // `address public owner`
+   * which `ethers.verifyMessage(getBytes(userOpHash), sig)` reproduces exactly.
+   *
+   * Stage 1 handles the ECDSA-owner case only. A P256/passkey-only account
+   * (owner() == 0x0) FAILS CLOSED (see #40 for Stage 2 P256-owner support).
+   *
+   * Fails closed (403) on ANY failure: malformed userOp, getUserOpHash revert,
+   * owner read failure, owner == 0x0, malformed/missing ownerAuth, or recovered
+   * signer != owner. Never signs on failure.
+   *
+   * @returns the derived userOpHash to BLS-sign.
+   * @throws ForbiddenException on any authorization failure.
    */
-  private async assertOwnerAuthorized(
-    userOpHash: string,
-    account: string,
-    ownerAuth: string
-  ): Promise<void> {
+  private async authorizeAndDeriveHash(
+    userOp: PackedUserOp,
+    ownerAuth: string | undefined
+  ): Promise<string> {
+    // account is the UserOperation sender — derived, never caller-claimed.
+    const account = userOp.sender;
+
+    // Derive the authoritative userOpHash on-chain. This binds the hash to the
+    // sender, chainId, and EntryPoint — a caller cannot substitute another hash.
+    let userOpHash: string;
+    try {
+      userOpHash = await this.blockchainService.getUserOpHash(userOp);
+    } catch {
+      throw new ForbiddenException("owner authorization required");
+    }
+
     let owner: string;
     try {
       owner = await this.blockchainService.getAccountOwner(account);
     } catch {
-      // Cannot establish authority → fail closed.
       throw new ForbiddenException("owner authorization required");
     }
 
-    // An ECDSA owner recovers to a non-zero EOA. The zero address indicates a
-    // P256/passkey-only account with no ECDSA owner — Stage 1 cannot authorize it.
+    // Zero owner → P256/passkey-only account, no ECDSA owner to authorize against.
     // TODO(#40): add P256-owner authorization for passkey-only accounts (Stage 2).
     if (owner === ethers.ZeroAddress) {
       throw new ForbiddenException(
@@ -56,8 +77,10 @@ export class BlsService {
 
     let recovered: string;
     try {
-      // Match the contract's EIP-191 convention exactly: prefix over the raw
-      // 32-byte userOpHash, then ecrecover.
+      if (typeof ownerAuth !== "string" || ownerAuth.length === 0) {
+        throw new Error("missing ownerAuth");
+      }
+      // EIP-191 over the raw 32-byte derived userOpHash, matching the contract.
       recovered = ethers.verifyMessage(ethers.getBytes(userOpHash), ownerAuth);
     } catch {
       throw new ForbiddenException("owner authorization required");
@@ -69,19 +92,21 @@ export class BlsService {
       );
       throw new ForbiddenException("owner authorization required");
     }
+
+    return userOpHash;
   }
 
   async signMessage(
-    userOpHash: string,
-    account: string,
-    ownerAuth: string,
+    userOp: PackedUserOp,
+    ownerAuth: string | undefined,
     node: NodeKeyPair
   ): Promise<SignatureResult> {
-    // Authorization gate (Fix 2 Stage 1): reject unless a valid owner signature
-    // over userOpHash accompanies the request. Closes the open-oracle hole.
-    await this.assertOwnerAuthorized(userOpHash, account, ownerAuth);
+    // Authorization gate (Fix 2 Stage 1): derive the authoritative userOpHash from
+    // the full UserOperation and require a valid owner signature over it. Returns
+    // the SAME derived hash that gets signed below — no caller-supplied hash, no TOCTOU.
+    const userOpHash = await this.authorizeAndDeriveHash(userOp, ownerAuth);
 
-    // The value actually signed remains hashToCurve(userOpHash).
+    // BLS-sign hashToCurve(userOpHash) using the exact derived hash.
     const messageBytes = ethers.getBytes(userOpHash);
     const messagePoint = await bls.G2.hashToCurve(messageBytes, {
       DST: BLS_DST,

--- a/src/modules/signature/signature.controller.ts
+++ b/src/modules/signature/signature.controller.ts
@@ -64,24 +64,36 @@ export class SignatureController {
       },
     },
   })
-  @ApiResponse({ status: 400, description: "Invalid input data" })
+  @ApiResponse({ status: 400, description: "Invalid input data (malformed userOp shape)" })
   @ApiResponse({
     status: 403,
-    description: "Owner authorization required (missing/malformed/mismatched ownerAuth)",
+    description:
+      "Owner authorization required (missing/malformed/mismatched ownerAuth, owner read " +
+      "failure, getUserOpHash revert, or P256/passkey-only account)",
   })
   @ApiBody({ type: SignMessageDto })
   @Post("sign")
   async signMessage(@Body(ValidationPipe) signDto: SignMessageDto) {
     this.logger.log(`=== BLS Sign Request ===`);
-    this.logger.log(`userOpHash: ${signDto.userOpHash}`);
-    this.logger.log(`account: ${signDto.account}`);
+    this.logger.log(`userOp.sender: ${signDto.userOp?.sender}`);
 
     try {
-      // Fix 2 Stage 1: bls.service rejects with 403 unless ownerAuth is a valid
-      // account-owner signature over userOpHash.
+      // Fix 2 Stage 1: bls.service derives the authoritative userOpHash from the full
+      // UserOperation and rejects with 403 unless ownerAuth is a valid signature by
+      // userOp.sender's on-chain owner over THAT derived hash.
       const result = await this.signatureService.signMessage(
-        signDto.userOpHash,
-        signDto.account,
+        {
+          sender: signDto.userOp.sender,
+          nonce: signDto.userOp.nonce,
+          initCode: signDto.userOp.initCode,
+          callData: signDto.userOp.callData,
+          accountGasLimits: signDto.userOp.accountGasLimits,
+          preVerificationGas: signDto.userOp.preVerificationGas,
+          gasFees: signDto.userOp.gasFees,
+          paymasterAndData: signDto.userOp.paymasterAndData,
+          // signature does not affect v0.7 getUserOpHash; default to 0x.
+          signature: signDto.userOp.signature ?? "0x",
+        },
         signDto.ownerAuth
       );
 

--- a/src/modules/signature/signature.controller.ts
+++ b/src/modules/signature/signature.controller.ts
@@ -64,12 +64,13 @@ export class SignatureController {
       },
     },
   })
-  @ApiResponse({ status: 400, description: "Invalid input data (malformed userOp shape)" })
+  @ApiResponse({ status: 400, description: "Request body is not a JSON object (userOp missing)" })
   @ApiResponse({
     status: 403,
     description:
-      "Owner authorization required (missing/malformed/mismatched ownerAuth, owner read " +
-      "failure, getUserOpHash revert, or P256/passkey-only account)",
+      "Owner authorization required — uniform fail-closed. Returned for malformed userOp " +
+      "fields (bad sender / missing fields), getUserOpHash revert, owner read failure, " +
+      "P256/passkey-only account (owner==0x0), and missing/malformed/mismatched ownerAuth",
   })
   @ApiBody({ type: SignMessageDto })
   @Post("sign")

--- a/src/modules/signature/signature.controller.ts
+++ b/src/modules/signature/signature.controller.ts
@@ -65,14 +65,25 @@ export class SignatureController {
     },
   })
   @ApiResponse({ status: 400, description: "Invalid input data" })
+  @ApiResponse({
+    status: 403,
+    description: "Owner authorization required (missing/malformed/mismatched ownerAuth)",
+  })
   @ApiBody({ type: SignMessageDto })
   @Post("sign")
   async signMessage(@Body(ValidationPipe) signDto: SignMessageDto) {
     this.logger.log(`=== BLS Sign Request ===`);
-    this.logger.log(`Message: ${signDto.message}`);
+    this.logger.log(`userOpHash: ${signDto.userOpHash}`);
+    this.logger.log(`account: ${signDto.account}`);
 
     try {
-      const result = await this.signatureService.signMessage(signDto.message);
+      // Fix 2 Stage 1: bls.service rejects with 403 unless ownerAuth is a valid
+      // account-owner signature over userOpHash.
+      const result = await this.signatureService.signMessage(
+        signDto.userOpHash,
+        signDto.account,
+        signDto.ownerAuth
+      );
 
       this.logger.log(`✅ Sign Success:`);
       this.logger.log(`  Node ID: ${result.nodeId}`);

--- a/src/modules/signature/signature.service.ts
+++ b/src/modules/signature/signature.service.ts
@@ -4,6 +4,7 @@ import { BlsService } from "../bls/bls.service.js";
 import { NodeService } from "../node/node.service.js";
 import { SignatureResult, AggregateSignatureResult } from "../../interfaces/signature.interface.js";
 import { sigs, bls, BLS_DST } from "../../utils/bls.util.js";
+import { PackedUserOp } from "../blockchain/blockchain.service.js";
 
 @Injectable()
 export class SignatureService {
@@ -12,14 +13,11 @@ export class SignatureService {
     private readonly nodeService: NodeService
   ) {}
 
-  async signMessage(
-    userOpHash: string,
-    account: string,
-    ownerAuth: string
-  ): Promise<SignatureResult> {
+  async signMessage(userOp: PackedUserOp, ownerAuth: string | undefined): Promise<SignatureResult> {
     const node = this.nodeService.getNodeForSigning();
-    // bls.service enforces the Fix 2 Stage 1 owner-authorization gate before signing.
-    return await this.blsService.signMessage(userOpHash, account, ownerAuth, node);
+    // bls.service enforces the Fix 2 Stage 1 owner-authorization gate: it derives the
+    // authoritative userOpHash from userOp and requires a valid owner signature over it.
+    return await this.blsService.signMessage(userOp, ownerAuth, node);
   }
 
   async aggregateExternalSignatures(signatureStrings: string[]): Promise<AggregateSignatureResult> {

--- a/src/modules/signature/signature.service.ts
+++ b/src/modules/signature/signature.service.ts
@@ -12,9 +12,14 @@ export class SignatureService {
     private readonly nodeService: NodeService
   ) {}
 
-  async signMessage(message: string): Promise<SignatureResult> {
+  async signMessage(
+    userOpHash: string,
+    account: string,
+    ownerAuth: string
+  ): Promise<SignatureResult> {
     const node = this.nodeService.getNodeForSigning();
-    return await this.blsService.signMessage(message, node);
+    // bls.service enforces the Fix 2 Stage 1 owner-authorization gate before signing.
+    return await this.blsService.signMessage(userOpHash, account, ownerAuth, node);
   }
 
   async aggregateExternalSignatures(signatureStrings: string[]): Promise<AggregateSignatureResult> {


### PR DESCRIPTION
## What & why

DVT signer nodes previously co-signed **any** `POST /signature/sign` request with no check on who was asking or what was being signed — an open signing oracle. This PR adds an **owner-authorization gate**: the node co-signs **only** when the request carries a valid account-owner signature over the userOpHash.

> **Updated after a Codex CRITICAL** (see "Cross-account oracle fix" below): the userOpHash is now **derived from the full UserOperation on-chain**, not trusted from the caller.

## Scope (be honest)

- ✅ **Stage 1 closes the open-oracle hole** — an attacker without the owner key (including one who owns a *different* account) can no longer get a DVT co-sign for someone else's userOpHash.
- ❌ **Stage 1 does NOT defend against owner-key compromise.** Stolen owner key → attacker can forge `ownerAuth`. That is **Stage 2**, tracked in #40.
- Relates to `AAStarCommunity/airaccount-contract#45`.

## Cross-account oracle fix (Codex CRITICAL — resolved)

**The hole:** the original gate verified `ownerAuth` against the owner of the *caller-supplied* `account`, but never checked that `userOpHash` belonged to that account. An attacker owning **any** account A could send `{account: A, userOpHash: <victim B's hash>, ownerAuth: <A-owner sig over B's hash>}` → the node checked A-owner's sig against A's owner (passes) and BLS-signed B's userOpHash. Still an oracle.

**The fix — bind the hash to the account by deriving it from the full UserOperation:**

```
account    = userOp.sender                          // derived, never caller-claimed
userOpHash = EntryPoint.getUserOpHash(userOp)        // authoritative; binds hash ↔ sender, chainId, EntryPoint
owner      = account.owner()
require verifyMessage(getBytes(userOpHash), ownerAuth) == owner
then BLS-sign hashToCurve(userOpHash)                // the SAME derived hash — no TOCTOU, no caller hash anywhere
```

`getUserOpHash` computes the hash from `userOp.sender`, chainId, and the EntryPoint address, so the hash **cannot be detached from its account**. An attacker can no longer pair their own account's owner signature with a victim's UserOperation.

**Codex re-review status:** CRITICAL (cross-account oracle) and HIGH (TOCTOU, full fail-closed) confirmed CLOSED. The MEDIUM (malformed `userOp` returned 400 not 403) is now resolved — field-level validation moved into the gate (→ 403); see "Uniform fail-closed" below. EntryPoint address is operator-config (not request input); operators must protect `ENTRY_POINT_ADDRESS`.

## Owner-auth verification convention (matched exactly)

Mirrors how the v0.18 account verifies an owner ECDSA signature in `AAStarAirAccountBase.sol` `_validateECDSA` (line 665):

```solidity
bytes32 hash = userOpHash.toEthSignedMessageHash();   // EIP-191 prefix
address recovered = ecrecover(hash, v, r, s);
return (recovered != address(0) && recovered == owner) ? 0 : 1;  // `address public owner`
```

Reproduced node-side with `ethers.verifyMessage(ethers.getBytes(userOpHash), ownerAuth)` → so any signature the account accepts also passes this gate.

## New request contract (breaking — clean break)

`POST /signature/sign` body — full ERC-4337 v0.7 PackedUserOperation + `ownerAuth` (no separate `userOpHash`/`account`):

```jsonc
{
  "userOp": {
    "sender":             "0x… (address — becomes the authorized account)",
    "nonce":              "0",
    "initCode":           "0x",
    "callData":           "0x…",
    "accountGasLimits":   "0x… (bytes32)",
    "preVerificationGas": "0",
    "gasFees":            "0x… (bytes32)",
    "paymasterAndData":   "0x",
    "signature":          "0x"          // optional; does not affect v0.7 getUserOpHash
  },
  "ownerAuth": "0x… (65-byte EIP-191 ECDSA sig by sender's owner over the derived userOpHash)"
}
```

- **Uniform fail-closed**: every rejected request returns `403 Forbidden` ("owner authorization required") from the authorization gate. The only `400` is for a body that is not a JSON object (no `userOp` at all — not even a signing request). Malformed `userOp` *fields* (bad `sender`, missing fields), `getUserOpHash` revert, owner read failure, P256/passkey-only account, and missing/malformed/mismatched `ownerAuth` are **all 403** (Codex MEDIUM/LOW).
- DTO does only a minimal `@IsObject()` check on `userOp`; all field-level + signature validation happens inside the gate (`ethers.getAddress(sender)` + required-field presence + `getUserOpHash` encoding) → 403. Never signs on any failure.
- The value actually BLS-signed is `hashToCurve(<derived userOpHash>)`.
- `POST /signature/aggregate` and `/verify` are **unchanged** (they don't sign).

EntryPoint address: `ENTRY_POINT_ADDRESS` env, default canonical v0.7 `0x0000000071727De22E5E9d8BAf0edAc6f37da032`.

## Caller-side change required (SDK / super-relay)

Send the **full UserOperation** (which the caller already has — it's the op being submitted) plus `ownerAuth`. The owner **already signs the UserOperation**; reuse that same EIP-191 owner signature over the **derived userOpHash** as `ownerAuth`. No separate `userOpHash`/`account` fields, no new signing step.

## Fail-closed cases (all → 403)

Malformed userOp fields (bad `sender` / missing field) · `getUserOpHash` revert · owner read fails · `owner() == 0x0` (P256/passkey-only, `TODO(#40)` Stage 2) · malformed/missing `ownerAuth` · recovered signer ≠ on-chain owner. (The lone `400` is a body that isn't a JSON object — no `userOp`.)

## Files changed

- `src/dto/sign.dto.ts` — `SignMessageDto` now `{ userOp: PackedUserOperationDto, ownerAuth? }`; `ownerAuth` not shape-validated (403 contract).
- `src/modules/blockchain/blockchain.service.ts` — `getUserOpHash(userOp)` via `IEntryPoint.getUserOpHash` (v0.7 PackedUserOperation ABI) on the configured EntryPoint; `PackedUserOp` type; keeps `getAccountOwner`.
- `src/modules/bls/bls.service.ts` — `authorizeAndDeriveHash(userOp, ownerAuth)` derives the hash + runs the gate; `signMessage(userOp, ownerAuth, node)` signs the derived hash.
- `src/config/configuration.ts` — `entryPointAddress` (`ENTRY_POINT_ADDRESS`, canonical default).
- `src/modules/signature/{service,controller}.ts` — thread `userOp`+`ownerAuth`; document 403.
- `src/modules/bls/bls.service.spec.ts` — 12 unit tests (incl. CRITICAL cross-account regression + 403-on-malformed-userOp); `getUserOpHash`+`getAccountOwner` mocked.
- `package.json` / `package-lock.json` — `NODE_OPTIONS=--experimental-vm-modules` on test scripts + `@jest/globals` devDep.

## Tests

`pnpm test` → **12/12 passing**. `pnpm type-check` clean, `pnpm build` clean.

- valid full userOp + owner sig → signs, returns signature
- **CRITICAL**: attacker owns a different account → 403 (account derived from `userOp.sender`, hash from EntryPoint)
- `userOp.sender`'s owner ≠ ownerAuth signer → 403
- attacker cannot substitute a different hash (it's derived, not supplied) → 403
- `getUserOpHash` revert → 403
- malformed ownerAuth → 403 (not 400)
- missing/undefined ownerAuth → 403 (not 400)
- **bad `userOp.sender` (not an address) → 403** (not 400; no chain read)
- **missing required `userOp` field → 403** (not 400; no `getUserOpHash`)
- P256/passkey-only (owner == 0x0) → 403 fail-closed
- owner read fails → 403 fail-closed
- checksum-casing robustness → signs

> ⚠️ Do not merge yet — opening for review.

