### PR TITLE
docs(roadmap): refine v1.4.0 notify — Telegram bot to registered account; defer Email/Nostr

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -74,7 +74,9 @@ conformance 基线。
 
 - **BLS 私钥 → KMS/HSM 可插拔 signer**(借 [#62] 的 AWS KMS / Cloudflare
   Secrets 调研)— 安全底线。
-- **Email + Nostr 通知通道**(补齐独立通道)。
+- **Telegram
+  bot 通知到指定已注册账户**:用户把自己的 Telegram 账户注册/绑定到节点,大额共签等事件经 bot 私信发到**该指定账户**(per-account 绑定,非全局频道)。**Email
+  / Nostr 通道延后**(后续版本)。
 - **常驻 Price Keeper Phase 1**([#58]):节点 24/7,顺带兜底链上价格新鲜。
 - **协议 spec + OpenAPI 升为唯一真相源** + `conformance/`
   向量正式纳入 CI([#63])。


### PR DESCRIPTION
Refines the just-merged ROADMAP v1.4.0 scope per review: notification in 1.4.0 = **Telegram bot DM to a specific user-registered Telegram account** (per-account binding, not a global channel); **Email/Nostr deferred** to a later version. KMS/HSM signer + keeper P1 + protocol freeze unchanged. Milestone v1.4.0 description already updated to match.

Docs-only. Normal review — do not self-merge, no protection bypass.