### PR TITLE
feat(#50 ⑤ / #52): out-of-band confirmation (scheme A) for high-value ops

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -55,6 +55,12 @@ export default () => {
     telegramBotToken: process.env.TELEGRAM_BOT_TOKEN || undefined,
     notifyContactsFile: process.env.NOTIFY_CONTACTS_FILE || undefined,
 
+    // Out-of-band confirmation (scheme A, #50 ⑤). Opt-in; a high-value op is withheld
+    // until the user approves over an independent channel. Fail-closed if undeliverable.
+    confirmEnabled: process.env.CONFIRM_ENABLED === "true",
+    confirmThresholdWei: process.env.CONFIRM_THRESHOLD_WEI || "0",
+    confirmTtlMs: parseInt(process.env.CONFIRM_TTL_MS || "600000", 10),
+
     // Per-IP rate limiting on signature endpoints (#50 hardening ⑦). Opt-in;
     // bounds pre-auth on-chain RPC amplification. Default off = behavior unchanged.
     rateLimitEnabled: process.env.RATE_LIMIT_ENABLED === "true",

--- a/src/modules/confirmation/confirmation.module.ts
+++ b/src/modules/confirmation/confirmation.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { ConfirmationService } from "./confirmation.service.js";
+import { NotificationModule } from "../notification/notification.module.js";
+
+@Module({
+  imports: [NotificationModule],
+  providers: [ConfirmationService],
+  exports: [ConfirmationService],
+})
+export class ConfirmationModule {}

--- a/src/modules/confirmation/confirmation.service.spec.ts
+++ b/src/modules/confirmation/confirmation.service.spec.ts
@@ -1,0 +1,105 @@
+import { ethers } from "ethers";
+import { ConfirmationService } from "./confirmation.service.js";
+import type { PackedUserOp } from "../blockchain/blockchain.service.js";
+
+const coder = new ethers.AbiCoder();
+const ACCOUNT = "0x" + "ab".repeat(20);
+
+function executeUserOp(valueWei: bigint): PackedUserOp {
+  const sel = ethers.id("execute(address,uint256,bytes)").slice(0, 10);
+  const callData =
+    sel +
+    coder
+      .encode(["address", "uint256", "bytes"], ["0x" + "11".repeat(20), valueWei, "0x"])
+      .slice(2);
+  return {
+    sender: ACCOUNT,
+    nonce: "0",
+    initCode: "0x",
+    callData,
+    accountGasLimits: "0x" + "00".repeat(32),
+    preVerificationGas: "0",
+    gasFees: "0x" + "00".repeat(32),
+    paymasterAndData: "0x",
+    signature: "0x",
+  };
+}
+
+/** NotificationService stub: hasContact toggle + sendToAccount capturing the token msg. */
+function notif(hasContact: boolean, deliver = true) {
+  const sent: string[] = [];
+  return {
+    sent,
+    hasContact: () => hasContact,
+    sendToAccount: async (_a: string, msg: string) => {
+      sent.push(msg);
+      return deliver;
+    },
+  } as any;
+}
+
+function make(config: Record<string, unknown>, n: any): ConfirmationService {
+  return new ConfirmationService({ get: (k: string) => config[k] } as any, n);
+}
+
+const HASH = "0x" + "cd".repeat(32);
+
+describe("ConfirmationService — out-of-band confirmation (scheme A, #50 ⑤)", () => {
+  it("not_required when disabled", async () => {
+    const svc = make({ confirmEnabled: false }, notif(true));
+    expect(await svc.gate(executeUserOp(10n ** 18n), HASH)).toBe("not_required");
+  });
+
+  it("not_required below threshold", async () => {
+    const svc = make(
+      { confirmEnabled: true, confirmThresholdWei: "1000000000000000000" },
+      notif(true)
+    );
+    expect(await svc.gate(executeUserOp(5n), HASH)).toBe("not_required");
+  });
+
+  it("undeliverable (fail-closed) when high-value but no contact", async () => {
+    const svc = make({ confirmEnabled: true, confirmThresholdWei: "100" }, notif(false));
+    expect(await svc.gate(executeUserOp(101n), HASH)).toBe("undeliverable");
+  });
+
+  it("undeliverable when contact exists but delivery fails", async () => {
+    const svc = make({ confirmEnabled: true, confirmThresholdWei: "100" }, notif(true, false));
+    expect(await svc.gate(executeUserOp(101n), HASH)).toBe("undeliverable");
+  });
+
+  it("pending on first high-value request and sends a token out-of-band", async () => {
+    const n = notif(true);
+    const svc = make({ confirmEnabled: true, confirmThresholdWei: "100" }, n);
+    expect(await svc.gate(executeUserOp(101n), HASH)).toBe("pending");
+    expect(n.sent.length).toBe(1);
+    expect(n.sent[0]).toMatch(/Confirm token: 0x[0-9a-f]+/);
+  });
+
+  it("confirmed after the user approves with the correct token (single-use)", async () => {
+    const n = notif(true);
+    const svc = make({ confirmEnabled: true, confirmThresholdWei: "100" }, n);
+    await svc.gate(executeUserOp(101n), HASH);
+    const token = n.sent[0].match(/Confirm token: (0x[0-9a-f]+)/)![1];
+    expect(svc.confirm(HASH, token)).toBe(true);
+    expect(await svc.gate(executeUserOp(101n), HASH)).toBe("confirmed");
+    // single-use: a fresh gate after consumption is pending again
+    expect(await svc.gate(executeUserOp(101n), HASH)).toBe("pending");
+  });
+
+  it("rejects a wrong token", async () => {
+    const n = notif(true);
+    const svc = make({ confirmEnabled: true, confirmThresholdWei: "100" }, n);
+    await svc.gate(executeUserOp(101n), HASH);
+    expect(svc.confirm(HASH, "0xwrong")).toBe(false);
+    expect(await svc.gate(executeUserOp(101n), HASH)).toBe("pending");
+  });
+
+  it("expires a pending confirmation (ttl=0)", async () => {
+    const n = notif(true);
+    const svc = make({ confirmEnabled: true, confirmThresholdWei: "100", confirmTtlMs: 0 }, n);
+    await svc.gate(executeUserOp(101n), HASH);
+    const token = n.sent[0].match(/Confirm token: (0x[0-9a-f]+)/)![1];
+    expect(svc.confirm(HASH, token)).toBe(false); // already expired
+  });
+});

--- a/src/modules/confirmation/confirmation.service.ts
+++ b/src/modules/confirmation/confirmation.service.ts
@@ -1,0 +1,118 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { ethers } from "ethers";
+import { randomBytes } from "crypto";
+import { PackedUserOp } from "../blockchain/blockchain.service.js";
+import { NotificationService } from "../notification/notification.service.js";
+
+/** Result of the confirmation gate for a co-sign request. */
+export type GateResult = "not_required" | "confirmed" | "pending" | "undeliverable";
+
+interface Pending {
+  token: string;
+  confirmed: boolean;
+  expiry: number;
+}
+
+const EXECUTE_SELECTOR = ethers.id("execute(address,uint256,bytes)").slice(0, 10);
+const ABI = new ethers.AbiCoder();
+
+/**
+ * Out-of-band CONFIRMATION (scheme A — #50 ⑤ / #52 increment 2).
+ *
+ * For a high-value op the node does NOT co-sign until the real account user approves via
+ * an independent channel (Telegram/email/Nostr) that an attacker — even one holding the
+ * owner key — does not control. This is what lets the DVT tier survive owner-key
+ * compromise: the stolen key alone can authorize Stage-1, but cannot produce the
+ * out-of-band approval.
+ *
+ * Flow: gate() on a high-value op creates a pending entry, sends a one-time `token`
+ * ONLY over the user's independent channel, and returns "pending" (node withholds the
+ * signature). The user approves by hitting POST /signature/confirm with that token
+ * (e.g. a link in the Telegram message) — the client/attacker never sees it. A later
+ * sign request for the same userOpHash then gates to "confirmed" and signs.
+ *
+ * Fail-closed: if a high-value op needs confirmation but no contact/channel can deliver
+ * the token ("undeliverable"), the node REFUSES — it must never sign a high-value op it
+ * cannot get the user to approve. Tokens are single-use and expire.
+ *
+ * Opt-in via CONFIRM_ENABLED.
+ */
+@Injectable()
+export class ConfirmationService {
+  private readonly logger = new Logger(ConfirmationService.name);
+  private readonly enabled: boolean;
+  private readonly thresholdWei: bigint;
+  private readonly ttlMs: number;
+  private readonly pending = new Map<string, Pending>();
+
+  constructor(
+    configService: ConfigService,
+    private readonly notificationService: NotificationService
+  ) {
+    this.enabled = configService.get<boolean>("confirmEnabled") === true;
+    this.thresholdWei = BigInt(configService.get<string>("confirmThresholdWei") ?? "0");
+    this.ttlMs = configService.get<number>("confirmTtlMs") ?? 600_000; // 10 min default
+    if (this.enabled) {
+      this.logger.log(
+        `Out-of-band confirmation ENABLED — threshold=${this.thresholdWei} wei, ttl=${this.ttlMs}ms`
+      );
+    }
+  }
+
+  /**
+   * Decide whether this op may be signed now. For a high-value op it creates/sends a
+   * pending confirmation and returns "pending" (withhold signature) until the user
+   * confirms out-of-band; "confirmed" releases it (single-use); "undeliverable" means
+   * fail-closed (no channel to reach the user).
+   */
+  async gate(userOp: PackedUserOp, userOpHash: string): Promise<GateResult> {
+    if (!this.enabled) return "not_required";
+    if (this.nativeValue(userOp) < this.thresholdWei) return "not_required";
+
+    const now = Date.now();
+    let p = this.pending.get(userOpHash);
+    if (p && p.expiry <= now) {
+      this.pending.delete(userOpHash);
+      p = undefined;
+    }
+    if (p?.confirmed) {
+      this.pending.delete(userOpHash); // single-use
+      return "confirmed";
+    }
+    if (p) return "pending"; // already awaiting confirmation
+
+    // New high-value op → require out-of-band approval.
+    if (!this.notificationService.hasContact(userOp.sender)) return "undeliverable";
+    const token = "0x" + randomBytes(16).toString("hex");
+    this.pending.set(userOpHash, { token, confirmed: false, expiry: now + this.ttlMs });
+    const msg =
+      `🔐 DVT confirmation required for ${userOp.sender}.\n` +
+      `Op ${userOpHash}\nApprove only if you initiated it. Confirm token: ${token}`;
+    const delivered = await this.notificationService.sendToAccount(userOp.sender, msg);
+    if (!delivered) {
+      this.pending.delete(userOpHash);
+      return "undeliverable";
+    }
+    return "pending";
+  }
+
+  /** Approve a pending op by its userOpHash + the out-of-band token. Single-use. */
+  confirm(userOpHash: string, token: string): boolean {
+    const p = this.pending.get(userOpHash);
+    if (!p || p.expiry <= Date.now() || p.token !== token) return false;
+    p.confirmed = true;
+    return true;
+  }
+
+  private nativeValue(userOp: PackedUserOp): bigint {
+    try {
+      const cd = userOp.callData;
+      if (typeof cd !== "string" || cd.slice(0, 10) !== EXECUTE_SELECTOR) return 0n;
+      const [, value] = ABI.decode(["address", "uint256", "bytes"], "0x" + cd.slice(10));
+      return value as bigint;
+    } catch {
+      return 0n;
+    }
+  }
+}

--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -109,6 +109,23 @@ export class NotificationService {
     }
   }
 
+  /** Whether an account has any registered out-of-band contact (used by confirmation). */
+  hasContact(account: string): boolean {
+    return this.contacts.has((account || "").toLowerCase());
+  }
+
+  /**
+   * Send an arbitrary message to an account's contacts over EVERY channel. Used by the
+   * out-of-band CONFIRMATION flow (which must know delivery succeeded). Returns true if
+   * at least one channel delivered. Awaited (unlike the fire-and-forget notify path).
+   */
+  async sendToAccount(account: string, message: string): Promise<boolean> {
+    const contact = this.contacts.get((account || "").toLowerCase());
+    if (!contact || this.channels.length === 0) return false;
+    const results = await Promise.allSettled(this.channels.map(ch => ch.send(contact, message)));
+    return results.some(r => r.status === "fulfilled");
+  }
+
   /**
    * Decide whether/what to notify. Returns null when disabled, below threshold, or no
    * contact. Pure (no I/O) — the testable core of notifyLargeSpend.

--- a/src/modules/signature/signature.controller.ts
+++ b/src/modules/signature/signature.controller.ts
@@ -100,6 +100,11 @@ export class SignatureController {
         signDto.ownerAuth
       );
 
+      if ("status" in result) {
+        this.logger.log(`⏳ Pending out-of-band confirmation: ${result.userOpHash}`);
+        return result;
+      }
+
       this.logger.log(`✅ Sign Success:`);
       this.logger.log(`  Node ID: ${result.nodeId}`);
       this.logger.log(
@@ -114,6 +119,18 @@ export class SignatureController {
       this.logger.error(`❌ Sign Failed: ${error.message}`);
       throw error;
     }
+  }
+
+  @ApiOperation({ summary: "Approve a high-value op pending out-of-band confirmation" })
+  @ApiResponse({ status: 200, description: "Confirmation result { confirmed: boolean }" })
+  @Post("confirm")
+  confirm(@Body() body: { userOpHash?: string; token?: string }) {
+    const ok =
+      typeof body?.userOpHash === "string" &&
+      typeof body?.token === "string" &&
+      this.signatureService.confirm(body.userOpHash, body.token);
+    this.logger.log(`Confirm ${body?.userOpHash}: ${ok ? "accepted" : "rejected"}`);
+    return { confirmed: ok };
   }
 
   @ApiOperation({ summary: "Aggregate multiple BLS signatures" })

--- a/src/modules/signature/signature.module.ts
+++ b/src/modules/signature/signature.module.ts
@@ -5,10 +5,11 @@ import { BlsModule } from "../bls/bls.module.js";
 import { NodeModule } from "../node/node.module.js";
 import { PolicyModule } from "../policy/policy.module.js";
 import { NotificationModule } from "../notification/notification.module.js";
+import { ConfirmationModule } from "../confirmation/confirmation.module.js";
 import { ThrottleGuard } from "../../common/throttle.guard.js";
 
 @Module({
-  imports: [BlsModule, NodeModule, PolicyModule, NotificationModule],
+  imports: [BlsModule, NodeModule, PolicyModule, NotificationModule, ConfirmationModule],
   providers: [SignatureService, ThrottleGuard],
   controllers: [SignatureController],
   exports: [SignatureService],

--- a/src/modules/signature/signature.service.ts
+++ b/src/modules/signature/signature.service.ts
@@ -4,9 +4,17 @@ import { BlsService } from "../bls/bls.service.js";
 import { NodeService } from "../node/node.service.js";
 import { PolicyService } from "../policy/policy.service.js";
 import { NotificationService } from "../notification/notification.service.js";
+import { ConfirmationService } from "../confirmation/confirmation.service.js";
 import { SignatureResult, AggregateSignatureResult } from "../../interfaces/signature.interface.js";
 import { sigs, bls, BLS_DST } from "../../utils/bls.util.js";
 import { PackedUserOp } from "../blockchain/blockchain.service.js";
+
+/** Returned (instead of a signature) when a high-value op awaits out-of-band confirmation. */
+export interface PendingConfirmation {
+  status: "pending_confirmation";
+  userOpHash: string;
+  message: string;
+}
 
 @Injectable()
 export class SignatureService {
@@ -16,10 +24,14 @@ export class SignatureService {
     private readonly blsService: BlsService,
     private readonly nodeService: NodeService,
     private readonly policyService: PolicyService,
-    private readonly notificationService: NotificationService
+    private readonly notificationService: NotificationService,
+    private readonly confirmationService: ConfirmationService
   ) {}
 
-  async signMessage(userOp: PackedUserOp, ownerAuth: string | undefined): Promise<SignatureResult> {
+  async signMessage(
+    userOp: PackedUserOp,
+    ownerAuth: string | undefined
+  ): Promise<SignatureResult | PendingConfirmation> {
     const node = this.nodeService.getNodeForSigning();
 
     // Fix 2 Stage 1 owner-auth gate FIRST: derive the authoritative userOpHash and
@@ -39,13 +51,36 @@ export class SignatureService {
       throw new ForbiddenException("operation rejected by node policy");
     }
 
-    // Sign the SAME already-authorized derived hash (no re-auth, no TOCTOU).
+    // Out-of-band confirmation gate (#50 ⑤ scheme A): a high-value op is withheld until
+    // the user approves over an independent channel — defends against owner-key compromise.
+    const gate = await this.confirmationService.gate(userOp, userOpHash);
+    if (gate === "undeliverable") {
+      this.logger.warn(`Confirmation undeliverable for ${userOp.sender} — refusing high-value op`);
+      throw new ForbiddenException(
+        "high-value operation requires out-of-band confirmation, but no contact channel is configured"
+      );
+    }
+    if (gate === "pending") {
+      this.logger.log(`Awaiting out-of-band confirmation for ${userOpHash}`);
+      return {
+        status: "pending_confirmation",
+        userOpHash,
+        message: "high-value operation pending out-of-band confirmation; approve via your channel",
+      };
+    }
+
+    // gate is "not_required" or "confirmed" → sign the same already-authorized hash.
     const result = await this.blsService.signDerivedHash(userOpHash, node);
 
     // Fire-and-forget large-spend notification (#52). Must never block or fail signing.
     this.notificationService.notifyLargeSpend(userOp, userOpHash);
 
     return result;
+  }
+
+  /** Approve a pending high-value op (out-of-band confirmation, #50 ⑤). */
+  confirm(userOpHash: string, token: string): boolean {
+    return this.confirmationService.confirm(userOpHash, token);
   }
 
   async aggregateExternalSignatures(signatureStrings: string[]): Promise<AggregateSignatureResult> {


### PR DESCRIPTION
Out-of-band CONFIRMATION (scheme A): a high-value co-sign is **withheld** until the real user approves over an independent channel (Telegram/email/Nostr) an attacker can't control — the core defense against owner-key compromise. `gate()` sends a one-time token ONLY out-of-band, returns `pending`; `POST /signature/confirm {userOpHash, token}` approves; a later sign for the same hash then signs. **Fail-closed**: undeliverable (no contact) → 403. Single-use + TTL. Opt-in (`CONFIRM_ENABLED`). Reuses #52 channels. 53/53 tests (+8). Refs #50, #52.