### PR TITLE
feat(#52): multi-channel large-spend notification (Telegram, one-way)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ dist/
 
 # IDE
 .vscode/
+# notification contacts (per-account chat ids / emails — never commit)
+notify-contacts.json

--- a/notify-contacts.example.json
+++ b/notify-contacts.example.json
@@ -1,0 +1,7 @@
+{
+  "0xYourAccountAddressLowercase": {
+    "telegramChatId": "123456789",
+    "email": "user@example.com",
+    "nostrPubkey": "npub1..."
+  }
+}

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -48,6 +48,13 @@ export default () => {
     policyEthSentinel:
       process.env.POLICY_ETH_SENTINEL || "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
 
+    // Multi-channel user notification (#52). Opt-in; fire-and-forget (never blocks
+    // signing). Contacts file is git-ignored. threshold 0 = notify every co-sign.
+    notifyEnabled: process.env.NOTIFY_ENABLED === "true",
+    notifyThresholdWei: process.env.NOTIFY_THRESHOLD_WEI || "0",
+    telegramBotToken: process.env.TELEGRAM_BOT_TOKEN || undefined,
+    notifyContactsFile: process.env.NOTIFY_CONTACTS_FILE || undefined,
+
     // Gossip Network
     gossipPublicUrl: process.env.GOSSIP_PUBLIC_URL || `ws://localhost:${port}/ws`,
     gossipBootstrapPeers: parseBootstrapPeers(process.env.GOSSIP_BOOTSTRAP_PEERS || ""),

--- a/src/modules/notification/notification.module.ts
+++ b/src/modules/notification/notification.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { NotificationService } from "./notification.service.js";
+
+@Module({
+  providers: [NotificationService],
+  exports: [NotificationService],
+})
+export class NotificationModule {}

--- a/src/modules/notification/notification.service.spec.ts
+++ b/src/modules/notification/notification.service.spec.ts
@@ -1,0 +1,91 @@
+import { ethers } from "ethers";
+import { NotificationService, Contact, NotificationChannel } from "./notification.service.js";
+import type { PackedUserOp } from "../blockchain/blockchain.service.js";
+
+const coder = new ethers.AbiCoder();
+const ACCOUNT = "0x" + "ab".repeat(20);
+const RECIPIENT = "0x" + "11".repeat(20);
+
+function executeUserOp(valueWei: bigint): PackedUserOp {
+  const sel = ethers.id("execute(address,uint256,bytes)").slice(0, 10);
+  const callData =
+    sel + coder.encode(["address", "uint256", "bytes"], [RECIPIENT, valueWei, "0x"]).slice(2);
+  return {
+    sender: ACCOUNT,
+    nonce: "0",
+    initCode: "0x",
+    callData,
+    accountGasLimits: "0x" + "00".repeat(32),
+    preVerificationGas: "0",
+    gasFees: "0x" + "00".repeat(32),
+    paymasterAndData: "0x",
+    signature: "0x",
+  };
+}
+
+function make(
+  config: Record<string, unknown>,
+  channels?: NotificationChannel[],
+  contacts?: Map<string, Contact>
+): NotificationService {
+  return new NotificationService({ get: (k: string) => config[k] } as any, channels, contacts);
+}
+
+const contactsOf = (c: Contact) => new Map([[ACCOUNT.toLowerCase(), c]]);
+
+describe("NotificationService — large-spend notification (#52)", () => {
+  it("no plan when disabled (default off)", () => {
+    const svc = make({ notifyEnabled: false }, [], contactsOf({ telegramChatId: "1" }));
+    expect(svc.plan(executeUserOp(10n ** 18n), "0xhash")).toBeNull();
+  });
+
+  it("no plan below threshold", () => {
+    const svc = make(
+      { notifyEnabled: true, notifyThresholdWei: "1000000000000000000" },
+      [],
+      contactsOf({ telegramChatId: "1" })
+    );
+    expect(svc.plan(executeUserOp(5n), "0xhash")).toBeNull();
+  });
+
+  it("plans a notification at/above threshold with a registered contact", () => {
+    const svc = make(
+      { notifyEnabled: true, notifyThresholdWei: "100" },
+      [],
+      contactsOf({ telegramChatId: "42" })
+    );
+    const plan = svc.plan(executeUserOp(101n), "0xhash");
+    expect(plan).not.toBeNull();
+    expect(plan!.contact.telegramChatId).toBe("42");
+    expect(plan!.message).toMatch(/large operation/);
+  });
+
+  it("no plan when the account has no registered contact", () => {
+    const svc = make({ notifyEnabled: true, notifyThresholdWei: "0" }, [], new Map());
+    expect(svc.plan(executeUserOp(10n ** 18n), "0xhash")).toBeNull();
+  });
+
+  it("notifyLargeSpend dispatches to every channel and NEVER throws on channel failure", async () => {
+    const calls: string[] = [];
+    const okChannel: NotificationChannel = {
+      name: "ok",
+      send: async () => {
+        calls.push("ok");
+      },
+    };
+    const failChannel: NotificationChannel = {
+      name: "fail",
+      send: async () => {
+        throw new Error("down");
+      },
+    };
+    const svc = make(
+      { notifyEnabled: true, notifyThresholdWei: "0" },
+      [okChannel, failChannel],
+      contactsOf({ telegramChatId: "1" })
+    );
+    expect(() => svc.notifyLargeSpend(executeUserOp(10n ** 18n), "0xhash")).not.toThrow();
+    await new Promise(r => setTimeout(r, 5)); // let fire-and-forget settle
+    expect(calls).toContain("ok"); // ok channel fired; fail channel's rejection swallowed
+  });
+});

--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -1,0 +1,140 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { ethers } from "ethers";
+import { existsSync, readFileSync } from "fs";
+import { PackedUserOp } from "../blockchain/blockchain.service.js";
+
+/** Per-account contact targets (loaded from a git-ignored file, never committed). */
+export interface Contact {
+  telegramChatId?: string;
+  email?: string;
+  nostrPubkey?: string;
+}
+
+/** A delivery channel. Telegram ships first; email + Nostr are follow-ups (#52). */
+export interface NotificationChannel {
+  readonly name: string;
+  send(contact: Contact, message: string): Promise<void>;
+}
+
+class TelegramChannel implements NotificationChannel {
+  readonly name = "telegram";
+  constructor(private readonly token: string) {}
+  async send(contact: Contact, message: string): Promise<void> {
+    if (!contact.telegramChatId) return;
+    const r = await fetch(`https://api.telegram.org/bot${this.token}/sendMessage`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chat_id: contact.telegramChatId, text: message }),
+    });
+    if (!r.ok) throw new Error(`telegram HTTP ${r.status}`);
+  }
+}
+
+const EXECUTE_SELECTOR = ethers.id("execute(address,uint256,bytes)").slice(0, 10);
+const ABI = new ethers.AbiCoder();
+
+/**
+ * Multi-channel user notification (#52). Increment 1: one-way "large spend" alert —
+ * after the node co-signs a high-value op, tell the real user via channels an attacker
+ * (even one holding the owner key) does not control, so anomalies are caught quickly.
+ *
+ * Hard rule: notification is **fire-and-forget and never throws / never blocks** — a
+ * delivery failure must not affect signing. (Out-of-band CONFIRMATION — which DOES gate
+ * signing, #50 ⑤ scheme A — is a separate follow-up that reuses these channels.)
+ *
+ * Opt-in via NOTIFY_ENABLED. Contacts load from NOTIFY_CONTACTS_FILE (git-ignored).
+ */
+@Injectable()
+export class NotificationService {
+  private readonly logger = new Logger(NotificationService.name);
+  private readonly enabled: boolean;
+  private readonly thresholdWei: bigint;
+  private readonly channels: NotificationChannel[] = [];
+  private readonly contacts = new Map<string, Contact>();
+
+  constructor(
+    configService: ConfigService,
+    /** Test seam: inject channels/contacts; production builds them from config. */
+    channels?: NotificationChannel[],
+    contacts?: Map<string, Contact>
+  ) {
+    this.enabled = configService.get<boolean>("notifyEnabled") === true;
+    this.thresholdWei = BigInt(configService.get<string>("notifyThresholdWei") ?? "0");
+
+    if (channels) {
+      this.channels = channels;
+    } else {
+      const tgToken = configService.get<string>("telegramBotToken");
+      if (tgToken) this.channels.push(new TelegramChannel(tgToken));
+    }
+
+    if (contacts) {
+      this.contacts = contacts;
+    } else {
+      const file = configService.get<string>("notifyContactsFile");
+      if (file && existsSync(file)) {
+        try {
+          const raw = JSON.parse(readFileSync(file, "utf8")) as Record<string, Contact>;
+          for (const [acct, c] of Object.entries(raw)) this.contacts.set(acct.toLowerCase(), c);
+        } catch (e: any) {
+          this.logger.error(`failed to load notify contacts from ${file}: ${e?.message ?? e}`);
+        }
+      }
+    }
+
+    if (this.enabled) {
+      this.logger.log(
+        `Notifications ENABLED — channels=[${this.channels.map(c => c.name).join(",") || "none"}], ` +
+          `contacts=${this.contacts.size}, threshold=${this.thresholdWei} wei`
+      );
+    }
+  }
+
+  /**
+   * Fire a one-way large-spend notification. Returns immediately; deliveries run in the
+   * background and any failure is swallowed (never affects the signing path).
+   */
+  notifyLargeSpend(userOp: PackedUserOp, userOpHash: string): void {
+    try {
+      const plan = this.plan(userOp, userOpHash);
+      if (!plan) return;
+      for (const ch of this.channels) {
+        ch.send(plan.contact, plan.message).catch(e =>
+          this.logger.warn(`notify ${ch.name} failed (ignored): ${e?.message ?? e}`)
+        );
+      }
+    } catch (e: any) {
+      this.logger.warn(`notifyLargeSpend error (ignored): ${e?.message ?? e}`);
+    }
+  }
+
+  /**
+   * Decide whether/what to notify. Returns null when disabled, below threshold, or no
+   * contact. Pure (no I/O) — the testable core of notifyLargeSpend.
+   */
+  plan(userOp: PackedUserOp, userOpHash: string): { contact: Contact; message: string } | null {
+    if (!this.enabled) return null;
+    const amount = this.nativeValue(userOp);
+    if (amount < this.thresholdWei) return null;
+    const contact = this.contacts.get((userOp.sender || "").toLowerCase());
+    if (!contact) return null;
+    const message =
+      `⚠️ DVT: account ${userOp.sender} just co-signed a large operation — ` +
+      `${ethers.formatEther(amount)} ETH (userOpHash ${userOpHash}). ` +
+      `If this wasn't you, freeze the account immediately.`;
+    return { contact, message };
+  }
+
+  /** Native ETH value of an execute() call; 0 for non-execute / undecodable. */
+  private nativeValue(userOp: PackedUserOp): bigint {
+    try {
+      const cd = userOp.callData;
+      if (typeof cd !== "string" || cd.slice(0, 10) !== EXECUTE_SELECTOR) return 0n;
+      const [, value] = ABI.decode(["address", "uint256", "bytes"], "0x" + cd.slice(10));
+      return value as bigint;
+    } catch {
+      return 0n;
+    }
+  }
+}

--- a/src/modules/signature/signature.module.ts
+++ b/src/modules/signature/signature.module.ts
@@ -4,9 +4,10 @@ import { SignatureController } from "./signature.controller.js";
 import { BlsModule } from "../bls/bls.module.js";
 import { NodeModule } from "../node/node.module.js";
 import { PolicyModule } from "../policy/policy.module.js";
+import { NotificationModule } from "../notification/notification.module.js";
 
 @Module({
-  imports: [BlsModule, NodeModule, PolicyModule],
+  imports: [BlsModule, NodeModule, PolicyModule, NotificationModule],
   providers: [SignatureService],
   controllers: [SignatureController],
   exports: [SignatureService],

--- a/src/modules/signature/signature.service.ts
+++ b/src/modules/signature/signature.service.ts
@@ -3,6 +3,7 @@ import { ethers } from "ethers";
 import { BlsService } from "../bls/bls.service.js";
 import { NodeService } from "../node/node.service.js";
 import { PolicyService } from "../policy/policy.service.js";
+import { NotificationService } from "../notification/notification.service.js";
 import { SignatureResult, AggregateSignatureResult } from "../../interfaces/signature.interface.js";
 import { sigs, bls, BLS_DST } from "../../utils/bls.util.js";
 import { PackedUserOp } from "../blockchain/blockchain.service.js";
@@ -14,7 +15,8 @@ export class SignatureService {
   constructor(
     private readonly blsService: BlsService,
     private readonly nodeService: NodeService,
-    private readonly policyService: PolicyService
+    private readonly policyService: PolicyService,
+    private readonly notificationService: NotificationService
   ) {}
 
   async signMessage(userOp: PackedUserOp, ownerAuth: string | undefined): Promise<SignatureResult> {
@@ -38,7 +40,12 @@ export class SignatureService {
     }
 
     // Sign the SAME already-authorized derived hash (no re-auth, no TOCTOU).
-    return await this.blsService.signDerivedHash(userOpHash, node);
+    const result = await this.blsService.signDerivedHash(userOpHash, node);
+
+    // Fire-and-forget large-spend notification (#52). Must never block or fail signing.
+    this.notificationService.notifyLargeSpend(userOp, userOpHash);
+
+    return result;
   }
 
   async aggregateExternalSignatures(signatureStrings: string[]): Promise<AggregateSignatureResult> {


### PR DESCRIPTION
First increment of #52: `NotificationService` + pluggable channel (Telegram first; email/Nostr next), fires a fire-and-forget large-spend alert to the real user after a high-value co-sign — never blocks/fails signing. Opt-in (`NOTIFY_ENABLED`); per-account contacts from a git-ignored `NOTIFY_CONTACTS_FILE` (example provided). 41/41 tests. Out-of-band CONFIRMATION (#50 ⑤ scheme A) reuses these channels (next increment). Refs #52, #50.