### PR TITLE
feat(#40 Fix2 Stage2): layer-1 on-chain IPolicyRegistry read

### DIFF
--- a/docs/design/dvt-policy-governance.md
+++ b/docs/design/dvt-policy-governance.md
@@ -150,3 +150,18 @@ hash，故 DVT co-sign 路径必须用独立 entry point 传 `userOpHash`。→ 
 PolicyRegistry 的 schema 应**对齐/复用 grant-session 的 scoping 字段模型**，避免重造。→
 ⏳ 待 **airaccount-contract #110**
 确认：每账户「合约 + 资产 + 数额」自定义限额的**实现进展**，以及 PolicyRegistry 能否直接复用 grant-session 原语。
+
+## 11. 部署地址 + 启用（layer-1）
+
+SuperPaymaster 已将 IPolicyRegistry 部署上链（v5.4，PR SuperPaymaster#285）。
+
+| 网络 | PolicyRegistry 地址 |
+| --- | --- |
+| Sepolia | `0x37e4E40e69Fb7d5C3fbAA0F52A4002D27472Ff29` |
+
+**启用 layer-1**：把上面地址填到节点 env `POLICY_REGISTRY_ADDRESS`（+ `POLICY_ENABLED=true`）即可，无需改码。
+`POLICY_ETH_SENTINEL` 默认 `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`（与合约一致）。
+
+**端到端实测（已验证）**：对 Sepolia 上述地址调 `checkPolicy(sender,target,ETH哨兵,1000,0x00000000)`
+→ 返回 `decision=0 (ALLOW)`、`remainingDaily=2^256-1`，即未开通账户的 opt-in default-ALLOW，
+ABI/接线与部署合约逐字段一致。

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -41,6 +41,12 @@ export default () => {
     policyEnabled: process.env.POLICY_ENABLED === "true",
     policyPerTxMaxWei: process.env.POLICY_PER_TX_MAX_WEI || undefined,
     policyRecipientAllowlist: parseAllowlist(process.env.POLICY_RECIPIENT_ALLOWLIST || ""),
+    // Layer-1 (on-chain IPolicyRegistry, Fix 2 Stage 2). Empty = layer-1 off.
+    // ethSentinel: asset key for native ETH in checkPolicy — default 0xEee… per
+    // airaccount-contract #110 (Q4, pending SP final confirm).
+    policyRegistryAddress: process.env.POLICY_REGISTRY_ADDRESS || undefined,
+    policyEthSentinel:
+      process.env.POLICY_ETH_SENTINEL || "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
 
     // Gossip Network
     gossipPublicUrl: process.env.GOSSIP_PUBLIC_URL || `ws://localhost:${port}/ws`,

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -293,6 +293,54 @@ export class BlockchainService {
     }
   }
 
+  /**
+   * Read the DVT policy decision for one decoded call from the on-chain
+   * IPolicyRegistry (Fix 2 Stage 2 — layer 1). This is the sender-keyed,
+   * validation-time `view` defined by SuperPaymaster #283 and confirmed by
+   * airaccount-contract #110:
+   *
+   *   checkPolicy(sender, target, asset, amount, selector)
+   *     -> (PolicyDecision decision, uint256 remainingDaily)
+   *   enum PolicyDecision { ALLOW = 0, REQUIRE_DVT = 1, REJECT = 2 }
+   *
+   * The registry is the SAME source slashing references (node-policy-source ==
+   * slash-source), so a node that honors this read cannot be unfairly slashed.
+   * Read-only — works without a wallet.
+   */
+  async checkPolicy(
+    registryAddress: string,
+    sender: string,
+    target: string,
+    asset: string,
+    amount: ethers.BigNumberish,
+    selector: string
+  ): Promise<{ decision: number; remainingDaily: bigint }> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+
+    const abi = [
+      "function checkPolicy(address sender, address target, address asset, uint256 amount, bytes4 selector) view returns (uint8 decision, uint256 remainingDaily)",
+    ];
+    const contract = new ethers.Contract(registryAddress, abi, this.provider);
+
+    try {
+      const [decision, remainingDaily] = await contract.checkPolicy(
+        sender,
+        target,
+        asset,
+        amount,
+        selector
+      );
+      return { decision: Number(decision), remainingDaily: BigInt(remainingDaily) };
+    } catch (error: any) {
+      this.logger.error(
+        `checkPolicy revert on registry ${registryAddress} for sender ${sender}: ${error.message}`
+      );
+      throw error;
+    }
+  }
+
   async getRegisteredNodes(
     contractAddress: string,
     offset: number,

--- a/src/modules/policy/policy.module.ts
+++ b/src/modules/policy/policy.module.ts
@@ -1,7 +1,9 @@
 import { Module } from "@nestjs/common";
 import { PolicyService } from "./policy.service.js";
+import { BlockchainModule } from "../blockchain/blockchain.module.js";
 
 @Module({
+  imports: [BlockchainModule],
   providers: [PolicyService],
   exports: [PolicyService],
 })

--- a/src/modules/policy/policy.service.spec.ts
+++ b/src/modules/policy/policy.service.spec.ts
@@ -130,8 +130,12 @@ describe("PolicyService — layer 2 (node-operator floor)", () => {
   });
 
   it("fails closed on an empty/malformed callData when enabled", async () => {
-    const svc = makeService({ policyEnabled: true });
+    const svc = makeService({ policyEnabled: true, policyPerTxMaxWei: "100" });
     expect((await svc.evaluate(userOpWith("0x"))).allowed).toBe(false);
+  });
+
+  it("fails fast at construction when enabled with no rules [Codex Low]", () => {
+    expect(() => makeService({ policyEnabled: true })).toThrow(/no policy configured/);
   });
 });
 
@@ -140,10 +144,13 @@ describe("PolicyService — layer 1 (on-chain IPolicyRegistry)", () => {
 
   it("is off when no registry configured (layer-2 only)", async () => {
     let called = false;
-    const svc = makeService({ policyEnabled: true }, async () => {
-      called = true;
-      return { decision: 2, remainingDaily: 0n };
-    });
+    const svc = makeService(
+      { policyEnabled: true, policyPerTxMaxWei: "1000000000000000000" },
+      async () => {
+        called = true;
+        return { decision: 2, remainingDaily: 0n };
+      }
+    );
     expect((await svc.evaluate(userOpWith(executeCallData(RECIPIENT, 5n)))).allowed).toBe(true);
     expect(called).toBe(false); // registry never consulted
   });
@@ -223,7 +230,7 @@ describe("PolicyService — layer 1 (on-chain IPolicyRegistry)", () => {
     await svc.evaluate(userOpWith(erc20TransferCallData(TOKEN, RECIPIENT, 1_000_000n)));
     expect(seen[0].asset.toLowerCase()).toBe(TOKEN.toLowerCase()); // asset = the token
     expect(seen[0].amount).toBe(1_000_000n); // amount from calldata, NOT 0
-    expect(seen[0].target.toLowerCase()).toBe(RECIPIENT.toLowerCase()); // real recipient
+    expect(seen[0].target.toLowerCase()).toBe(TOKEN.toLowerCase()); // checkPolicy target = contract (call.to)
   });
 
   it("captures ERC-20 approve(spender, amount) so allowances are gated [Codex F7]", async () => {
@@ -240,19 +247,35 @@ describe("PolicyService — layer 1 (on-chain IPolicyRegistry)", () => {
     await svc.evaluate(userOpWith(erc20ApproveCallData(TOKEN, SPENDER, 999_999n)));
     expect(seen[0].asset.toLowerCase()).toBe(TOKEN.toLowerCase());
     expect(seen[0].amount).toBe(999_999n); // approved amount gated, not 0
-    expect(seen[0].target.toLowerCase()).toBe(SPENDER.toLowerCase());
+    expect(seen[0].target.toLowerCase()).toBe(TOKEN.toLowerCase()); // checkPolicy target = contract
   });
 
-  it("layer-2 allowlist checks the REAL ERC-20 recipient, not the token contract [Codex F3]", async () => {
-    const TOKEN = "0x" + "cc".repeat(20); // token contract NOT in allowlist
-    // allowlist only RECIPIENT — a transfer to RECIPIENT must pass (recipient allowlisted),
-    // a transfer to OTHER must fail, even though both call the same (non-listed) token.
-    const allow = makeService({ policyEnabled: true, policyRecipientAllowlist: [RECIPIENT] });
+  it("layer-2 allowlist must cover BOTH contract and recipient (augment) [Codex F3]", async () => {
+    const TOKEN = "0x" + "cc".repeat(20);
+    // both token and recipient listed → allowed
+    const ok = makeService({ policyEnabled: true, policyRecipientAllowlist: [TOKEN, RECIPIENT] });
     expect(
-      (await allow.evaluate(userOpWith(erc20TransferCallData(TOKEN, RECIPIENT, 1n)))).allowed
+      (await ok.evaluate(userOpWith(erc20TransferCallData(TOKEN, RECIPIENT, 1n)))).allowed
     ).toBe(true);
-    const deny = makeService({ policyEnabled: true, policyRecipientAllowlist: [RECIPIENT] });
-    const d = await deny.evaluate(userOpWith(erc20TransferCallData(TOKEN, OTHER, 1n)));
+    // recipient NOT listed → rejected
+    const noRecip = makeService({ policyEnabled: true, policyRecipientAllowlist: [TOKEN] });
+    expect(
+      (await noRecip.evaluate(userOpWith(erc20TransferCallData(TOKEN, OTHER, 1n)))).allowed
+    ).toBe(false);
+    // token contract NOT listed → rejected (recipient alone is not enough)
+    const noToken = makeService({ policyEnabled: true, policyRecipientAllowlist: [RECIPIENT] });
+    const d = await noToken.evaluate(userOpWith(erc20TransferCallData(TOKEN, RECIPIENT, 1n)));
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toMatch(/not in allowlist/);
+  });
+
+  it("blocks selector-collision: malicious contract masquerading as a token transfer [Codex F3 regression]", async () => {
+    const MALICIOUS = "0x" + "66".repeat(20);
+    // execute(MALICIOUS, 0, transfer(RECIPIENT, 1)) — MALICIOUS's calldata collides with
+    // the transfer selector + an allowlisted recipient. The contract (MALICIOUS) is NOT
+    // allowlisted, so it MUST be rejected — not waved through as a benign token transfer.
+    const svc = makeService({ policyEnabled: true, policyRecipientAllowlist: [RECIPIENT] });
+    const d = await svc.evaluate(userOpWith(erc20TransferCallData(MALICIOUS, RECIPIENT, 1n)));
     expect(d.allowed).toBe(false);
     expect(d.reason).toMatch(/not in allowlist/);
   });

--- a/src/modules/policy/policy.service.spec.ts
+++ b/src/modules/policy/policy.service.spec.ts
@@ -29,6 +29,14 @@ function executeBatchCallData(tos: string[], values: bigint[]): string {
   );
 }
 
+/** Build callData for execute() wrapping an ERC-20 transfer(to, amount) on `token`. */
+function erc20TransferCallData(token: string, to: string, amount: bigint): string {
+  const transferSel = ethers.id("transfer(address,uint256)").slice(0, 10);
+  const innerFunc = transferSel + coder.encode(["address", "uint256"], [to, amount]).slice(2);
+  const exec = ethers.id("execute(address,uint256,bytes)").slice(0, 10);
+  return exec + coder.encode(["address", "uint256", "bytes"], [token, 0n, innerFunc]).slice(2);
+}
+
 function userOpWith(callData: string): PackedUserOp {
   return {
     sender: "0x" + "ab".repeat(20),
@@ -181,6 +189,54 @@ describe("PolicyService — layer 1 (on-chain IPolicyRegistry)", () => {
     expect(seen[0].asset.toLowerCase()).toBe("0x" + "ee".repeat(20));
     expect(seen[0].amount).toBe(777n);
     expect(seen[0].target.toLowerCase()).toBe(RECIPIENT.toLowerCase());
+  });
+
+  it("extracts ERC-20 transfer amount/asset/recipient from inner calldata", async () => {
+    const TOKEN = "0x" + "cc".repeat(20);
+    const seen: any[] = [];
+    const svc = makeService(
+      { policyEnabled: true, policyRegistryAddress: REGISTRY },
+      async (_registry, _sender, target, asset, amount) => {
+        seen.push({ target, asset, amount });
+        return { decision: 1, remainingDaily: 0n };
+      }
+    );
+    // execute(TOKEN, 0, transfer(RECIPIENT, 1_000_000)) — native value is 0.
+    await svc.evaluate(userOpWith(erc20TransferCallData(TOKEN, RECIPIENT, 1_000_000n)));
+    expect(seen[0].asset.toLowerCase()).toBe(TOKEN.toLowerCase()); // asset = the token
+    expect(seen[0].amount).toBe(1_000_000n); // amount from calldata, NOT 0
+    expect(seen[0].target.toLowerCase()).toBe(RECIPIENT.toLowerCase()); // real recipient
+  });
+
+  it("REJECTs an over-limit ERC-20 transfer that amount=0 would have missed", async () => {
+    const TOKEN = "0x" + "cc".repeat(20);
+    const svc = makeService(
+      { policyEnabled: true, policyRegistryAddress: REGISTRY },
+      async (_r, _s, _t, _a, amount) => ({
+        decision: amount > 500_000n ? 2 : 1, // registry rejects over-cap token spend
+        remainingDaily: 0n,
+      })
+    );
+    const d = await svc.evaluate(userOpWith(erc20TransferCallData(TOKEN, RECIPIENT, 1_000_000n)));
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toMatch(/REJECT/);
+  });
+
+  it("fails closed on a malformed ERC-20 transfer payload", async () => {
+    const TOKEN = "0x" + "cc".repeat(20);
+    const exec = ethers.id("execute(address,uint256,bytes)").slice(0, 10);
+    const transferSel = ethers.id("transfer(address,uint256)").slice(0, 10);
+    // transfer selector but truncated args → decode throws → fail-closed
+    const badInner = transferSel + "00";
+    const callData =
+      exec + coder.encode(["address", "uint256", "bytes"], [TOKEN, 0n, badInner]).slice(2);
+    const svc = makeService({ policyEnabled: true, policyRegistryAddress: REGISTRY }, async () => ({
+      decision: 1,
+      remainingDaily: 0n,
+    }));
+    const d = await svc.evaluate(userOpWith(callData));
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toMatch(/undecodable transfer/);
   });
 
   it("layer-2 floor still applies before layer-1 (operator floor wins)", async () => {

--- a/src/modules/policy/policy.service.spec.ts
+++ b/src/modules/policy/policy.service.spec.ts
@@ -37,6 +37,14 @@ function erc20TransferCallData(token: string, to: string, amount: bigint): strin
   return exec + coder.encode(["address", "uint256", "bytes"], [token, 0n, innerFunc]).slice(2);
 }
 
+/** Build callData for execute() wrapping an ERC-20 approve(spender, amount) on `token`. */
+function erc20ApproveCallData(token: string, spender: string, amount: bigint): string {
+  const approveSel = ethers.id("approve(address,uint256)").slice(0, 10);
+  const innerFunc = approveSel + coder.encode(["address", "uint256"], [spender, amount]).slice(2);
+  const exec = ethers.id("execute(address,uint256,bytes)").slice(0, 10);
+  return exec + coder.encode(["address", "uint256", "bytes"], [token, 0n, innerFunc]).slice(2);
+}
+
 function userOpWith(callData: string): PackedUserOp {
   return {
     sender: "0x" + "ab".repeat(20),
@@ -160,7 +168,17 @@ describe("PolicyService — layer 1 (on-chain IPolicyRegistry)", () => {
     }));
     const d = await svc.evaluate(userOpWith(executeCallData(RECIPIENT, 5n)));
     expect(d.allowed).toBe(false);
-    expect(d.reason).toMatch(/REJECT/);
+    expect(d.reason).toMatch(/decision = 2|not ALLOW/);
+  });
+
+  it("fails closed on an UNKNOWN registry decision, not just REJECT [Codex F4]", async () => {
+    const svc = makeService({ policyEnabled: true, policyRegistryAddress: REGISTRY }, async () => ({
+      decision: 3, // future REQUIRE_EXTRA / garbage — must NOT be treated as allow (fail-open)
+      remainingDaily: 0n,
+    }));
+    const d = await svc.evaluate(userOpWith(executeCallData(RECIPIENT, 5n)));
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toMatch(/not ALLOW/);
   });
 
   it("fails closed when checkPolicy reverts", async () => {
@@ -208,6 +226,37 @@ describe("PolicyService — layer 1 (on-chain IPolicyRegistry)", () => {
     expect(seen[0].target.toLowerCase()).toBe(RECIPIENT.toLowerCase()); // real recipient
   });
 
+  it("captures ERC-20 approve(spender, amount) so allowances are gated [Codex F7]", async () => {
+    const TOKEN = "0x" + "cc".repeat(20);
+    const SPENDER = "0x" + "dd".repeat(20);
+    const seen: any[] = [];
+    const svc = makeService(
+      { policyEnabled: true, policyRegistryAddress: REGISTRY },
+      async (_registry, _sender, target, asset, amount) => {
+        seen.push({ target, asset, amount });
+        return { decision: 1, remainingDaily: 0n };
+      }
+    );
+    await svc.evaluate(userOpWith(erc20ApproveCallData(TOKEN, SPENDER, 999_999n)));
+    expect(seen[0].asset.toLowerCase()).toBe(TOKEN.toLowerCase());
+    expect(seen[0].amount).toBe(999_999n); // approved amount gated, not 0
+    expect(seen[0].target.toLowerCase()).toBe(SPENDER.toLowerCase());
+  });
+
+  it("layer-2 allowlist checks the REAL ERC-20 recipient, not the token contract [Codex F3]", async () => {
+    const TOKEN = "0x" + "cc".repeat(20); // token contract NOT in allowlist
+    // allowlist only RECIPIENT — a transfer to RECIPIENT must pass (recipient allowlisted),
+    // a transfer to OTHER must fail, even though both call the same (non-listed) token.
+    const allow = makeService({ policyEnabled: true, policyRecipientAllowlist: [RECIPIENT] });
+    expect(
+      (await allow.evaluate(userOpWith(erc20TransferCallData(TOKEN, RECIPIENT, 1n)))).allowed
+    ).toBe(true);
+    const deny = makeService({ policyEnabled: true, policyRecipientAllowlist: [RECIPIENT] });
+    const d = await deny.evaluate(userOpWith(erc20TransferCallData(TOKEN, OTHER, 1n)));
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toMatch(/not in allowlist/);
+  });
+
   it("REJECTs an over-limit ERC-20 transfer that amount=0 would have missed", async () => {
     const TOKEN = "0x" + "cc".repeat(20);
     const svc = makeService(
@@ -219,7 +268,7 @@ describe("PolicyService — layer 1 (on-chain IPolicyRegistry)", () => {
     );
     const d = await svc.evaluate(userOpWith(erc20TransferCallData(TOKEN, RECIPIENT, 1_000_000n)));
     expect(d.allowed).toBe(false);
-    expect(d.reason).toMatch(/REJECT/);
+    expect(d.reason).toMatch(/decision = 2|not ALLOW/);
   });
 
   it("fails closed on a malformed ERC-20 transfer payload", async () => {

--- a/src/modules/policy/policy.service.spec.ts
+++ b/src/modules/policy/policy.service.spec.ts
@@ -43,69 +43,158 @@ function userOpWith(callData: string): PackedUserOp {
   };
 }
 
-/** Minimal ConfigService stub returning policy config by key. */
-function makeService(config: Record<string, unknown>): PolicyService {
+/**
+ * Minimal ConfigService stub + BlockchainService stub. `checkPolicyImpl` lets a
+ * test drive the layer-1 on-chain decision (or throw to simulate a revert).
+ */
+function makeService(
+  config: Record<string, unknown>,
+  checkPolicyImpl?: (...args: any[]) => Promise<{ decision: number; remainingDaily: bigint }>
+): PolicyService {
   const configService = {
     get: (key: string) => config[key],
   } as any;
-  return new PolicyService(configService);
+  const blockchainService = {
+    checkPolicy: checkPolicyImpl ?? (async () => ({ decision: 1, remainingDaily: 0n })), // default REQUIRE_DVT
+  } as any;
+  return new PolicyService(configService, blockchainService);
 }
 
-describe("PolicyService — DVT independent policy gate (Fix 2 Stage 2)", () => {
-  it("allows everything when disabled (preserves Stage 1 behavior)", () => {
+describe("PolicyService — layer 2 (node-operator floor)", () => {
+  it("allows everything when disabled (preserves Stage 1 behavior)", async () => {
     const svc = makeService({ policyEnabled: false });
     // even garbage callData passes when the gate is off
-    expect(svc.evaluate(userOpWith("0xdeadbeef")).allowed).toBe(true);
+    expect((await svc.evaluate(userOpWith("0xdeadbeef"))).allowed).toBe(true);
   });
 
-  it("allows an execute() within the per-tx limit", () => {
+  it("allows an execute() within the per-tx limit", async () => {
     const svc = makeService({ policyEnabled: true, policyPerTxMaxWei: "1000000000000000000" });
     const op = userOpWith(executeCallData(RECIPIENT, 5n));
-    expect(svc.evaluate(op).allowed).toBe(true);
+    expect((await svc.evaluate(op)).allowed).toBe(true);
   });
 
-  it("rejects an execute() above the per-tx limit", () => {
+  it("rejects an execute() above the per-tx limit", async () => {
     const svc = makeService({ policyEnabled: true, policyPerTxMaxWei: "100" });
     const op = userOpWith(executeCallData(RECIPIENT, 101n));
-    const d = svc.evaluate(op);
+    const d = await svc.evaluate(op);
     expect(d.allowed).toBe(false);
     expect(d.reason).toMatch(/exceeds perTxMaxWei/);
   });
 
-  it("rejects a recipient outside the allowlist", () => {
+  it("rejects a recipient outside the allowlist", async () => {
     const svc = makeService({ policyEnabled: true, policyRecipientAllowlist: [RECIPIENT] });
     const op = userOpWith(executeCallData(OTHER, 0n));
-    const d = svc.evaluate(op);
+    const d = await svc.evaluate(op);
     expect(d.allowed).toBe(false);
     expect(d.reason).toMatch(/not in allowlist/);
   });
 
-  it("allows a recipient inside the allowlist (case-insensitive)", () => {
+  it("allows a recipient inside the allowlist (case-insensitive)", async () => {
     const svc = makeService({
       policyEnabled: true,
       policyRecipientAllowlist: [RECIPIENT.toUpperCase()],
     });
     const op = userOpWith(executeCallData(RECIPIENT, 0n));
-    expect(svc.evaluate(op).allowed).toBe(true);
+    expect((await svc.evaluate(op)).allowed).toBe(true);
   });
 
-  it("enforces the limit against EVERY call in executeBatch", () => {
+  it("enforces the limit against EVERY call in executeBatch", async () => {
     const svc = makeService({ policyEnabled: true, policyPerTxMaxWei: "100" });
     const op = userOpWith(executeBatchCallData([RECIPIENT, OTHER], [10n, 999n]));
-    const d = svc.evaluate(op);
+    const d = await svc.evaluate(op);
     expect(d.allowed).toBe(false);
     expect(d.reason).toMatch(/call\[1\]/);
   });
 
-  it("fails closed on undecodable callData when enabled", () => {
+  it("fails closed on undecodable callData when enabled", async () => {
     const svc = makeService({ policyEnabled: true, policyPerTxMaxWei: "100" });
-    const d = svc.evaluate(userOpWith("0xdeadbeef"));
+    const d = await svc.evaluate(userOpWith("0xdeadbeef"));
     expect(d.allowed).toBe(false);
     expect(d.reason).toMatch(/unsupported callData selector|undecodable/);
   });
 
-  it("fails closed on an empty/malformed callData when enabled", () => {
+  it("fails closed on an empty/malformed callData when enabled", async () => {
     const svc = makeService({ policyEnabled: true });
-    expect(svc.evaluate(userOpWith("0x")).allowed).toBe(false);
+    expect((await svc.evaluate(userOpWith("0x"))).allowed).toBe(false);
+  });
+});
+
+describe("PolicyService — layer 1 (on-chain IPolicyRegistry)", () => {
+  const REGISTRY = "0x" + "99".repeat(20);
+
+  it("is off when no registry configured (layer-2 only)", async () => {
+    let called = false;
+    const svc = makeService({ policyEnabled: true }, async () => {
+      called = true;
+      return { decision: 2, remainingDaily: 0n };
+    });
+    expect((await svc.evaluate(userOpWith(executeCallData(RECIPIENT, 5n)))).allowed).toBe(true);
+    expect(called).toBe(false); // registry never consulted
+  });
+
+  it("allows when registry returns ALLOW (0) / REQUIRE_DVT (1)", async () => {
+    for (const decision of [0, 1]) {
+      const svc = makeService(
+        { policyEnabled: true, policyRegistryAddress: REGISTRY },
+        async () => ({
+          decision,
+          remainingDaily: 0n,
+        })
+      );
+      expect((await svc.evaluate(userOpWith(executeCallData(RECIPIENT, 5n)))).allowed).toBe(true);
+    }
+  });
+
+  it("refuses when registry returns REJECT (2)", async () => {
+    const svc = makeService({ policyEnabled: true, policyRegistryAddress: REGISTRY }, async () => ({
+      decision: 2,
+      remainingDaily: 0n,
+    }));
+    const d = await svc.evaluate(userOpWith(executeCallData(RECIPIENT, 5n)));
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toMatch(/REJECT/);
+  });
+
+  it("fails closed when checkPolicy reverts", async () => {
+    const svc = makeService({ policyEnabled: true, policyRegistryAddress: REGISTRY }, async () => {
+      throw new Error("execution reverted");
+    });
+    const d = await svc.evaluate(userOpWith(executeCallData(RECIPIENT, 5n)));
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toMatch(/checkPolicy reverted/);
+  });
+
+  it("passes native-ETH calls to the registry with the ETH sentinel asset", async () => {
+    const seen: any[] = [];
+    const svc = makeService(
+      {
+        policyEnabled: true,
+        policyRegistryAddress: REGISTRY,
+        policyEthSentinel: "0x" + "ee".repeat(20),
+      },
+      async (_registry, sender, target, asset, amount) => {
+        seen.push({ sender, target, asset, amount });
+        return { decision: 1, remainingDaily: 0n };
+      }
+    );
+    await svc.evaluate(userOpWith(executeCallData(RECIPIENT, 777n)));
+    expect(seen[0].asset.toLowerCase()).toBe("0x" + "ee".repeat(20));
+    expect(seen[0].amount).toBe(777n);
+    expect(seen[0].target.toLowerCase()).toBe(RECIPIENT.toLowerCase());
+  });
+
+  it("layer-2 floor still applies before layer-1 (operator floor wins)", async () => {
+    let called = false;
+    const svc = makeService(
+      { policyEnabled: true, policyPerTxMaxWei: "100", policyRegistryAddress: REGISTRY },
+      async () => {
+        called = true;
+        return { decision: 0, remainingDaily: 0n };
+      }
+    );
+    const d = await svc.evaluate(userOpWith(executeCallData(RECIPIENT, 999n)));
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toMatch(/exceeds perTxMaxWei/);
+    expect(called).toBe(false); // layer-2 rejected before consulting the chain
   });
 });

--- a/src/modules/policy/policy.service.ts
+++ b/src/modules/policy/policy.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { ethers } from "ethers";
-import { PackedUserOp } from "../blockchain/blockchain.service.js";
+import { PackedUserOp, BlockchainService } from "../blockchain/blockchain.service.js";
 
 /**
  * Fix 2 Stage 2 — DVT node INDEPENDENT policy gate (owner-compromise protection).
@@ -12,17 +12,20 @@ import { PackedUserOp } from "../blockchain/blockchain.service.js";
  *
  * Stage 2's value comes purely from INDEPENDENCE (see AirAccount #70): this node
  * applies its OWN decision, using rules that the account owner and the CA cannot
- * change, BEFORE it co-signs. The node decodes the operation and refuses to
- * co-sign anything outside policy. A node that blind-signs provides zero security,
- * so this gate is the whole point of the DVT tier as a true second factor.
+ * change, BEFORE it co-signs. A node that blind-signs provides zero security.
  *
- * This gate is INDEPENDENT of the on-chain BLS binding format (airaccount-contract
- * #45/#110): it decides *whether* to sign, not *what* the signed messagePoint is.
- * It can therefore ship before the cross-repo signature-format negotiation settles.
+ * Two layers, ANDed (either rejects → no co-sign):
+ *   - Layer 1 (per-account, on-chain): IPolicyRegistry.checkPolicy — the account
+ *     owner's own limits, governance-gated so a compromised owner cannot instantly
+ *     loosen them. SAME source slashing references (node-source == slash-source).
+ *   - Layer 2 (node operator, local): perTxMax + recipient allowlist — the operator's
+ *     floor that no on-chain state can override. The hard independence guarantee.
  *
- * v1 scope: per-tx value limit + recipient allowlist, fail-closed on anything it
- * cannot decode. Daily/velocity limits and out-of-band confirmation are follow-ups
- * (they need cross-request persistence; see #40).
+ * v1 layer-1 scope: native-value flows map to (asset = ETH sentinel, amount = value);
+ * token/contract calls pass (asset = target, amount = value) + selector, so the
+ * registry's per-contract ContractScope applies. ERC20 in-calldata amount extraction
+ * is a follow-up. Pending SP final Q4 (ETH sentinel value) / Q5 (governance) — both
+ * are configurable constants and do not change the checkPolicy read signature.
  */
 export interface PolicyDecision {
   allowed: boolean;
@@ -33,11 +36,17 @@ export interface PolicyDecision {
 interface DecodedCall {
   to: string;
   value: bigint;
+  /** 4-byte selector of the inner call (0x00000000 if none / plain transfer). */
+  selector: string;
 }
+
+// IPolicyRegistry.PolicyDecision enum.
+const REJECT = 2;
 
 // Account call surface (contracts/src/AAStarAccountBase.sol).
 const EXECUTE_SELECTOR = ethers.id("execute(address,uint256,bytes)").slice(0, 10);
 const EXECUTE_BATCH_SELECTOR = ethers.id("executeBatch(address[],uint256[],bytes[])").slice(0, 10);
+const NULL_SELECTOR = "0x00000000";
 
 const ABI = new ethers.AbiCoder();
 
@@ -49,18 +58,30 @@ export class PolicyService {
   private readonly perTxMaxWei: bigint | null;
   /** Lowercased recipient allowlist; empty set = allow any recipient. */
   private readonly recipientAllowlist: Set<string>;
+  /** Layer-1: on-chain IPolicyRegistry address; empty = layer-1 disabled. */
+  private readonly registryAddress: string;
+  /** Asset key used for native ETH in checkPolicy (Q4 — pending SP final). */
+  private readonly ethSentinel: string;
 
-  constructor(private readonly configService: ConfigService) {
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly blockchainService: BlockchainService
+  ) {
     this.enabled = this.configService.get<boolean>("policyEnabled") === true;
     const max = this.configService.get<string>("policyPerTxMaxWei");
     this.perTxMaxWei = max ? BigInt(max) : null;
     const allow = this.configService.get<string[]>("policyRecipientAllowlist") ?? [];
     this.recipientAllowlist = new Set(allow.map(a => a.toLowerCase()));
+    this.registryAddress = this.configService.get<string>("policyRegistryAddress") ?? "";
+    this.ethSentinel =
+      this.configService.get<string>("policyEthSentinel") ??
+      "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 
     if (this.enabled) {
       this.logger.log(
         `DVT policy gate ENABLED — perTxMaxWei=${this.perTxMaxWei ?? "unset"}, ` +
-          `allowlist=${this.recipientAllowlist.size} entries`
+          `allowlist=${this.recipientAllowlist.size} entries, ` +
+          `registry=${this.registryAddress || "unset (layer-1 off)"}`
       );
     } else {
       this.logger.log("DVT policy gate DISABLED (POLICY_ENABLED!=true) — Stage 1 behavior only");
@@ -69,12 +90,12 @@ export class PolicyService {
 
   /**
    * Decide whether this node may co-sign `userOp`. Fail-closed: when the gate is
-   * enabled and the operation cannot be decoded into concrete (to, value) calls,
-   * the node REFUSES — an undecodable op cannot be proven within policy.
+   * enabled and the operation cannot be decoded into concrete calls — or the
+   * on-chain registry read reverts — the node REFUSES.
    *
    * When disabled, always allows (preserves Stage 1 behavior exactly).
    */
-  evaluate(userOp: PackedUserOp): PolicyDecision {
+  async evaluate(userOp: PackedUserOp): Promise<PolicyDecision> {
     if (!this.enabled) {
       return { allowed: true };
     }
@@ -90,6 +111,7 @@ export class PolicyService {
       return { allowed: false, reason: "no decodable calls in callData (fail-closed)" };
     }
 
+    // Layer 2 — node-operator floor (local, owner/CA cannot override).
     for (const [i, call] of calls.entries()) {
       if (this.perTxMaxWei !== null && call.value > this.perTxMaxWei) {
         return {
@@ -102,12 +124,41 @@ export class PolicyService {
       }
     }
 
+    // Layer 1 — per-account on-chain registry (if configured). Fail-closed on revert.
+    if (this.registryAddress) {
+      for (const [i, call] of calls.entries()) {
+        const isNative = call.value > 0n;
+        const asset = isNative ? this.ethSentinel : call.to;
+        let decision: number;
+        try {
+          ({ decision } = await this.blockchainService.checkPolicy(
+            this.registryAddress,
+            userOp.sender,
+            call.to,
+            asset,
+            call.value,
+            call.selector
+          ));
+        } catch (e: any) {
+          return {
+            allowed: false,
+            reason: `call[${i}] registry checkPolicy reverted (fail-closed): ${e?.message ?? e}`,
+          };
+        }
+        // ALLOW / REQUIRE_DVT are both within policy → node may co-sign. REJECT → refuse.
+        if (decision === REJECT) {
+          return { allowed: false, reason: `call[${i}] registry decision = REJECT` };
+        }
+      }
+    }
+
     return { allowed: true };
   }
 
   /**
-   * Decode the account's callData into concrete (to, value) calls. Supports the
-   * standard ERC-4337 v0.7/v0.8 account surface; anything else throws → fail-closed.
+   * Decode the account's callData into concrete (to, value, selector) calls.
+   * Supports the standard ERC-4337 v0.7/v0.8 account surface; anything else
+   * throws → fail-closed.
    */
   private decodeCalls(callData: string): DecodedCall[] {
     if (typeof callData !== "string" || !callData.startsWith("0x") || callData.length < 10) {
@@ -118,20 +169,39 @@ export class PolicyService {
     const args = "0x" + callData.slice(10);
 
     if (selector === EXECUTE_SELECTOR) {
-      const [dest, value] = ABI.decode(["address", "uint256", "bytes"], args);
-      return [{ to: dest as string, value: value as bigint }];
+      const [dest, value, func] = ABI.decode(["address", "uint256", "bytes"], args);
+      return [
+        {
+          to: dest as string,
+          value: value as bigint,
+          selector: this.innerSelector(func as string),
+        },
+      ];
     }
 
     if (selector === EXECUTE_BATCH_SELECTOR) {
-      const [dests, values] = ABI.decode(["address[]", "uint256[]", "bytes[]"], args);
+      const [dests, values, funcs] = ABI.decode(["address[]", "uint256[]", "bytes[]"], args);
       const destArr = dests as string[];
       const valueArr = values as bigint[];
-      if (destArr.length !== valueArr.length) {
-        throw new Error("executeBatch dest/value length mismatch");
+      const funcArr = funcs as string[];
+      if (destArr.length !== valueArr.length || destArr.length !== funcArr.length) {
+        throw new Error("executeBatch dest/value/func length mismatch");
       }
-      return destArr.map((to, i) => ({ to, value: valueArr[i] }));
+      return destArr.map((to, i) => ({
+        to,
+        value: valueArr[i],
+        selector: this.innerSelector(funcArr[i]),
+      }));
     }
 
     throw new Error(`unsupported callData selector ${selector}`);
+  }
+
+  /** 4-byte selector of an inner call payload, or NULL_SELECTOR for a bare transfer. */
+  private innerSelector(func: string): string {
+    if (typeof func !== "string" || !func.startsWith("0x") || func.length < 10) {
+      return NULL_SELECTOR;
+    }
+    return func.slice(0, 10);
   }
 }

--- a/src/modules/policy/policy.service.ts
+++ b/src/modules/policy/policy.service.ts
@@ -21,10 +21,11 @@ import { PackedUserOp, BlockchainService } from "../blockchain/blockchain.servic
  *   - Layer 2 (node operator, local): perTxMax + recipient allowlist — the operator's
  *     floor that no on-chain state can override. The hard independence guarantee.
  *
- * layer-1 amount semantics: native-value flows map to (asset = ETH sentinel,
- * amount = value); ERC-20 transfer/transferFrom map to (asset = token, amount =
- * the in-calldata amount, target = recipient) so per-asset token limits apply;
- * other contract calls pass (asset = target, amount = 0) for ContractScope only.
+ * layer-1 checkPolicy is keyed by the CONTRACT actually called (call.to) as
+ * `target`, with `asset`/`amount` decoded from the call (native value, or an ERC-20
+ * transfer/transferFrom/approve amount from calldata). The decoded recipient is
+ * checked only by the layer-2 allowlist (alongside the contract — never instead of
+ * it), so a selector collision cannot pose as a benign token transfer.
  * Pending SP final Q4 (ETH sentinel value) / Q5 (governance) — both are
  * configurable constants and do not change the checkPolicy read signature.
  */

--- a/src/modules/policy/policy.service.ts
+++ b/src/modules/policy/policy.service.ts
@@ -21,11 +21,12 @@ import { PackedUserOp, BlockchainService } from "../blockchain/blockchain.servic
  *   - Layer 2 (node operator, local): perTxMax + recipient allowlist — the operator's
  *     floor that no on-chain state can override. The hard independence guarantee.
  *
- * v1 layer-1 scope: native-value flows map to (asset = ETH sentinel, amount = value);
- * token/contract calls pass (asset = target, amount = value) + selector, so the
- * registry's per-contract ContractScope applies. ERC20 in-calldata amount extraction
- * is a follow-up. Pending SP final Q4 (ETH sentinel value) / Q5 (governance) — both
- * are configurable constants and do not change the checkPolicy read signature.
+ * layer-1 amount semantics: native-value flows map to (asset = ETH sentinel,
+ * amount = value); ERC-20 transfer/transferFrom map to (asset = token, amount =
+ * the in-calldata amount, target = recipient) so per-asset token limits apply;
+ * other contract calls pass (asset = target, amount = 0) for ContractScope only.
+ * Pending SP final Q4 (ETH sentinel value) / Q5 (governance) — both are
+ * configurable constants and do not change the checkPolicy read signature.
  */
 export interface PolicyDecision {
   allowed: boolean;
@@ -36,7 +37,17 @@ export interface PolicyDecision {
 interface DecodedCall {
   to: string;
   value: bigint;
+  /** Inner call payload (the ERC-20/contract call the account makes). */
+  func: string;
   /** 4-byte selector of the inner call (0x00000000 if none / plain transfer). */
+  selector: string;
+}
+
+/** The policy-relevant view of a call: who/what/how-much actually moves. */
+interface PolicyCall {
+  target: string;
+  asset: string;
+  amount: bigint;
   selector: string;
 }
 
@@ -47,6 +58,12 @@ const REJECT = 2;
 const EXECUTE_SELECTOR = ethers.id("execute(address,uint256,bytes)").slice(0, 10);
 const EXECUTE_BATCH_SELECTOR = ethers.id("executeBatch(address[],uint256[],bytes[])").slice(0, 10);
 const NULL_SELECTOR = "0x00000000";
+
+// ERC-20 value-moving calls — the moved amount lives in the inner calldata, not
+// in execute()'s native `value`. Extracting it is what lets per-asset amount
+// limits apply to token transfers (the common case), not just native ETH.
+const ERC20_TRANSFER = ethers.id("transfer(address,uint256)").slice(0, 10);
+const ERC20_TRANSFER_FROM = ethers.id("transferFrom(address,address,uint256)").slice(0, 10);
 
 const ABI = new ethers.AbiCoder();
 
@@ -127,17 +144,24 @@ export class PolicyService {
     // Layer 1 — per-account on-chain registry (if configured). Fail-closed on revert.
     if (this.registryAddress) {
       for (const [i, call] of calls.entries()) {
-        const isNative = call.value > 0n;
-        const asset = isNative ? this.ethSentinel : call.to;
+        let pc: PolicyCall;
+        try {
+          pc = this.normalizeForPolicy(call);
+        } catch (e: any) {
+          return {
+            allowed: false,
+            reason: `call[${i}] undecodable transfer (fail-closed): ${e?.message ?? e}`,
+          };
+        }
         let decision: number;
         try {
           ({ decision } = await this.blockchainService.checkPolicy(
             this.registryAddress,
             userOp.sender,
-            call.to,
-            asset,
-            call.value,
-            call.selector
+            pc.target,
+            pc.asset,
+            pc.amount,
+            pc.selector
           ));
         } catch (e: any) {
           return {
@@ -174,6 +198,7 @@ export class PolicyService {
         {
           to: dest as string,
           value: value as bigint,
+          func: func as string,
           selector: this.innerSelector(func as string),
         },
       ];
@@ -190,11 +215,58 @@ export class PolicyService {
       return destArr.map((to, i) => ({
         to,
         value: valueArr[i],
+        func: funcArr[i],
         selector: this.innerSelector(funcArr[i]),
       }));
     }
 
     throw new Error(`unsupported callData selector ${selector}`);
+  }
+
+  /**
+   * Reduce a decoded call to what the policy actually cares about: which asset
+   * moves, how much, and to whom. Native ETH's amount is execute()'s `value`;
+   * an ERC-20 transfer's amount lives in the inner calldata (value == 0), so it
+   * must be decoded — otherwise per-asset token limits see amount 0 and never fire
+   * (the gap a compromised owner draining stablecoins would slip through).
+   * Throws on a malformed token payload → caller fails closed.
+   */
+  private normalizeForPolicy(call: DecodedCall): PolicyCall {
+    // Native ETH movement: the value leaving the account is execute()'s `value`.
+    if (call.value > 0n) {
+      return {
+        target: call.to,
+        asset: this.ethSentinel,
+        amount: call.value,
+        selector: call.selector,
+      };
+    }
+    // ERC-20 transfer(to, amount): asset = the token (call.to), amount from calldata.
+    if (call.selector === ERC20_TRANSFER) {
+      const [to, amount] = ABI.decode(["address", "uint256"], "0x" + call.func.slice(10));
+      return {
+        target: to as string,
+        asset: call.to,
+        amount: amount as bigint,
+        selector: call.selector,
+      };
+    }
+    // ERC-20 transferFrom(from, to, amount): value pulled to `to`; asset = the token.
+    if (call.selector === ERC20_TRANSFER_FROM) {
+      const [, to, amount] = ABI.decode(
+        ["address", "address", "uint256"],
+        "0x" + call.func.slice(10)
+      );
+      return {
+        target: to as string,
+        asset: call.to,
+        amount: amount as bigint,
+        selector: call.selector,
+      };
+    }
+    // Generic contract call: no native value, no recognized token transfer.
+    // amount 0 → only the registry's per-contract ContractScope (allow/velocity) applies.
+    return { target: call.to, asset: call.to, amount: 0n, selector: call.selector };
   }
 
   /** 4-byte selector of an inner call payload, or NULL_SELECTOR for a bare transfer. */

--- a/src/modules/policy/policy.service.ts
+++ b/src/modules/policy/policy.service.ts
@@ -43,9 +43,18 @@ interface DecodedCall {
   selector: string;
 }
 
-/** The policy-relevant view of a call: who/what/how-much actually moves. */
+/**
+ * The policy-relevant view of a call. `contract` and `recipient` are kept SEPARATE
+ * on purpose: a selector match alone must never let a call masquerade as a token
+ * transfer and skip the contract check (the F3-augment fix). For a real ERC-20
+ * transfer these differ (contract = token, recipient = payee); for native/generic
+ * calls they coincide (both = execute's dest).
+ */
 interface PolicyCall {
-  target: string;
+  /** The contract actually being called (execute's dest) — the ContractScope key. */
+  contract: string;
+  /** Value recipient: decoded payee/spender for token ops, else the contract. */
+  recipient: string;
   asset: string;
   amount: bigint;
   selector: string;
@@ -100,6 +109,18 @@ export class PolicyService {
       "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 
     if (this.enabled) {
+      // Fail fast on a no-op gate: POLICY_ENABLED=true with zero rules would silently
+      // allow everything, giving operators a false sense of enforcement.
+      if (
+        !this.registryAddress &&
+        this.perTxMaxWei === null &&
+        this.recipientAllowlist.size === 0
+      ) {
+        throw new Error(
+          "POLICY_ENABLED=true but no policy configured — set POLICY_REGISTRY_ADDRESS, " +
+            "POLICY_PER_TX_MAX_WEI, and/or POLICY_RECIPIENT_ALLOWLIST. Refusing to start a no-op gate."
+        );
+      }
       this.logger.log(
         `DVT policy gate ENABLED — perTxMaxWei=${this.perTxMaxWei ?? "unset"}, ` +
           `allowlist=${this.recipientAllowlist.size} entries, ` +
@@ -152,10 +173,16 @@ export class PolicyService {
           reason: `call[${i}] value ${call.value} exceeds perTxMaxWei ${this.perTxMaxWei}`,
         };
       }
-      // Allowlist checks the REAL recipient (decoded), not the token contract (Codex F3).
-      const target = pcs[i].target;
-      if (this.recipientAllowlist.size > 0 && !this.recipientAllowlist.has(target.toLowerCase())) {
-        return { allowed: false, reason: `call[${i}] recipient ${target} not in allowlist` };
+      // Allowlist must cover EVERY address the call touches — both the contract being
+      // called AND the decoded recipient (augment, not replace). Checking only the
+      // decoded recipient would let execute(maliciousContract, 0, transferSelector‖
+      // allowlistedAddr‖x) masquerade as a token transfer and skip the contract check.
+      if (this.recipientAllowlist.size > 0) {
+        for (const addr of [pcs[i].contract, pcs[i].recipient]) {
+          if (!this.recipientAllowlist.has(addr.toLowerCase())) {
+            return { allowed: false, reason: `call[${i}] address ${addr} not in allowlist` };
+          }
+        }
       }
     }
 
@@ -166,10 +193,13 @@ export class PolicyService {
       try {
         results = await Promise.all(
           pcs.map(pc =>
+            // ContractScope key = the contract actually called (call.to), NOT the
+            // decoded recipient — so a selector-collision call can't be checked as a
+            // benign token transfer while the real target goes unexamined.
             this.blockchainService.checkPolicy(
               this.registryAddress,
               userOp.sender,
-              pc.target,
+              pc.contract,
               pc.asset,
               pc.amount,
               pc.selector
@@ -258,7 +288,8 @@ export class PolicyService {
     if (call.selector === ERC20_TRANSFER) {
       const [to, amount] = ABI.decode(["address", "uint256"], "0x" + call.func.slice(10));
       return {
-        target: to as string,
+        contract: call.to,
+        recipient: to as string,
         asset: call.to,
         amount: amount as bigint,
         selector: call.selector,
@@ -271,7 +302,8 @@ export class PolicyService {
         "0x" + call.func.slice(10)
       );
       return {
-        target: to as string,
+        contract: call.to,
+        recipient: to as string,
         asset: call.to,
         amount: amount as bigint,
         selector: call.selector,
@@ -282,7 +314,8 @@ export class PolicyService {
     if (call.selector === ERC20_APPROVE) {
       const [spender, amount] = ABI.decode(["address", "uint256"], "0x" + call.func.slice(10));
       return {
-        target: spender as string,
+        contract: call.to,
+        recipient: spender as string,
         asset: call.to,
         amount: amount as bigint,
         selector: call.selector,
@@ -291,7 +324,8 @@ export class PolicyService {
     // Native ETH movement: the value leaving the account is execute()'s `value`.
     if (call.value > 0n) {
       return {
-        target: call.to,
+        contract: call.to,
+        recipient: call.to,
         asset: this.ethSentinel,
         amount: call.value,
         selector: call.selector,
@@ -299,7 +333,13 @@ export class PolicyService {
     }
     // Generic contract call: no native value, no recognized token transfer.
     // amount 0 → only the registry's per-contract ContractScope (allow/velocity) applies.
-    return { target: call.to, asset: call.to, amount: 0n, selector: call.selector };
+    return {
+      contract: call.to,
+      recipient: call.to,
+      asset: call.to,
+      amount: 0n,
+      selector: call.selector,
+    };
   }
 
   /** 4-byte selector of an inner call payload, or NULL_SELECTOR for a bare transfer. */

--- a/src/modules/policy/policy.service.ts
+++ b/src/modules/policy/policy.service.ts
@@ -51,8 +51,10 @@ interface PolicyCall {
   selector: string;
 }
 
-// IPolicyRegistry.PolicyDecision enum.
-const REJECT = 2;
+// IPolicyRegistry.PolicyDecision enum. Co-sign ONLY on these known-good values;
+// REJECT (2) and any unknown/future variant (e.g. a v2 REQUIRE_EXTRA) fail closed.
+const ALLOW = 0;
+const REQUIRE_DVT = 1;
 
 // Account call surface (contracts/src/AAStarAccountBase.sol).
 const EXECUTE_SELECTOR = ethers.id("execute(address,uint256,bytes)").slice(0, 10);
@@ -64,6 +66,9 @@ const NULL_SELECTOR = "0x00000000";
 // limits apply to token transfers (the common case), not just native ETH.
 const ERC20_TRANSFER = ethers.id("transfer(address,uint256)").slice(0, 10);
 const ERC20_TRANSFER_FROM = ethers.id("transferFrom(address,address,uint256)").slice(0, 10);
+// approve() authorizes future spend — gate the approved amount too, else an
+// infinite approval is invisible to the amount checks (Codex F7).
+const ERC20_APPROVE = ethers.id("approve(address,uint256)").slice(0, 10);
 
 const ABI = new ethers.AbiCoder();
 
@@ -128,50 +133,63 @@ export class PolicyService {
       return { allowed: false, reason: "no decodable calls in callData (fail-closed)" };
     }
 
+    // Normalize each call ONCE to its policy-relevant (target, asset, amount, selector).
+    // Throws on a malformed token payload → fail-closed. Reused by both layers so the
+    // operator floor sees the REAL recipient/amount, not just the immediate `to`.
+    let pcs: PolicyCall[];
+    try {
+      pcs = calls.map(c => this.normalizeForPolicy(c));
+    } catch (e: any) {
+      return { allowed: false, reason: `undecodable transfer (fail-closed): ${e?.message ?? e}` };
+    }
+
     // Layer 2 — node-operator floor (local, owner/CA cannot override).
     for (const [i, call] of calls.entries()) {
+      // perTxMaxWei is a NATIVE-wei cap → only the native value of the call.
       if (this.perTxMaxWei !== null && call.value > this.perTxMaxWei) {
         return {
           allowed: false,
           reason: `call[${i}] value ${call.value} exceeds perTxMaxWei ${this.perTxMaxWei}`,
         };
       }
-      if (this.recipientAllowlist.size > 0 && !this.recipientAllowlist.has(call.to.toLowerCase())) {
-        return { allowed: false, reason: `call[${i}] recipient ${call.to} not in allowlist` };
+      // Allowlist checks the REAL recipient (decoded), not the token contract (Codex F3).
+      const target = pcs[i].target;
+      if (this.recipientAllowlist.size > 0 && !this.recipientAllowlist.has(target.toLowerCase())) {
+        return { allowed: false, reason: `call[${i}] recipient ${target} not in allowlist` };
       }
     }
 
     // Layer 1 — per-account on-chain registry (if configured). Fail-closed on revert.
+    // Checks run concurrently (Codex F6 — no sequential per-call RPC latency).
     if (this.registryAddress) {
-      for (const [i, call] of calls.entries()) {
-        let pc: PolicyCall;
-        try {
-          pc = this.normalizeForPolicy(call);
-        } catch (e: any) {
+      let results: { decision: number; remainingDaily: bigint }[];
+      try {
+        results = await Promise.all(
+          pcs.map(pc =>
+            this.blockchainService.checkPolicy(
+              this.registryAddress,
+              userOp.sender,
+              pc.target,
+              pc.asset,
+              pc.amount,
+              pc.selector
+            )
+          )
+        );
+      } catch (e: any) {
+        return {
+          allowed: false,
+          reason: `registry checkPolicy reverted (fail-closed): ${e?.message ?? e}`,
+        };
+      }
+      // Fail-closed: co-sign ONLY on a known-good decision. REJECT and any unknown/
+      // future variant refuse (Codex F4 — was fail-open on anything != REJECT).
+      for (const [i, { decision }] of results.entries()) {
+        if (decision !== ALLOW && decision !== REQUIRE_DVT) {
           return {
             allowed: false,
-            reason: `call[${i}] undecodable transfer (fail-closed): ${e?.message ?? e}`,
+            reason: `call[${i}] registry decision = ${decision} (not ALLOW/REQUIRE_DVT)`,
           };
-        }
-        let decision: number;
-        try {
-          ({ decision } = await this.blockchainService.checkPolicy(
-            this.registryAddress,
-            userOp.sender,
-            pc.target,
-            pc.asset,
-            pc.amount,
-            pc.selector
-          ));
-        } catch (e: any) {
-          return {
-            allowed: false,
-            reason: `call[${i}] registry checkPolicy reverted (fail-closed): ${e?.message ?? e}`,
-          };
-        }
-        // ALLOW / REQUIRE_DVT are both within policy → node may co-sign. REJECT → refuse.
-        if (decision === REJECT) {
-          return { allowed: false, reason: `call[${i}] registry decision = REJECT` };
         }
       }
     }
@@ -232,15 +250,10 @@ export class PolicyService {
    * Throws on a malformed token payload → caller fails closed.
    */
   private normalizeForPolicy(call: DecodedCall): PolicyCall {
-    // Native ETH movement: the value leaving the account is execute()'s `value`.
-    if (call.value > 0n) {
-      return {
-        target: call.to,
-        asset: this.ethSentinel,
-        amount: call.value,
-        selector: call.selector,
-      };
-    }
+    // Token value-moving calls are checked BEFORE the native-value shortcut (Codex F2)
+    // so a token transfer's real (asset, amount, recipient) is always captured — even
+    // if a stray native value is also attached.
+    //
     // ERC-20 transfer(to, amount): asset = the token (call.to), amount from calldata.
     if (call.selector === ERC20_TRANSFER) {
       const [to, amount] = ABI.decode(["address", "uint256"], "0x" + call.func.slice(10));
@@ -261,6 +274,26 @@ export class PolicyService {
         target: to as string,
         asset: call.to,
         amount: amount as bigint,
+        selector: call.selector,
+      };
+    }
+    // ERC-20 approve(spender, amount): an allowance is authorized FUTURE spend — gate
+    // the approved amount so a large/infinite approval is not invisible (Codex F7).
+    if (call.selector === ERC20_APPROVE) {
+      const [spender, amount] = ABI.decode(["address", "uint256"], "0x" + call.func.slice(10));
+      return {
+        target: spender as string,
+        asset: call.to,
+        amount: amount as bigint,
+        selector: call.selector,
+      };
+    }
+    // Native ETH movement: the value leaving the account is execute()'s `value`.
+    if (call.value > 0n) {
+      return {
+        target: call.to,
+        asset: this.ethSentinel,
+        amount: call.value,
         selector: call.selector,
       };
     }

--- a/src/modules/signature/signature.service.ts
+++ b/src/modules/signature/signature.service.ts
@@ -25,7 +25,7 @@ export class SignatureService {
     // signature. Fail-closed and uniform with the Stage 1 gate — rejection is a 403,
     // never a 200-with-no-signature. The decision is local to this node (owner/CA
     // cannot change it), which is the source of the DVT tier's independence.
-    const decision = this.policyService.evaluate(userOp);
+    const decision = await this.policyService.evaluate(userOp);
     if (!decision.allowed) {
       this.logger.warn(`DVT policy rejected sign for ${userOp.sender}: ${decision.reason}`);
       throw new ForbiddenException("operation rejected by node policy");


### PR DESCRIPTION
## Fix 2 Stage 2 — layer-1 on-chain IPolicyRegistry read (#40 / #42)

Stacked on #43. Base = `feat/fix2-stage2-dvt-policy`.

### What
Adds the **per-account on-chain layer** to the DVT node policy gate (#42 Decision 2).
`PolicyService.evaluate` is now async and ANDs two independent layers:

- **Layer 2** (node-operator floor, local) — runs first; perTxMax + allowlist.
- **Layer 1** (per-account, on-chain) — `IPolicyRegistry.checkPolicy(sender, target,
  asset, amount, selector) → (decision, remainingDaily)`. `ALLOW`/`REQUIRE_DVT` pass,
  `REJECT` refuses, **checkPolicy revert fails closed**. Off unless `POLICY_REGISTRY_ADDRESS` set.

Native value → `(asset = ETH sentinel, amount = value)`; token/contract calls pass
`(asset = target)` + selector so the registry's per-contract `ContractScope` applies.

### Cross-repo alignment (#42)
- Read signature is **final** — airaccount-contract #110 confirmed; node-policy-source ==
  slash-source (fair slashing).
- Pending SP final: Q4 ETH sentinel value (default `0xEee…`, env `POLICY_ETH_SENTINEL`)
  and Q5 governance impl — **neither changes this read path** (Q4 is one constant, Q5 is
  the update path, not the read).
- Follow-up: ERC20 in-calldata amount extraction (v1 relies on ContractScope for token calls).

### Tests
28/28 (6 new layer-1 cases: registry-off, ALLOW/REQUIRE_DVT pass, REJECT refuse, revert
fail-closed, ETH-sentinel mapping, layer-2-floor-precedence). type-check + prettier clean.

Refs #40, #42.
