### PR TITLE
feat(#50 ⑦): per-IP rate limit on signature endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,10 @@ node_modules/
 dist/
 
 # IDE
-.vscode/
+.vscode/.e2e/
+.e2e/
+
+# env / secrets
+.env.sepolia
+.env.*
+.env*.local

--- a/scripts/e2e/handleops-tx.mjs
+++ b/scripts/e2e/handleops-tx.mjs
@@ -53,6 +53,8 @@ const EP_ABI = [
   "function depositTo(address account) payable",
   "function balanceOf(address account) view returns (uint256)",
   "function handleOps((address sender,uint256 nonce,bytes initCode,bytes callData,bytes32 accountGasLimits,uint256 preVerificationGas,bytes32 gasFees,bytes paymasterAndData,bytes signature)[] ops, address beneficiary)",
+  "error FailedOp(uint256 opIndex, string reason)",
+  "error FailedOpWithRevert(uint256 opIndex, string reason, bytes inner)",
 ];
 const acct = new ethers.Contract(ACCOUNT, ACCOUNT_ABI, owner);
 const ep = new ethers.Contract(ENTRY, EP_ABI, owner);
@@ -169,15 +171,12 @@ try {
   await ep.handleOps.staticCall([userOp], owner.address);
   console.log("[simulation] ✅ passes — sending real tx");
 } catch (e) {
+  const data = e.data || e.info?.error?.data || e.error?.data;
   console.log("[simulation] ❌ revert:", e.shortMessage || e.message);
-  if (e.data) {
-    try {
-      console.log("  FailedOp:", ep.interface.parseError(e.data)?.args);
-    } catch {
-      console.log("  raw data:", e.data?.slice(0, 80));
-    }
+  console.log("  raw data:", typeof data === "string" ? data.slice(0, 200) : data);
+  if (typeof data === "string" && data.length >= 10) {
+    try { const p = ep.interface.parseError(data); console.log("  decoded:", p?.name, JSON.stringify(p?.args, (k,v)=>typeof v==="bigint"?v.toString():v)); } catch (err) { console.log("  (undecodable selector", data.slice(0,10) + ")"); }
   }
-  if (e.revert) console.log("  reason:", e.revert.args);
   process.exit(1);
 }
 console.log("[handleOps] submitting...");

--- a/src/common/throttle.guard.spec.ts
+++ b/src/common/throttle.guard.spec.ts
@@ -1,0 +1,49 @@
+import { HttpException } from "@nestjs/common";
+import { ThrottleGuard } from "./throttle.guard.js";
+
+/** Build a fake ExecutionContext carrying a request IP. */
+function ctx(ip: string): any {
+  return { switchToHttp: () => ({ getRequest: () => ({ ip }) }) };
+}
+function make(config: Record<string, unknown>): ThrottleGuard {
+  return new ThrottleGuard({ get: (k: string) => config[k] } as any);
+}
+
+describe("ThrottleGuard — per-IP rate limit (#50 ⑦)", () => {
+  it("is a no-op when disabled (behavior unchanged)", () => {
+    const g = make({ rateLimitEnabled: false });
+    for (let i = 0; i < 1000; i++) expect(g.canActivate(ctx("1.1.1.1"))).toBe(true);
+  });
+
+  it("allows up to max then throws 429 within the window", () => {
+    const g = make({ rateLimitEnabled: true, rateLimitWindowMs: 60_000, rateLimitMax: 3 });
+    expect(g.canActivate(ctx("2.2.2.2"))).toBe(true);
+    expect(g.canActivate(ctx("2.2.2.2"))).toBe(true);
+    expect(g.canActivate(ctx("2.2.2.2"))).toBe(true);
+    try {
+      g.canActivate(ctx("2.2.2.2"));
+      throw new Error("should have thrown");
+    } catch (e: any) {
+      expect(e).toBeInstanceOf(HttpException);
+      expect(e.getStatus()).toBe(429);
+    }
+  });
+
+  it("limits each IP independently", () => {
+    const g = make({ rateLimitEnabled: true, rateLimitWindowMs: 60_000, rateLimitMax: 1 });
+    expect(g.canActivate(ctx("3.3.3.3"))).toBe(true);
+    expect(g.canActivate(ctx("4.4.4.4"))).toBe(true); // different IP, own budget
+    expect(() => g.canActivate(ctx("3.3.3.3"))).toThrow(HttpException);
+  });
+
+  it("frees budget after the window elapses", () => {
+    const g = make({ rateLimitEnabled: true, rateLimitWindowMs: 10, rateLimitMax: 1 });
+    expect(g.canActivate(ctx("5.5.5.5"))).toBe(true);
+    expect(() => g.canActivate(ctx("5.5.5.5"))).toThrow(HttpException);
+    const t0 = Date.now();
+    while (Date.now() - t0 < 15) {
+      /* spin past the 10ms window */
+    }
+    expect(g.canActivate(ctx("5.5.5.5"))).toBe(true);
+  });
+});

--- a/src/common/throttle.guard.ts
+++ b/src/common/throttle.guard.ts
@@ -1,0 +1,64 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+
+/**
+ * Per-IP sliding-window rate limiter (#50 hardening ⑦).
+ *
+ * Guards the signature endpoints, which — even before the Stage-1 owner-auth gate
+ * rejects an unauthorized caller — make on-chain RPC reads (EntryPoint.getUserOpHash,
+ * account.owner()). An unauthenticated flood would therefore amplify into on-chain RPC
+ * load. This caps requests per source IP so that pre-auth abuse is bounded.
+ *
+ * Opt-in via RATE_LIMIT_ENABLED (default off → no limiting, behavior unchanged).
+ * In-memory + per-process (good enough for a single node; a multi-node deployment
+ * fronts nodes with its own edge limiter). Rejects over-limit with HTTP 429.
+ */
+@Injectable()
+export class ThrottleGuard implements CanActivate {
+  private readonly logger = new Logger(ThrottleGuard.name);
+  private readonly enabled: boolean;
+  private readonly windowMs: number;
+  private readonly max: number;
+  /** ip -> request timestamps within the current window. */
+  private readonly hits = new Map<string, number[]>();
+
+  constructor(configService: ConfigService) {
+    this.enabled = configService.get<boolean>("rateLimitEnabled") === true;
+    this.windowMs = configService.get<number>("rateLimitWindowMs") ?? 60_000;
+    this.max = configService.get<number>("rateLimitMax") ?? 30;
+    if (this.enabled) {
+      this.logger.log(`Rate limit ENABLED — ${this.max} req / ${this.windowMs}ms per IP`);
+    }
+  }
+
+  canActivate(context: ExecutionContext): boolean {
+    if (!this.enabled) return true;
+
+    const req = context.switchToHttp().getRequest();
+    const ip: string = req?.ip || req?.socket?.remoteAddress || "unknown";
+    const now = Date.now();
+
+    const recent = (this.hits.get(ip) ?? []).filter(t => now - t < this.windowMs);
+    if (recent.length >= this.max) {
+      this.logger.warn(`Rate limit exceeded for ${ip} (${recent.length}/${this.max})`);
+      throw new HttpException("Too many requests", HttpStatus.TOO_MANY_REQUESTS);
+    }
+    recent.push(now);
+    this.hits.set(ip, recent);
+
+    // Opportunistic cleanup so the map doesn't grow unbounded across idle IPs.
+    if (this.hits.size > 10_000) {
+      for (const [k, ts] of this.hits) {
+        if (ts.every(t => now - t >= this.windowMs)) this.hits.delete(k);
+      }
+    }
+    return true;
+  }
+}

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -48,6 +48,12 @@ export default () => {
     policyEthSentinel:
       process.env.POLICY_ETH_SENTINEL || "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
 
+    // Per-IP rate limiting on signature endpoints (#50 hardening ⑦). Opt-in;
+    // bounds pre-auth on-chain RPC amplification. Default off = behavior unchanged.
+    rateLimitEnabled: process.env.RATE_LIMIT_ENABLED === "true",
+    rateLimitWindowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS || "60000", 10),
+    rateLimitMax: parseInt(process.env.RATE_LIMIT_MAX || "30", 10),
+
     // Gossip Network
     gossipPublicUrl: process.env.GOSSIP_PUBLIC_URL || `ws://localhost:${port}/ws`,
     gossipBootstrapPeers: parseBootstrapPeers(process.env.GOSSIP_BOOTSTRAP_PEERS || ""),

--- a/src/modules/signature/signature.controller.ts
+++ b/src/modules/signature/signature.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Post, Body, ValidationPipe, Logger } from "@nestjs/common";
+import { Controller, Post, Body, ValidationPipe, Logger, UseGuards } from "@nestjs/common";
+import { ThrottleGuard } from "../../common/throttle.guard.js";
 import { ApiTags, ApiOperation, ApiResponse, ApiBody } from "@nestjs/swagger";
 import { SignatureService } from "./signature.service.js";
 import { SignMessageDto } from "../../dto/sign.dto.js";
@@ -33,6 +34,7 @@ export class VerifySignatureDto {
 
 @ApiTags("signature")
 @Controller("signature")
+@UseGuards(ThrottleGuard)
 export class SignatureController {
   private readonly logger = new Logger(SignatureController.name);
 

--- a/src/modules/signature/signature.module.ts
+++ b/src/modules/signature/signature.module.ts
@@ -4,10 +4,11 @@ import { SignatureController } from "./signature.controller.js";
 import { BlsModule } from "../bls/bls.module.js";
 import { NodeModule } from "../node/node.module.js";
 import { PolicyModule } from "../policy/policy.module.js";
+import { ThrottleGuard } from "../../common/throttle.guard.js";
 
 @Module({
   imports: [BlsModule, NodeModule, PolicyModule],
-  providers: [SignatureService],
+  providers: [SignatureService, ThrottleGuard],
   controllers: [SignatureController],
   exports: [SignatureService],
 })


### PR DESCRIPTION
Opt-in ThrottleGuard (RATE_LIMIT_ENABLED, default off) — per-IP sliding-window limiter on /signature/* bounding pre-auth on-chain RPC amplification; over-limit → 429. First production-hardening item from #50. 40/40 tests. Refs #50.