### PR TITLE
feat(v1.4.0): pluggable BlsSigner key-custody port (LocalKeySigner default; KMS/HSM-ready)

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -67,6 +67,11 @@ export default () => {
     rateLimitWindowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS || "60000", 10),
     rateLimitMax: parseInt(process.env.RATE_LIMIT_MAX || "30", 10),
 
+    // BLS key-custody backend (#50; arch #67). "local" (default) = in-process key from
+    // node_state.json. Future: "kms"/"hsm" via a BLS-capable HSM. Signing output is
+    // backend-independent (algorithm/wire is the fixed kernel — see conformance/).
+    signerBackend: process.env.SIGNER_BACKEND || "local",
+
     // Gossip Network
     gossipPublicUrl: process.env.GOSSIP_PUBLIC_URL || `ws://localhost:${port}/ws`,
     gossipBootstrapPeers: parseBootstrapPeers(process.env.GOSSIP_BOOTSTRAP_PEERS || ""),

--- a/src/modules/bls/bls.module.ts
+++ b/src/modules/bls/bls.module.ts
@@ -1,9 +1,10 @@
 import { Module } from "@nestjs/common";
 import { BlsService } from "./bls.service.js";
 import { BlockchainModule } from "../blockchain/blockchain.module.js";
+import { SignerModule } from "../signer/signer.module.js";
 
 @Module({
-  imports: [BlockchainModule],
+  imports: [BlockchainModule, SignerModule],
   providers: [BlsService],
   exports: [BlsService],
 })

--- a/src/modules/bls/bls.service.spec.ts
+++ b/src/modules/bls/bls.service.spec.ts
@@ -26,8 +26,11 @@ jest.unstable_mockModule("../../utils/bls.util.js", () => {
 const { BlsService } = await import("./bls.service.js");
 const { BlockchainService } = await import("../blockchain/blockchain.service.js");
 type BlockchainService = InstanceType<typeof BlockchainService>;
+// LocalKeySigner imports the (mocked) bls.util sigs — must load AFTER the mock above.
+const { LocalKeySigner } = await import("../signer/local-key.signer.js");
 import type { PackedUserOp } from "../blockchain/blockchain.service.js";
 import type { NodeKeyPair } from "../../interfaces/node.interface.js";
+import type { SignerService } from "../signer/signer.service.js";
 
 /**
  * Fix 2 Stage 1 — owner-authorization gate tests.
@@ -86,7 +89,11 @@ describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
     getAccountOwner = jest.fn<(account: string) => Promise<string>>();
     getUserOpHash = jest.fn<(userOp: PackedUserOp) => Promise<string>>();
     const blockchain = { getAccountOwner, getUserOpHash } as unknown as BlockchainService;
-    service = new BlsService(blockchain);
+    // Default local-key signer (byte-identical to the pre-port signing path).
+    const signer = {
+      forNode: (n: { privateKey: string }) => new LocalKeySigner(n.privateKey),
+    } as unknown as SignerService;
+    service = new BlsService(blockchain, signer);
   });
 
   it("signs and returns a signature when ownerAuth recovers to the derived-hash owner", async () => {

--- a/src/modules/bls/bls.service.ts
+++ b/src/modules/bls/bls.service.ts
@@ -4,12 +4,16 @@ import { bls, sigs, BLS_DST, encodeG2Point } from "../../utils/bls.util.js";
 import { SignatureResult } from "../../interfaces/signature.interface.js";
 import { NodeKeyPair } from "../../interfaces/node.interface.js";
 import { BlockchainService, PackedUserOp } from "../blockchain/blockchain.service.js";
+import { SignerService } from "../signer/signer.service.js";
 
 @Injectable()
 export class BlsService {
   private readonly logger = new Logger(BlsService.name);
 
-  constructor(private readonly blockchainService: BlockchainService) {}
+  constructor(
+    private readonly blockchainService: BlockchainService,
+    private readonly signerService: SignerService
+  ) {}
 
   /**
    * Fix 2 Stage 1 — owner-authorization gate.
@@ -146,9 +150,11 @@ export class BlsService {
       DST: BLS_DST,
     });
 
-    const privateKeyBytes = this.hexToBytes(node.privateKey.substring(2));
-    const publicKey = sigs.getPublicKey(privateKeyBytes);
-    const signature = await sigs.sign(messagePoint as any, privateKeyBytes);
+    // Key custody behind the pluggable BlsSigner port (default = local key). The signing
+    // algorithm/wire is unchanged (conformance-bound); only WHERE the key lives is abstracted.
+    const signer = this.signerService.forNode(node);
+    const publicKey = await signer.getPublicKey();
+    const signature = await signer.sign(messagePoint as any);
 
     // Return both compact and EIP-2537 formats
     return {

--- a/src/modules/signer/bls-signer.interface.ts
+++ b/src/modules/signer/bls-signer.interface.ts
@@ -1,0 +1,17 @@
+/**
+ * BlsSigner — the key-CUSTODY port for BLS12-381 co-signing.
+ *
+ * The DVT signing ALGORITHM + wire (hashToCurve/DST/EIP-2537 — see conformance/) is the
+ * fixed kernel and is NOT part of this port: every backend produces a byte-identical
+ * signature for the same messagePoint. This port abstracts only WHERE the private key
+ * lives and how signing is invoked, so a BLS-capable KMS/HSM can drop in (#50) without
+ * touching the verifiable signing logic.
+ */
+export interface BlsSigner {
+  /** backend id for logs/telemetry: "local" | "kms" | "hsm" | ... */
+  readonly backend: string;
+  /** G1 public key (noble point) for this signer's key. */
+  getPublicKey(): Promise<any>;
+  /** Sign a G2 messagePoint (= hashToCurve(userOpHash, DST)); returns a G2 signature point. */
+  sign(messagePoint: any): Promise<any>;
+}

--- a/src/modules/signer/local-key.signer.ts
+++ b/src/modules/signer/local-key.signer.ts
@@ -1,0 +1,27 @@
+import { sigs } from "../../utils/bls.util.js";
+import { BlsSigner } from "./bls-signer.interface.js";
+
+/**
+ * Default signer: the BLS private key is held in-process (from node_state.json).
+ * Behaviourally identical to the pre-port signing path — getPublicKey/sign call the
+ * exact same @noble/curves primitives, so output is byte-for-byte unchanged.
+ */
+export class LocalKeySigner implements BlsSigner {
+  readonly backend = "local";
+  private readonly sk: Uint8Array;
+
+  constructor(privateKeyHex: string) {
+    const h = privateKeyHex.startsWith("0x") ? privateKeyHex.slice(2) : privateKeyHex;
+    const b = new Uint8Array(h.length / 2);
+    for (let i = 0; i < b.length; i++) b[i] = parseInt(h.substr(i * 2, 2), 16);
+    this.sk = b;
+  }
+
+  async getPublicKey(): Promise<any> {
+    return sigs.getPublicKey(this.sk);
+  }
+
+  async sign(messagePoint: any): Promise<any> {
+    return sigs.sign(messagePoint, this.sk);
+  }
+}

--- a/src/modules/signer/signer.module.ts
+++ b/src/modules/signer/signer.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { SignerService } from "./signer.service.js";
+
+@Module({
+  providers: [SignerService],
+  exports: [SignerService],
+})
+export class SignerModule {}

--- a/src/modules/signer/signer.service.spec.ts
+++ b/src/modules/signer/signer.service.spec.ts
@@ -1,0 +1,50 @@
+import { jest } from "@jest/globals";
+
+// Mock bls.util so the test does not pull in the ESM-only curve lib; assert the port
+// delegates to the BLS primitives with the signer's key (custody seam, not the algorithm).
+jest.unstable_mockModule("../../utils/bls.util.js", () => {
+  const getPublicKey = jest.fn((sk: Uint8Array) => ({ kind: "pk", sk }));
+  const sign = jest.fn(async (mp: any, sk: Uint8Array) => ({ kind: "sig", mp, sk }));
+  return {
+    sigs: { getPublicKey, sign },
+    bls: {},
+    BLS_DST: "TEST",
+    encodeG2Point: () => new Uint8Array(256),
+  };
+});
+
+const { LocalKeySigner } = await import("./local-key.signer.js");
+const { SignerService } = await import("./signer.service.js");
+
+describe("SignerService / LocalKeySigner (BLS key-custody port)", () => {
+  const node = { privateKey: "0x" + "00".repeat(31) + "11" } as any;
+
+  it("LocalKeySigner parses 0x-prefixed key and delegates getPublicKey/sign to bls primitives", async () => {
+    const s = new LocalKeySigner(node.privateKey);
+    expect(s.backend).toBe("local");
+    const pk: any = await s.getPublicKey();
+    expect(pk.kind).toBe("pk");
+    expect(pk.sk).toBeInstanceOf(Uint8Array);
+    expect(pk.sk.length).toBe(32);
+    expect(pk.sk[31]).toBe(0x11); // last byte of the key
+    const sig: any = await s.sign({ point: true });
+    expect(sig.kind).toBe("sig");
+    expect(sig.mp).toEqual({ point: true });
+  });
+
+  it("forNode returns a local signer by default", () => {
+    const svc = new SignerService({ get: () => undefined } as any);
+    const signer = svc.forNode(node);
+    expect(signer.backend).toBe("local");
+  });
+
+  it("forNode honors SIGNER_BACKEND=local", () => {
+    const svc = new SignerService({ get: () => "local" } as any);
+    expect(svc.forNode(node).backend).toBe("local");
+  });
+
+  it("forNode throws on an unknown backend (fail-closed, no silent fallback)", () => {
+    const svc = new SignerService({ get: () => "kms" } as any);
+    expect(() => svc.forNode(node)).toThrow(/unknown SIGNER_BACKEND/);
+  });
+});

--- a/src/modules/signer/signer.service.ts
+++ b/src/modules/signer/signer.service.ts
@@ -1,0 +1,30 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { NodeKeyPair } from "../../interfaces/node.interface.js";
+import { BlsSigner } from "./bls-signer.interface.js";
+import { LocalKeySigner } from "./local-key.signer.js";
+
+/**
+ * Pluggable factory for the BLS key-custody backend (#50, arch #67 port-adapter example).
+ * Default `local` reproduces the existing in-process key behaviour exactly. A BLS-capable
+ * KMS/HSM adapter (future) slots in here behind SIGNER_BACKEND — the signing output stays
+ * conformance-identical because the algorithm/wire is the fixed kernel, not part of this seam.
+ */
+@Injectable()
+export class SignerService {
+  private readonly logger = new Logger(SignerService.name);
+
+  constructor(private readonly config: ConfigService) {}
+
+  forNode(node: NodeKeyPair): BlsSigner {
+    const backend = this.config.get<string>("signerBackend") || "local";
+    switch (backend) {
+      case "local":
+        return new LocalKeySigner(node.privateKey);
+      // case "kms": return new KmsSigner(...);  // future (#50): needs a BLS-capable KMS/HSM
+      // case "hsm": return new HsmSigner(...);
+      default:
+        throw new Error(`unknown SIGNER_BACKEND="${backend}" (supported: local)`);
+    }
+  }
+}


### PR DESCRIPTION
First **v1.4.0** feature (branch off `release/v1.4.0`), and the first **port-adapter** example of the microkernel/pluggable-capability direction ([#67]). Foundation for "BLS key → KMS/HSM" ([#50]).

## What
Abstracts **where the BLS private key lives** behind a `BlsSigner` port — **without touching the signing algorithm/wire** (the fixed, conformance-bound kernel).
- `src/modules/signer/`:
  - `BlsSigner` interface (`backend`, `getPublicKey()`, `sign(messagePoint)`).
  - `LocalKeySigner` — default; in-process key from `node_state.json`; byte-identical to the prior path.
  - `SignerService.forNode()` — factory keyed by `SIGNER_BACKEND` (default `local`); **fail-closed** on unknown backend (no silent fallback).
  - `SignerModule`.
- `bls.service.signDerivedHash` signs via the injected signer instead of raw `node.privateKey`. Output unchanged.
- `config`: `SIGNER_BACKEND` (default `local`). The seam a BLS-capable KMS/HSM slots into later.

## Why this shape
DVT core (BLS sign/aggregate/verify, DST, EIP-2537 wire) stays untouched — it's the kernel. Only key **custody** becomes pluggable, so the signature is backend-independent and `conformance/vectors.json` is unchanged.

## Verified
- `type-check` ok · **57/57** unit tests (incl. 4 new signer tests) · `build` ok.
- **`conformance` STILL byte-for-byte identical** — proves signing behaviour is unchanged.

## Target / review
Merges into **`release/v1.4.0`** (aggregation branch). Normal review — do not self-merge, no protection bypass.
