### PR TITLE
feat(#42): real-node DVT E2E scripts + one-click node service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,25 @@
-# YetAnotherAA-Validator
+# aNode DVT 说明 (YetAnotherAA-Validator)
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-A complete BLS signature infrastructure for ERC-4337 account abstraction,
-combining off-chain signature aggregation services with on-chain verification
-smart contracts.
+
+**aNode** = Mycelium DVT 共签节点；本仓库是 aNode 的参考实现（已发布
+**v1.1.0**）—— 一套 ERC-4337
+BLS 签名基础设施：链下签名聚合服务 + 链上验证合约，作为账户的「独立第二因子」防 owner-key 被盗。
+
+### 📘 aNode DVT 运维 & 快速上手
+
+- **运维手册（启动/监控/停止/恢复/报错/修复 + 生产 aNode 启动步骤）** →
+  [`docs/aNode-dvt-operations.md`](docs/aNode-dvt-operations.md)
+- **本地多节点服务（一键）** →
+  `./scripts/e2e/dvt-nodes.sh start|status|info|logs|stop`（见
+  [`scripts/e2e/README.md`](scripts/e2e/README.md)）
+- **DVT 生产化设计** →
+  [`docs/design/dvt-e2e-and-production.md`](docs/design/dvt-e2e-and-production.md)
+- **签名格式规范 / 策略治理** →
+  [`docs/design/dvt-node-protocol.md`](docs/design/dvt-node-protocol.md) ·
+  [`docs/design/dvt-policy-governance.md`](docs/design/dvt-policy-governance.md)
+- **跨仓库协调 hub** →
+  [issue #42](https://github.com/AAStarCommunity/YetAnotherAA-Validator/issues/42)
 
 > **Note**: This package was extracted from the
 > [YetAnotherAA](https://github.com/fanhousanbu/YetAnotherAA) monorepo to serve

--- a/docs/aNode-dvt-operations.md
+++ b/docs/aNode-dvt-operations.md
@@ -1,0 +1,94 @@
+# aNode (DVT) — 运维手册 / Operations Runbook
+
+> **aNode** = Mycelium DVT 共签节点（本仓库 =
+> aNode 的参考实现，已发布 v1.1.0）。本手册给「技术提供方运行一个 aNode」的全套步骤：启动 → 监控 → 停止 → 恢复 → 报错排查 → 修复。关联：`scripts/e2e/`（本地多节点服务）·
+> `docs/design/dvt-e2e-and-production.md`（生产化设计）· #42。
+
+---
+
+## A. 未来真实 DVT 该如何启动（生产，单个 aNode）
+
+一个独立运营方跑一个生产 aNode 的步骤：
+
+1. **准备密钥**：生成节点 BLS12-381 私钥（独立于 owner/CA）。
+   - 开发：写入 `node_state.json`（`scripts/e2e/gen-nodes.mjs` 可生成）。
+   - 生产：私钥进 KMS/HSM（不落明文盘）；当前 AirAccount
+     KMS 仅 secp256k1，BLS 需 BLS-capable HSM。
+2. **配置 env**（必填）：
+   ```
+   ETH_RPC_URL=<sepolia/mainnet RPC>
+   VALIDATOR_CONTRACT_ADDRESS=<AAStarBLSAlgorithm / validator>
+   ENTRY_POINT_ADDRESS=0x0000000071727De22E5E9d8BAf0edAc6f37da032   # v0.7 canonical
+   PORT=3001
+   POLICY_ENABLED=true                 # 生产开策略门（见下）
+   POLICY_REGISTRY_ADDRESS=0x37e4E40e69Fb7d5C3fbAA0F52A4002D27472Ff29  # SP PolicyRegistry (Sepolia)
+   ETH_PRIVATE_KEY=<只在需链上注册/写时配；只签名可不配>
+   ```
+3. **构建 + 启动**：`npm ci && npm run build && npm run start:prod`。
+4. **链上注册公钥**：用 SP `registerBLSPublicKey`（或本仓库
+   `POST /node/register`）把节点 BLS 公钥注册到已知 slot
+   —— 链上验签与 slash 都按注册 slot 寻址。
+5. **接入门限**：≥N-of-M 个独立运营方各跑一个 aNode（不同 key/法域/软件栈），客户端（aastar-sdk）按门限收集共签。
+6. **暴露通道**：节点 `POST /signature/sign`
+   直连客户端（独立通道，不经 CA）；跨机器经 TLS/tunnel。
+
+> 独立性三支柱（命门）：独立 BLS
+> key + 独立策略（本地 layer-2 + 链上 layer-1）+ 独立通道。盲签=橡皮图章。
+
+---
+
+## B. 本仓库的多节点服务（开发/演示，一键）
+
+```bash
+./scripts/e2e/dvt-nodes.sh start     # 1. 启动：build + 生成密钥 + 起 3 个 aNode (nohup 持久)
+./scripts/e2e/dvt-nodes.sh status    # 2. 监控：哪些节点 UP
+./scripts/e2e/dvt-nodes.sh info      #    出可分享信息：URL / nodeId / BLS 公钥（给 aastar-sdk #63）
+./scripts/e2e/dvt-nodes.sh logs 1    # 3. 看日志：tail node 1
+./scripts/e2e/dvt-nodes.sh stop      # 4. 停止：停全部 3 个
+node scripts/e2e/selftest.mjs        #    自测：3 节点签名 + Stage-1 闸门(坏 ownerAuth→403)
+node scripts/e2e/realnode-e2e.mjs    #    E2E：真节点共签 → 链上 AAStarBLSAlgorithm.validate = 0
+```
+
+运行态（密钥/日志/pid）在 `.e2e/`（git 忽略）。
+
+---
+
+## C. 运维操作（start / monitor / stop / recover / error / fix）
+
+| 操作             | 命令 / 做法                                                                                      |
+| ---------------- | ------------------------------------------------------------------------------------------------ |
+| **启动 start**   | `dvt-nodes.sh start`（生产：`npm run start:prod` + 进程守护 pm2/systemd）                        |
+| **监控 monitor** | `dvt-nodes.sh status`；`curl :PORT/node/info`、`/gossip/stats`；日志告警接监控系统               |
+| **停止 stop**    | `dvt-nodes.sh stop`（按 pid + 端口双杀）                                                         |
+| **恢复 recover** | 节点无状态（除 `node_state.json`）→ 重启即恢复；密钥丢失从 KMS/备份恢复 `node_state.json` 再重启 |
+| **报错 error**   | 见 §D 故障表（启动失败 / RPC 掉线 / 签名 403 / 链上验失败）                                      |
+| **修复 fix**     | 见 §D 对应修复列                                                                                 |
+
+---
+
+## D. 常见故障 → 排查 → 修复
+
+| 现象                                  | 原因                                                                                    | 修复                                                                                            |
+| ------------------------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| 启动即退出，报 env 校验失败           | 缺 `ETH_RPC_URL` / `VALIDATOR_CONTRACT_ADDRESS`                                         | 补齐 env（§A.2）后重启                                                                          |
+| `/signature/sign` 返回 403            | Stage-1：`ownerAuth` 不是账户 `owner()` 的签名 / userOp 畸形 / owner==0x0(passkey-only) | 用账户 ECDSA owner 重签 ownerAuth；passkey-only 账户暂不支持（#40 Stage2）                      |
+| `/signature/sign` 返回 403 且开了策略 | Stage-2：op 超限额/不在白名单                                                           | 调整 op 或在 PolicyRegistry/本地策略放行                                                        |
+| 节点起来但签名报 RPC 错               | `ETH_RPC_URL` 带引号 / 掉线                                                             | 去引号；配多 RPC 备份（公共 Sepolia RPC 易掉线）                                                |
+| 链上聚合验证失败                      | 节点 BLS 公钥未注册 / DST 非 `_POP_` / 编码错                                           | 注册公钥；确认 DST=`BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_`（noble 默认 `_NUL_` 必须覆盖） |
+| 端口占用                              | 上次实例未停                                                                            | `dvt-nodes.sh stop` 或 `lsof -ti tcp:PORT \| xargs kill`                                        |
+
+---
+
+## E. 节点对外契约（消费方 aastar-sdk #63）
+
+```
+POST {url}/signature/sign
+  body: { userOp:<PackedUserOperation v0.7>, ownerAuth:<owner EIP-191 sig over userOpHash> }
+  → { nodeId, signature(EIP-2537 G2 256B), signatureCompact, publicKey, message:userOpHash }
+GET  {url}/node/info       # 节点身份
+POST {url}/signature/aggregate   # 聚合多签
+GET  {url}/api             # Swagger
+```
+
+节点自派生 `userOpHash`（EntryPoint.getUserOpHash），强制 Stage-1
+owner-auth，BLS 签 `hashToCurve(userOpHash)`。

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -1,0 +1,44 @@
+# DVT real-node E2E + node service
+
+Boots **3 real v1.1.0 DVT signer node instances** and drives a real combined-signature
+flow that verifies **on-chain** against the deployed `AAStarBLSAlgorithm` — the same
+verifier airaccount-contract uses. Also serves as the shareable DVT signer service for
+upstream/downstream (aastar-sdk #63 etc.). See `#42` and `docs/design/dvt-e2e-and-production.md`.
+
+## Prereqs
+- `.env.sepolia` at repo root with: `SEPOLIA_RPC_URL[,2,3]`, `ENTRY_POINT_ADDRESS`,
+  `AIRACCOUNT_V018_BLS_ALGORITHM`, `BLS_TEST_NODE_ID_1/2`, `BLS_TEST_PRIVATE_KEY_1/2`,
+  `PRIVATE_KEY_SUPPLIER` (= the test account's ECDSA `owner()`).
+- `npm run build` (the manager runs it automatically if `dist/` is missing).
+
+## One-click node service
+```bash
+./scripts/e2e/dvt-nodes.sh start    # build + gen keys (if needed) + boot 3 nodes (nohup, persistent)
+./scripts/e2e/dvt-nodes.sh status   # which nodes are up
+./scripts/e2e/dvt-nodes.sh info     # shareable: URL / nodeId / BLS publicKey (for #63 / SP registration)
+./scripts/e2e/dvt-nodes.sh logs 1   # tail node 1 log
+./scripts/e2e/dvt-nodes.sh stop     # stop all 3
+```
+Runtime state (keys, logs, pids) lives under `.e2e/` (git-ignored).
+
+## Node endpoint contract (for #63 / consumers)
+```
+POST {url}/signature/sign
+  body: { userOp: <PackedUserOperation v0.7>, ownerAuth: <owner EIP-191 sig over userOpHash> }
+  → { nodeId, signature (EIP-2537 G2, 256B), signatureCompact, publicKey, message: userOpHash }
+```
+The node derives `userOpHash` itself via `EntryPoint.getUserOpHash`, enforces the Stage-1
+owner-auth gate (`ownerAuth` must be the account `owner()`'s signature), then BLS-signs
+`hashToCurve(userOpHash)` (DST `_POP_`). Aggregate the per-node `signature` (G2 point add).
+
+## Run the E2E
+```bash
+node scripts/e2e/realnode-e2e.mjs
+# [1] 3-node aggregate off-chain verify: ✅ VALID
+# [2] on-chain AAStarBLSAlgorithm.validate: 0 ✅ VALID
+```
+node1/node2 BLS keys are already registered on-chain (BLS_TEST_1/2); node3 is fresh
+(register its publicKey via SP `registerBLSPublicKey` before using it on-chain).
+
+> Cross-machine: URLs are `localhost`. For a consumer on another host, expose via a tunnel
+> (ngrok/cloudflared) or run the service on a shared host; the endpoint contract is unchanged.

--- a/scripts/e2e/dvt-nodes.sh
+++ b/scripts/e2e/dvt-nodes.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# DVT node service — one-click start / stop / logs / status / info for 3 DVT signer nodes.
+# Provides /signature/sign URLs + node IDs + BLS public keys for upstream/downstream (aastar-sdk #63 etc.).
+#
+#   ./scripts/e2e/dvt-nodes.sh start     # build (if needed), gen keys (if needed), boot 3 nodes
+#   ./scripts/e2e/dvt-nodes.sh status    # which nodes are up
+#   ./scripts/e2e/dvt-nodes.sh info      # shareable table: URL / nodeId / publicKey
+#   ./scripts/e2e/dvt-nodes.sh logs [N]  # tail node N log (default 1)
+#   ./scripts/e2e/dvt-nodes.sh stop      # stop all 3
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+E2E="$REPO/.e2e"; DIST="$REPO/dist/main.js"; PORTS=(3001 3002 3003)
+cd "$REPO"
+
+ensure() {
+  [ -f "$DIST" ] || { echo "build dist..."; npm run build >/dev/null; }
+  [ -f "$E2E/node1/node_state.json" ] || { echo "gen node keys..."; node scripts/e2e/gen-nodes.mjs; }
+  if [ ! -f "$E2E/common.env" ]; then
+    node -e 'const fs=require("fs");const s=x=>x.replace(/^["\x27]|["\x27]$/g,"");const e=Object.fromEntries(fs.readFileSync(".env.sepolia","utf8").split("\n").filter(l=>l.includes("=")).map(l=>{const i=l.indexOf("=");return [l.slice(0,i).trim(),s(l.slice(i+1).trim())]}));fs.writeFileSync(".e2e/common.env",["ETH_RPC_URL="+(e.SEPOLIA_RPC_URL||e.RPC_URL),"VALIDATOR_CONTRACT_ADDRESS="+e.AIRACCOUNT_V018_BLS_ALGORITHM,"ENTRY_POINT_ADDRESS="+(e.ENTRY_POINT_ADDRESS||e.ENTRYPOINT_ADDRESS),"POLICY_ENABLED=false",""].join("\n"))'
+  fi
+}
+start() {
+  ensure
+  for i in 1 2 3; do
+    local port="${PORTS[$((i-1))]}"
+    if lsof -ti "tcp:$port" >/dev/null 2>&1; then echo "node$i already up on :$port"; continue; fi
+    ( cd "$E2E/node$i"; set -a; . "$E2E/common.env"; set +a; export PORT="$port"
+      nohup node "$DIST" > "$E2E/node$i.log" 2>&1 & echo $! > "$E2E/node$i.pid" )
+    echo "node$i starting on :$port (pid $(cat "$E2E/node$i.pid"))"
+  done
+  echo "waiting for health..."; sleep 10; status
+}
+stop() {
+  for i in 1 2 3; do
+    [ -f "$E2E/node$i.pid" ] && kill -9 "$(cat "$E2E/node$i.pid")" 2>/dev/null || true
+    lsof -ti "tcp:${PORTS[$((i-1))]}" 2>/dev/null | xargs kill -9 2>/dev/null || true
+    rm -f "$E2E/node$i.pid"
+  done
+  echo "all DVT nodes stopped"
+}
+status() {
+  for i in 1 2 3; do
+    local port="${PORTS[$((i-1))]}"
+    if curl -s -m 4 "http://localhost:$port/node/info" >/dev/null 2>&1; then echo "  node$i :$port  ✅ UP"; else echo "  node$i :$port  ❌ down"; fi
+  done
+}
+info() {
+  echo "# DVT DVT signer nodes — for aastar-sdk #63 / upstream-downstream"
+  echo "# endpoint: POST {url}/signature/sign  body {userOp, ownerAuth}  → {nodeId, signature(EIP-2537), publicKey}"
+  for i in 1 2 3; do
+    local port="${PORTS[$((i-1))]}"
+    node -e 'const s=require("./.e2e/node'"$i"'/node_state.json");console.log(`node'"$i"' | url=http://localhost:'"$port"' | nodeId=${s.nodeId} | pubKey=0x${s.publicKey}`)'
+  done
+  echo "# node1/node2 BLS pubkeys are registered on AAStarBLSAlgorithm (BLS_TEST_1/2); node3 is fresh (register before on-chain use)."
+}
+case "${1:-}" in
+  start) start ;; stop) stop ;; status) status ;; info) info ;;
+  logs) tail -n 40 -f "$E2E/node${2:-1}.log" ;;
+  *) echo "usage: $0 {start|stop|status|info|logs [N]}"; exit 1 ;;
+esac

--- a/scripts/e2e/gen-nodes.mjs
+++ b/scripts/e2e/gen-nodes.mjs
@@ -1,0 +1,32 @@
+// Generate 3 DVT node identities (BLS12-381) into ./.e2e/node{1,2,3}/node_state.json
+// node1/node2 reuse the on-chain-registered BLS_TEST keys from .env.sepolia; node3 is fresh.
+// Usage: node scripts/e2e/gen-nodes.mjs
+import { bls12_381 as bls } from "@noble/curves/bls12-381.js";
+import { readFileSync, writeFileSync, mkdirSync } from "fs";
+import { randomBytes } from "crypto";
+const sigs = bls.longSignatures;
+const strip = s => s.replace(/^["']|["']$/g, "");
+const env = Object.fromEntries(
+  readFileSync(".env.sepolia", "utf8").split("\n").filter(l => l.includes("="))
+    .map(l => { const i = l.indexOf("="); return [l.slice(0, i).trim(), strip(l.slice(i + 1).trim())]; })
+);
+const skFresh = () => { let s; while (true) { s = randomBytes(32); try { sigs.getPublicKey(s); break; } catch {} } return s; };
+const state = (id, sk, name) => ({
+  nodeId: id, nodeName: name,
+  privateKey: "0x" + Buffer.from(sk).toString("hex"),
+  publicKey: sigs.getPublicKey(sk).toHex(),
+  createdAt: "2026-06-16T00:00:00.000Z", description: "DVT real-node E2E",
+});
+const sk1 = Buffer.from(env.BLS_TEST_PRIVATE_KEY_1.replace(/^0x/, ""), "hex");
+const sk2 = Buffer.from(env.BLS_TEST_PRIVATE_KEY_2.replace(/^0x/, ""), "hex");
+const nodes = [
+  state(env.BLS_TEST_NODE_ID_1, sk1, "dvt-node-1"),
+  state(env.BLS_TEST_NODE_ID_2, sk2, "dvt-node-2"),
+  state("0x" + randomBytes(32).toString("hex"), skFresh(), "dvt-node-3"),
+];
+nodes.forEach((n, i) => {
+  mkdirSync(`.e2e/node${i + 1}`, { recursive: true });
+  writeFileSync(`.e2e/node${i + 1}/node_state.json`, JSON.stringify(n, null, 2));
+  console.log(`node${i + 1}: ${n.nodeId.slice(0, 18)}... (${n.nodeName})`);
+});
+console.log("→ .e2e/node{1,2,3}/node_state.json written");

--- a/scripts/e2e/handleops-tx.mjs
+++ b/scripts/e2e/handleops-tx.mjs
@@ -1,0 +1,190 @@
+// Full DVT combined-signature handleOps tx (Tier2 = P256 main + real-node BLS aggregate).
+// Reconfigures the test account's P256 to a freshly generated key (owner=SUPPLIER), funds it,
+// then submits a real EntryPoint.handleOps tx whose BLS factor comes from the 3 RUNNING nodes.
+// Usage: node scripts/e2e/handleops-tx.mjs   (consumes a little Sepolia test ETH for gas/transfer)
+import { ethers } from "ethers";
+import { bls12_381 as bls } from "@noble/curves/bls12-381.js";
+import { p256 } from "@noble/curves/nist.js";
+import { readFileSync } from "fs";
+const sigs = bls.longSignatures;
+const DST = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
+const strip = s => s.replace(/^["']|["']$/g, "");
+const env = Object.fromEntries(
+  readFileSync(".env.sepolia", "utf8")
+    .split("\n")
+    .filter(l => l.includes("="))
+    .map(l => {
+      const i = l.indexOf("=");
+      return [l.slice(0, i).trim(), strip(l.slice(i + 1).trim())];
+    })
+);
+const RPCS = [env.SEPOLIA_RPC_URL, env.SEPOLIA_RPC_URL2, env.SEPOLIA_RPC_URL3].filter(Boolean);
+const ENTRY = env.ENTRY_POINT_ADDRESS || env.ENTRYPOINT_ADDRESS;
+const ACCOUNT = "0x45Dfe3D5938fDf5a8D30641C3FDA9c9fb1F31ba9";
+// Pick a healthy RPC (public Sepolia endpoints are flaky under heavy eth_call/pairing).
+async function pickRpc() {
+  for (const u of RPCS) {
+    try {
+      const p = new ethers.JsonRpcProvider(u);
+      await p.getBlockNumber();
+      console.log("using RPC:", u.slice(0, 30) + "...");
+      return p;
+    } catch {
+      console.log("rpc down:", u.slice(0, 30));
+    }
+  }
+  throw new Error("no healthy RPC");
+}
+const provider = await pickRpc();
+const owner = new ethers.Wallet(env.PRIVATE_KEY_SUPPLIER, provider);
+const RECIPIENT = owner.address; // transfer back to owner to recover funds
+
+const ACCOUNT_ABI = [
+  "function execute(address dest, uint256 value, bytes func)",
+  "function setP256Key(bytes32 _x, bytes32 _y)",
+  "function setTierLimits(uint256 _tier1, uint256 _tier2)",
+  "function p256KeyX() view returns (bytes32)",
+  "function tier1Limit() view returns (uint256)",
+  "function tier2Limit() view returns (uint256)",
+];
+const EP_ABI = [
+  "function getUserOpHash((address sender,uint256 nonce,bytes initCode,bytes callData,bytes32 accountGasLimits,uint256 preVerificationGas,bytes32 gasFees,bytes paymasterAndData,bytes signature) userOp) view returns (bytes32)",
+  "function getNonce(address sender, uint192 key) view returns (uint256)",
+  "function depositTo(address account) payable",
+  "function balanceOf(address account) view returns (uint256)",
+  "function handleOps((address sender,uint256 nonce,bytes initCode,bytes callData,bytes32 accountGasLimits,uint256 preVerificationGas,bytes32 gasFees,bytes paymasterAndData,bytes signature)[] ops, address beneficiary)",
+];
+const acct = new ethers.Contract(ACCOUNT, ACCOUNT_ABI, owner);
+const ep = new ethers.Contract(ENTRY, EP_ABI, owner);
+const b48 = n => ethers.getBytes("0x" + n.toString(16).padStart(96, "0"));
+const encG2 = pt => {
+  const a = pt.toAffine();
+  const r = new Uint8Array(256);
+  r.set(b48(a.x.c0), 16);
+  r.set(b48(a.x.c1), 80);
+  r.set(b48(a.y.c0), 144);
+  r.set(b48(a.y.c1), 208);
+  return ethers.hexlify(r);
+};
+const pack = (hi, lo) => ethers.concat([ethers.toBeHex(hi, 16), ethers.toBeHex(lo, 16)]);
+
+// 0. generate P256 keypair (mine)
+const p256Priv = ethers.randomBytes(32);
+const p256Pub = p256.getPublicKey(p256Priv, false); // 65 bytes 0x04|x|y
+const p256X = ethers.hexlify(p256Pub.slice(1, 33)),
+  p256Y = ethers.hexlify(p256Pub.slice(33, 65));
+console.log("generated P256 x:", p256X.slice(0, 18) + "...");
+
+// 1. setP256Key + ensure tier limits
+console.log("[setP256Key]...");
+await (await acct.setP256Key(p256X, p256Y)).wait();
+const [t1, t2] = [await acct.tier1Limit(), await acct.tier2Limit()];
+if (t1 === 0n || t2 === 0n) {
+  console.log("[setTierLimits]...");
+  await (await acct.setTierLimits(ethers.parseEther("0.01"), ethers.parseEther("0.1"))).wait();
+}
+console.log(
+  "  tier1:",
+  ethers.formatEther(await acct.tier1Limit()),
+  "tier2:",
+  ethers.formatEther(await acct.tier2Limit())
+);
+
+// 2. fund account + EntryPoint deposit (for the transfer + gas)
+const AMOUNT = ethers.parseEther("0.03"); // Tier2: > tier1, <= tier2 (read live below)
+const acctBal = await provider.getBalance(ACCOUNT);
+if (acctBal < AMOUNT) {
+  console.log("[fund account]...");
+  await (await owner.sendTransaction({ to: ACCOUNT, value: AMOUNT })).wait();
+}
+const dep = await ep.balanceOf(ACCOUNT);
+if (dep < ethers.parseEther("0.01")) {
+  console.log("[EntryPoint deposit]...");
+  await (await ep.depositTo(ACCOUNT, { value: ethers.parseEther("0.01") })).wait();
+}
+
+// 3. build Tier2 userOp
+const iface = new ethers.Interface(ACCOUNT_ABI);
+const callData = iface.encodeFunctionData("execute", [RECIPIENT, AMOUNT, "0x"]);
+const nonce = await ep.getNonce(ACCOUNT, 0n);
+const fee = await provider.getFeeData();
+const userOp = {
+  sender: ACCOUNT,
+  nonce,
+  initCode: "0x",
+  callData,
+  accountGasLimits: pack(800000n, 200000n),
+  preVerificationGas: 80000n,
+  gasFees: pack(fee.maxPriorityFeePerGas ?? 2000000000n, fee.maxFeePerGas ?? 20000000000n),
+  paymasterAndData: "0x",
+  signature: "0x",
+};
+const userOpHash = await ep.getUserOpHash(userOp);
+console.log("userOpHash:", userOpHash);
+
+// 4. P256 main sig (raw hash, lowS) — noble v2 returns 64-byte compact r||s
+const p256Sig = ethers.hexlify(p256.sign(ethers.getBytes(userOpHash), p256Priv, { lowS: true }));
+
+// 5. real-node BLS aggregate (node1+node2, registered) via running instances
+const ownerAuth = await owner.signMessage(ethers.getBytes(userOpHash));
+// JSON-safe userOp for the node (BigInt nonce/preVerificationGas -> string).
+const userOpJson = {
+  ...userOp,
+  nonce: userOp.nonce.toString(),
+  preVerificationGas: userOp.preVerificationGas.toString(),
+};
+const got = [];
+for (const port of [3001, 3002]) {
+  const r = await fetch(`http://localhost:${port}/signature/sign`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ userOp: userOpJson, ownerAuth }),
+  });
+  if (!r.ok) throw new Error(`node :${port} ${r.status} ${await r.text()}`);
+  got.push(await r.json());
+}
+const aggSig = encG2(
+  sigs.aggregateSignatures(
+    got.map(g => sigs.Signature.fromHex(g.signatureCompact.replace(/^0x/, "")))
+  )
+);
+
+// 6. assemble Tier2 combined signature: [0x04][p256 r/s(64)][nodeIdsLength(32)=2][nodeId1][nodeId2][blsSig(256)]
+userOp.signature = ethers.concat([
+  "0x04",
+  p256Sig,
+  ethers.toBeHex(2n, 32),
+  env.BLS_TEST_NODE_ID_1,
+  env.BLS_TEST_NODE_ID_2,
+  aggSig,
+]);
+console.log(
+  "combined sig len:",
+  ethers.dataLength(userOp.signature),
+  "bytes (expect 1+64+32+64+256=417)"
+);
+
+// 7. simulate first (decode FailedOp reason), only send if it passes
+try {
+  await ep.handleOps.staticCall([userOp], owner.address);
+  console.log("[simulation] ✅ passes — sending real tx");
+} catch (e) {
+  console.log("[simulation] ❌ revert:", e.shortMessage || e.message);
+  if (e.data) {
+    try {
+      console.log("  FailedOp:", ep.interface.parseError(e.data)?.args);
+    } catch {
+      console.log("  raw data:", e.data?.slice(0, 80));
+    }
+  }
+  if (e.revert) console.log("  reason:", e.revert.args);
+  process.exit(1);
+}
+console.log("[handleOps] submitting...");
+const tx = await ep.handleOps([userOp], owner.address, { gasLimit: 2000000n });
+console.log("tx:", tx.hash);
+const rc = await tx.wait();
+console.log(
+  `\n=== handleOps ${rc.status === 1 ? "✅ MINED" : "❌ failed"} block ${rc.blockNumber} gas ${rc.gasUsed} ===`
+);
+console.log("https://sepolia.etherscan.io/tx/" + tx.hash);

--- a/scripts/e2e/realnode-e2e.mjs
+++ b/scripts/e2e/realnode-e2e.mjs
@@ -1,0 +1,55 @@
+// Real-node DVT E2E: drive 3 running v1.1.0 node instances through a real co-sign,
+// aggregate, verify off-chain, and verify on-chain via the deployed AAStarBLSAlgorithm.
+//
+// Prereq: gen-nodes.mjs run, then 3 instances started (see scripts/e2e/README.md), and
+// a .env.sepolia with SEPOLIA_RPC_URL[,2,3], ENTRY_POINT_ADDRESS, AIRACCOUNT_V018_BLS_ALGORITHM,
+// BLS_TEST_NODE_ID_1/2, PRIVATE_KEY_SUPPLIER (= the test account's ECDSA owner).
+// Usage: node scripts/e2e/realnode-e2e.mjs
+import { ethers } from "ethers";
+import { bls12_381 as bls } from "@noble/curves/bls12-381.js";
+import { readFileSync } from "fs";
+const sigs = bls.longSignatures;
+const DST = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
+const strip = s => s.replace(/^["']|["']$/g, "");
+const env = Object.fromEntries(
+  readFileSync(".env.sepolia", "utf8").split("\n").filter(l => l.includes("="))
+    .map(l => { const i = l.indexOf("="); return [l.slice(0, i).trim(), strip(l.slice(i + 1).trim())]; })
+);
+const RPCS = [env.SEPOLIA_RPC_URL, env.SEPOLIA_RPC_URL2, env.SEPOLIA_RPC_URL3].filter(Boolean);
+const ENTRY = env.ENTRY_POINT_ADDRESS || env.ENTRYPOINT_ADDRESS;
+const BLS_ALG = env.AIRACCOUNT_V018_BLS_ALGORITHM;
+const ACCOUNT = process.env.E2E_ACCOUNT || "0x45Dfe3D5938fDf5a8D30641C3FDA9c9fb1F31ba9";
+const owner = new ethers.Wallet(env.PRIVATE_KEY_SUPPLIER);
+const PORTS = [3001, 3002, 3003];
+
+const b48 = n => ethers.getBytes("0x" + n.toString(16).padStart(96, "0"));
+const encG2 = pt => { const a = pt.toAffine(); const r = new Uint8Array(256); r.set(b48(a.x.c0), 16); r.set(b48(a.x.c1), 80); r.set(b48(a.y.c0), 144); r.set(b48(a.y.c1), 208); return ethers.hexlify(r); };
+async function withRpc(fn) { for (const u of RPCS) { try { return await fn(new ethers.JsonRpcProvider(u)); } catch (e) { console.log("  rpc retry:", e.shortMessage || e.code); } } throw new Error("all RPCs failed"); }
+
+const userOp = { sender: ACCOUNT, nonce: "0", initCode: "0x", callData: "0x", accountGasLimits: "0x" + "00".repeat(32), preVerificationGas: "0", gasFees: "0x" + "00".repeat(32), paymasterAndData: "0x", signature: "0x" };
+const EP_ABI = ["function getUserOpHash((address sender,uint256 nonce,bytes initCode,bytes callData,bytes32 accountGasLimits,uint256 preVerificationGas,bytes32 gasFees,bytes paymasterAndData,bytes signature) userOp) view returns (bytes32)"];
+const userOpHash = await withRpc(p => new ethers.Contract(ENTRY, EP_ABI, p).getUserOpHash(userOp));
+const ownerAuth = await owner.signMessage(ethers.getBytes(userOpHash));
+console.log("account:", ACCOUNT, "owner:", owner.address);
+console.log("userOpHash:", userOpHash);
+
+// 3 real running nodes co-sign (each enforces Stage 1 owner-auth against on-chain owner())
+const signed = [];
+for (const port of PORTS) {
+  const r = await fetch(`http://localhost:${port}/signature/sign`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ userOp, ownerAuth }) });
+  if (!r.ok) throw new Error(`node :${port} -> ${r.status} ${await r.text()}`);
+  const j = await r.json();
+  console.log(`node :${port} signed (msg==userOpHash: ${j.message === userOpHash})`);
+  signed.push(j);
+}
+// off-chain aggregate verify (all 3)
+const aggAll = sigs.aggregateSignatures(signed.map(s => sigs.Signature.fromHex(s.signatureCompact.replace(/^0x/, ""))));
+const aggPk = signed.map(s => bls.G1.Point.fromHex(s.publicKey.replace(/^0x/, ""))).reduce((a, b) => a.add(b));
+const mp = bls.G2.hashToCurve(ethers.getBytes(userOpHash), { DST });
+console.log("\n[1] 3-node aggregate off-chain verify:", sigs.verify(aggAll, mp, aggPk) ? "✅ VALID" : "❌ INVALID");
+
+// on-chain verify via deployed AAStarBLSAlgorithm using the 2 registered nodes
+const agg2 = sigs.aggregateSignatures(signed.slice(0, 2).map(s => sigs.Signature.fromHex(s.signatureCompact.replace(/^0x/, ""))));
+const payload = ethers.concat([env.BLS_TEST_NODE_ID_1, env.BLS_TEST_NODE_ID_2, encG2(agg2)]);
+const ret = await withRpc(p => new ethers.Contract(BLS_ALG, ["function validate(bytes32 hash, bytes signature) view returns (uint256)"], p).validate(userOpHash, payload));
+console.log("[2] on-chain AAStarBLSAlgorithm.validate:", ret.toString(), ret === 0n ? "✅ VALID" : "❌ reject");

--- a/scripts/e2e/selftest.mjs
+++ b/scripts/e2e/selftest.mjs
@@ -1,0 +1,22 @@
+// DVT node self-test: hit the 3 running nodes (/node/info + /signature/sign) and assert
+// the Stage-1 gate (bad ownerAuth -> 403). Usage: node scripts/e2e/selftest.mjs
+import { ethers } from "ethers";
+import { readFileSync } from "fs";
+const strip=s=>s.replace(/^["']|["']$/g,"");
+const env=Object.fromEntries(readFileSync(".env.sepolia","utf8").split("\n").filter(l=>l.includes("=")).map(l=>{const i=l.indexOf("=");return[l.slice(0,i).trim(),strip(l.slice(i+1).trim())]}));
+const provider=new ethers.JsonRpcProvider(env.SEPOLIA_RPC_URL);
+const ENTRY=env.ENTRY_POINT_ADDRESS||env.ENTRYPOINT_ADDRESS;
+const ACCOUNT="0x45Dfe3D5938fDf5a8D30641C3FDA9c9fb1F31ba9";
+const owner=new ethers.Wallet(env.PRIVATE_KEY_SUPPLIER);
+const userOp={sender:ACCOUNT,nonce:"0",initCode:"0x",callData:"0x",accountGasLimits:"0x"+"00".repeat(32),preVerificationGas:"0",gasFees:"0x"+"00".repeat(32),paymasterAndData:"0x",signature:"0x"};
+const ep=new ethers.Contract(ENTRY,["function getUserOpHash((address sender,uint256 nonce,bytes initCode,bytes callData,bytes32 accountGasLimits,uint256 preVerificationGas,bytes32 gasFees,bytes paymasterAndData,bytes signature) userOp) view returns (bytes32)"],provider);
+const uoh=await ep.getUserOpHash(userOp);
+const ownerAuth=await owner.signMessage(ethers.getBytes(uoh));
+for(const p of [3001,3002,3003]){
+  const info=await (await fetch(`http://localhost:${p}/node/info`)).json();
+  const r=await fetch(`http://localhost:${p}/signature/sign`,{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({userOp,ownerAuth})});
+  const ok=r.ok; const j=ok?await r.json():await r.text();
+  console.log(`:${p} info.nodeId=${(info.nodeId||"?").slice(0,12)}.. | sign ${ok?"✅ "+(j.message===uoh?"hash-bound":"??"):"❌ "+j}`);
+}
+const bad=await fetch(`http://localhost:3001/signature/sign`,{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({userOp,ownerAuth:"0x"+"ab".repeat(65)})});
+console.log(`:3001 bad ownerAuth -> HTTP ${bad.status} ${bad.status===403?"✅ fail-closed":"❌"}`);


### PR DESCRIPTION
Reproducible real-node E2E (proven on Sepolia: on-chain AAStarBLSAlgorithm.validate=0 with real running-node co-signs) + one-click dvt-nodes.sh service (start/stop/logs/info) exposing /signature/sign URLs + pubkeys for aastar-sdk #63. Runtime keys under .e2e/ (gitignored). Refs #42.