### PR TITLE
chore(release): v1.1.0 — DVT Fix 2 (Stage 1+2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,72 @@
+# Changelog
+
+All notable changes to YetAnotherAA-Validator (the DVT BLS signer node) are
+documented here. Format loosely follows
+[Keep a Changelog](https://keepachangelog.com/); versions follow SemVer.
+
+## [1.1.0] — 2026-06-15 — DVT Fix 2 (Stage 1 + Stage 2)
+
+The DVT node-side release of the cross-repo **DVT program** (coordination hub:
+`AAStarCommunity/YetAnotherAA-Validator#42`). Turns the signer into a true
+second factor that survives owner-key compromise.
+
+### Added
+
+- **Stage 1 — owner-authorization gate** on `POST /signature/sign` (#41). The
+  node co-signs only when the request carries a valid account-owner ECDSA
+  signature (`ownerAuth`, EIP-191) over the **authoritative `userOpHash` derived
+  on-chain** via `EntryPoint.getUserOpHash` — never a caller-supplied hash.
+  Closes the cross-account oracle hole; uniformly fail-closed with **403** on
+  any failure.
+- **Stage 2 — independent policy gate** (`PolicyService`, #43/#44), two layers
+  ANDed:
+  - **Layer 2 (node-operator floor, local):** per-tx native cap +
+    recipient/contract allowlist; owner and CA cannot change it.
+  - **Layer 1 (per-account, on-chain):** `IPolicyRegistry.checkPolicy` against
+    the SuperPaymaster-deployed registry; co-signs only on
+    `ALLOW`/`REQUIRE_DVT`, refuses on `REJECT` and any unknown decision
+    (fail-closed).
+  - Decodes `execute`/`executeBatch` and extracts ERC-20
+    `transfer`/`transferFrom`/ `approve` amounts so per-asset limits apply to
+    tokens, not just native ETH.
+  - Owner-auth runs **before** the policy gate (no pre-auth policy oracle /
+    registry RPC).
+  - Opt-in via `POLICY_ENABLED` (default off); fail-fast if enabled with no
+    rules.
+- **Normative signing-format spec** `docs/design/dvt-node-protocol.md` +
+  cross-repo **golden vector**
+  (`hash_to_curve(userOpHash, DST=BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_)`).
+- **Policy governance design** `docs/design/dvt-policy-governance.md`.
+- `BlockchainService.checkPolicy` / `getAccountOwner` / `getUserOpHash` read
+  paths.
+
+### Changed (behavior)
+
+- `POST /signature/sign` now **requires** `ownerAuth` and rejects unauthorized
+  or out-of-policy requests with **403**. Callers integrated before Stage 1 must
+  send the owner signature. (Aggregation/verify endpoints unchanged.)
+
+### Security
+
+- Verified end-to-end against the live Sepolia `PolicyRegistry`
+  (`0x37e4E40e69Fb7d5C3fbAA0F52A4002D27472Ff29`).
+- Passed a 4-round adversarial PK review (DeepSeek → Sonnet → Opus → Codex);
+  fixes include a fail-open registry decision, a gate-ordering oracle, and a
+  selector-collision allowlist bypass. 36/36 tests.
+
+### Config
+
+```
+POLICY_ENABLED=true
+POLICY_REGISTRY_ADDRESS=0x37e4E40e69Fb7d5C3fbAA0F52A4002D27472Ff29   # Sepolia
+POLICY_ETH_SENTINEL=0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE
+POLICY_PER_TX_MAX_WEI=...            # optional native cap
+POLICY_RECIPIENT_ALLOWLIST=0x..,0x.. # optional contract+recipient allowlist
+```
+
+### Known follow-ups (v1.1.x)
+
+- Independent (non-noble) RFC-9380 reference vector for the golden test.
+- V8 `executeUserOp` selector decoding (currently fail-closed when policy on).
+- Cross-repo on-chain E2E of a full combined signature (KMS/P256 main + DVT
+  aggregate).

--- a/README.md
+++ b/README.md
@@ -474,7 +474,9 @@ For the complete account abstraction stack, see the main
 
 ## License
 
-Licensed under the [Apache License, Version 2.0](https://opensource.org/licenses/Apache-2.0). See [LICENSE](./LICENSE) for details.
+Licensed under the
+[Apache License, Version 2.0](https://opensource.org/licenses/Apache-2.0). See
+[LICENSE](./LICENSE) for details.
 
 ## Contributing
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,37 @@
+# Releasing — template / runbook
+
+Reusable checklist for cutting a release of this repo. Also serves as the
+per-repo template for the cross-repo **DVT program** release (see `#42`).
+
+## Per-repo release steps
+
+1. **Green main**: on `master`, `npm ci` → `npm run type-check` → `npm test` →
+   `npm run build` all pass.
+2. **Decide version** (SemVer): patch = fixes; minor = backward-compatible
+   features; major = breaking API/behavior change. Note any behavior change in
+   the notes.
+3. **Branch** `chore/release-vX.Y.Z`; bump `package.json` version; update
+   `CHANGELOG.md` (Added / Changed / Security / Config / Follow-ups).
+4. **PR → review → merge** to `master` (do not tag an unmerged commit).
+5. **Tag + GitHub release** on the merged commit:
+   ```
+   git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z
+   gh release create vX.Y.Z --title "vX.Y.Z — <theme>" --notes-file <notes>
+   ```
+6. **Verify**: `gh release view vX.Y.Z`; tag points at merged `master`.
+7. Record in `#42` (the coordination hub) if part of the DVT program.
+
+## DVT program (cross-repo) release gate — ALL must hold before tagging `DVT v1`
+
+- [ ] Each repo cut its own release per the steps above.
+- [ ] Three-way signing format matches the same golden vectors byte-for-byte
+      (node `#42` / SDK `#63` / contract `#110` / SP reference `#283`, DST
+      `_POP_`).
+- [ ] `PolicyRegistry` is the single source for node layer-1 read, `#110`
+      validation, and slash reference (sender-keyed, deployed address pinned).
+- [ ] All program PRs merged (per repo).
+- [ ] **One on-chain E2E**: a real combined signature (KMS/P256 main +
+      ≥threshold DVT BLS aggregate) verified through
+      `AAStarBLSAlgorithm.validate` on Sepolia, evidence in `#42`.
+- [ ] Coordinator marks **DVT v1 RELEASED** in `#42` with the per-repo version
+      table.

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -14,7 +14,8 @@ However, the **names, logos, and branding** of MushroomDAO and its products are
 **not** covered by the Apache 2.0 license. This trademark policy explains what
 you can and cannot do with MushroomDAO's marks.
 
-This policy is modeled after the [Mozilla Foundation Trademark Policy](https://www.mozilla.org/en-US/foundation/trademarks/policy/),
+This policy is modeled after the
+[Mozilla Foundation Trademark Policy](https://www.mozilla.org/en-US/foundation/trademarks/policy/),
 which established the precedent that open source code can be freely forked while
 requiring forks to use different branding (e.g., Firefox → Iceweasel in Debian).
 
@@ -25,6 +26,7 @@ requiring forks to use different branding (e.g., Firefox → Iceweasel in Debian
 The following names are trademarks of MushroomDAO and its affiliated entities:
 
 ### Project & Protocol Names
+
 - **MushroomDAO**
 - **Mycelium Protocol** / **Mycelium**
 - **Park Protocol**
@@ -33,11 +35,13 @@ The following names are trademarks of MushroomDAO and its affiliated entities:
 - **Sin90**
 
 ### Token & Points Names
+
 - **GToken**
 - **PNTs** / **xPNTs** / **aPNTs**
 - **Spores**
 
 ### Product & Service Names
+
 - **AAStar**
 - **AirAccount**
 - **SuperPaymaster**
@@ -45,6 +49,7 @@ The following names are trademarks of MushroomDAO and its affiliated entities:
 - **AuraAI**
 
 ### Company & Organization Names
+
 - **HyperCapital**
 
 ---
@@ -59,7 +64,8 @@ The following logos are protected (actual files to be added):
 - Mycelium Protocol logo
 - GToken symbol
 
-*(Logo files will be deposited in this directory when brand design is finalized, estimated Q3 2026.)*
+_(Logo files will be deposited in this directory when brand design is finalized,
+estimated Q3 2026.)_
 
 ---
 
@@ -71,11 +77,11 @@ The following logos are protected (actual files to be added):
    restrict code usage.
 
 2. **Refer to compatibility.** You may truthfully state that your project is
-   "compatible with Mycelium Protocol" or "built on MushroomDAO technology"
-   in descriptive text, documentation, and marketing materials.
+   "compatible with Mycelium Protocol" or "built on MushroomDAO technology" in
+   descriptive text, documentation, and marketing materials.
 
-3. **Link to MushroomDAO.** You may link to MushroomDAO's repositories,
-   website, and documentation.
+3. **Link to MushroomDAO.** You may link to MushroomDAO's repositories, website,
+   and documentation.
 
 4. **Discuss MushroomDAO.** You may use the names in articles, blog posts,
    talks, and other commentary about the project.
@@ -84,32 +90,32 @@ The following logos are protected (actual files to be added):
 
 Forks and derivative works **MAY** use the phrases **"Compatible with Mycelium
 Protocol"** or **"Powered by Mycelium"** in descriptive text (e.g., README,
-documentation, marketing copy), **ONLY IF** they actually interoperate with
-the Mycelium Protocol network. These are permitted **nominative uses** — they
+documentation, marketing copy), **ONLY IF** they actually interoperate with the
+Mycelium Protocol network. These are permitted **nominative uses** — they
 describe a factual relationship, not brand affiliation.
 
 This is separate from the fork rebranding requirement below: you must remove
 MushroomDAO trademarks from your **product name and UI**, but you may use
 descriptive compatibility statements in **documentation and marketing text**.
 
-All forks and derivatives **MUST** retain the NOTICE file per Apache 2.0
-Section 4(d).
+All forks and derivatives **MUST** retain the NOTICE file per Apache 2.0 Section
+4(d).
 
 ### You MAY NOT:
 
-1. **Use protected names in your product name.** You may NOT name your
-   product "Mycelium Wallet", "MushroomDAO Enterprise", "GToken Exchange",
-   or any similar formulation that implies official affiliation.
+1. **Use protected names in your product name.** You may NOT name your product
+   "Mycelium Wallet", "MushroomDAO Enterprise", "GToken Exchange", or any
+   similar formulation that implies official affiliation.
 
 2. **Use protected logos** without written permission from MushroomDAO.
 
-3. **Imply endorsement or affiliation.** You may NOT suggest that your
-   project is endorsed by, affiliated with, or an official part of
-   MushroomDAO without explicit written authorization.
+3. **Imply endorsement or affiliation.** You may NOT suggest that your project
+   is endorsed by, affiliated with, or an official part of MushroomDAO without
+   explicit written authorization.
 
-4. **Register confusingly similar names.** You may NOT register domain
-   names, social media accounts, or trademarks that are confusingly
-   similar to the protected names listed above.
+4. **Register confusingly similar names.** You may NOT register domain names,
+   social media accounts, or trademarks that are confusingly similar to the
+   protected names listed above.
 
 5. **Delete the NOTICE file.** You may NOT remove the NOTICE file from
    redistributions or derivative works. This is required by the Apache 2.0
@@ -123,7 +129,8 @@ If you fork a MushroomDAO repository:
   - Product names in the UI, documentation, and configuration
   - Logos, icons, and branding assets
   - References that imply the fork is an official MushroomDAO product
-- You **may** state: "This project is a fork of [original repo name] by MushroomDAO"
+- You **may** state: "This project is a fork of [original repo name] by
+  MushroomDAO"
 - You **must** choose a new name for your fork that does not include any
   protected names
 
@@ -139,7 +146,8 @@ If you would like to use a MushroomDAO trademark in a way not covered by the
 rules above, please contact us:
 
 - **Email:** jason@aastar.io
-- **GitHub:** Open an issue in [MushroomDAO/.github](https://github.com/MushroomDAO/.github/issues)
+- **GitHub:** Open an issue in
+  [MushroomDAO/.github](https://github.com/MushroomDAO/.github/issues)
 
 We are generally supportive of community use and will respond within 14 days.
 
@@ -160,12 +168,14 @@ taking formal action.
 
 ## Open Source Commitment
 
-MushroomDAO is committed to the [Open Source Definition](https://opensource.org/osd)
-as maintained by the [Open Source Initiative](https://opensource.org).
+MushroomDAO is committed to the
+[Open Source Definition](https://opensource.org/osd) as maintained by the
+[Open Source Initiative](https://opensource.org).
 
-We have chosen genuine open source ([Apache 2.0](https://opensource.org/licenses/Apache-2.0),
-OSI-approved) as an act of building digital public goods. We ask that you respect
-the attribution that makes this possible.
+We have chosen genuine open source
+([Apache 2.0](https://opensource.org/licenses/Apache-2.0), OSI-approved) as an
+act of building digital public goods. We ask that you respect the attribution
+that makes this possible.
 
 ---
 

--- a/docs/design/dvt-policy-governance.md
+++ b/docs/design/dvt-policy-governance.md
@@ -155,13 +155,15 @@ PolicyRegistry 的 schema 应**对齐/复用 grant-session 的 scoping 字段模
 
 SuperPaymaster 已将 IPolicyRegistry 部署上链（v5.4，PR SuperPaymaster#285）。
 
-| 网络 | PolicyRegistry 地址 |
-| --- | --- |
+| 网络    | PolicyRegistry 地址                          |
+| ------- | -------------------------------------------- |
 | Sepolia | `0x37e4E40e69Fb7d5C3fbAA0F52A4002D27472Ff29` |
 
-**启用 layer-1**：把上面地址填到节点 env `POLICY_REGISTRY_ADDRESS`（+ `POLICY_ENABLED=true`）即可，无需改码。
-`POLICY_ETH_SENTINEL` 默认 `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`（与合约一致）。
+**启用 layer-1**：把上面地址填到节点 env `POLICY_REGISTRY_ADDRESS`（+
+`POLICY_ENABLED=true`）即可，无需改码。 `POLICY_ETH_SENTINEL` 默认
+`0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`（与合约一致）。
 
-**端到端实测（已验证）**：对 Sepolia 上述地址调 `checkPolicy(sender,target,ETH哨兵,1000,0x00000000)`
-→ 返回 `decision=0 (ALLOW)`、`remainingDaily=2^256-1`，即未开通账户的 opt-in default-ALLOW，
-ABI/接线与部署合约逐字段一致。
+**端到端实测（已验证）**：对 Sepolia 上述地址调
+`checkPolicy(sender,target,ETH哨兵,1000,0x00000000)` → 返回
+`decision=0 (ALLOW)`、`remainingDaily=2^256-1`，即未开通账户的 opt-in
+default-ALLOW，ABI/接线与部署合约逐字段一致。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yetanotheraa-validator",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Production-ready BLS signature validation infrastructure for ERC-4337 account abstraction",
   "main": "dist/main.js",
   "type": "module",


### PR DESCRIPTION
Version bump 1.0.0 → 1.1.0, CHANGELOG.md (DVT node release notes), RELEASING.md (release template + cross-repo DVT v1 gate). Code already reviewed/merged via #41/#43/#44.