### PR TITLE
feat(v1.4.0): CapabilityRegistry seed — microkernel pluggable-capability foundation

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,10 +6,12 @@ import { BlockchainModule } from "./modules/blockchain/blockchain.module.js";
 import { GossipModule } from "./modules/gossip/gossip.module.js";
 import { DashboardModule } from "./modules/dashboard/dashboard.module.js";
 import { AppConfigModule } from "./config/config.module.js";
+import { CapabilityModule } from "./modules/capability/capability.module.js";
 
 @Module({
   imports: [
-    AppConfigModule, // This must be first to validate env vars on startup
+    AppConfigModule, // must be first — validates env vars on startup
+    CapabilityModule, // global singleton registry; must load before optional modules
     BlsModule,
     NodeModule,
     SignatureModule,

--- a/src/modules/capability/capability-registry.service.spec.ts
+++ b/src/modules/capability/capability-registry.service.spec.ts
@@ -1,0 +1,51 @@
+import { CapabilityRegistry } from "./capability-registry.service.js";
+
+describe("CapabilityRegistry", () => {
+  let registry: CapabilityRegistry;
+
+  beforeEach(() => {
+    registry = new CapabilityRegistry();
+  });
+
+  it("starts empty", () => {
+    expect(registry.list()).toHaveLength(0);
+  });
+
+  it("registers and lists a capability", () => {
+    registry.register({ name: "policy", class: "infra-core", description: "DVT policy gate", enabled: true });
+    const list = registry.list();
+    expect(list).toHaveLength(1);
+    expect(list[0].name).toBe("policy");
+    expect(list[0].enabled).toBe(true);
+  });
+
+  it("isEnabled returns true for an enabled capability", () => {
+    registry.register({ name: "notify", class: "infra-app", description: "notifications", enabled: true });
+    expect(registry.isEnabled("notify")).toBe(true);
+  });
+
+  it("isEnabled returns false for a disabled capability", () => {
+    registry.register({ name: "confirm", class: "infra-app", description: "OOB confirm", enabled: false });
+    expect(registry.isEnabled("confirm")).toBe(false);
+  });
+
+  it("isEnabled returns false for an unregistered name", () => {
+    expect(registry.isEnabled("nonexistent")).toBe(false);
+  });
+
+  it("re-registering the same name overwrites", () => {
+    registry.register({ name: "policy", class: "infra-core", description: "old", enabled: false });
+    registry.register({ name: "policy", class: "infra-core", description: "new", enabled: true });
+    expect(registry.list()).toHaveLength(1);
+    expect(registry.isEnabled("policy")).toBe(true);
+    expect(registry.list()[0].description).toBe("new");
+  });
+
+  it("list returns capabilities sorted by name", () => {
+    registry.register({ name: "notify", class: "infra-app", description: "", enabled: false });
+    registry.register({ name: "confirm", class: "infra-app", description: "", enabled: false });
+    registry.register({ name: "policy", class: "infra-core", description: "", enabled: true });
+    const names = registry.list().map(c => c.name);
+    expect(names).toEqual(["confirm", "notify", "policy"]);
+  });
+});

--- a/src/modules/capability/capability-registry.service.ts
+++ b/src/modules/capability/capability-registry.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from "@nestjs/common";
+import { Capability } from "./capability.interface.js";
+
+/**
+ * Microkernel capability registry (arch #67).
+ *
+ * Each optional module self-registers at construction time. The registry is a
+ * global singleton (CapabilityModule is @Global) so every module can inject it
+ * without re-importing CapabilityModule. Query it for health checks, admin panels,
+ * or startup-time conditional-load decisions.
+ *
+ * Registering the same name twice overwrites — the last constructor to run wins,
+ * which matches NestJS module load order and lets tests re-register freely.
+ */
+@Injectable()
+export class CapabilityRegistry {
+  private readonly capabilities = new Map<string, Capability>();
+
+  register(cap: Capability): void {
+    this.capabilities.set(cap.name, cap);
+  }
+
+  list(): Capability[] {
+    return [...this.capabilities.values()].sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  isEnabled(name: string): boolean {
+    return this.capabilities.get(name)?.enabled ?? false;
+  }
+}

--- a/src/modules/capability/capability.interface.ts
+++ b/src/modules/capability/capability.interface.ts
@@ -1,0 +1,11 @@
+/** 'infra-core' = security-critical kernel (policy gate, key custody).
+ *  'infra-app'  = application-level capability; can be absent without affecting
+ *                 the DVT signing correctness (notifications, confirmation UI). */
+export type CapabilityClass = "infra-core" | "infra-app";
+
+export interface Capability {
+  readonly name: string;
+  readonly class: CapabilityClass;
+  readonly description: string;
+  readonly enabled: boolean;
+}

--- a/src/modules/capability/capability.module.ts
+++ b/src/modules/capability/capability.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from "@nestjs/common";
+import { CapabilityRegistry } from "./capability-registry.service.js";
+
+@Global()
+@Module({
+  providers: [CapabilityRegistry],
+  exports: [CapabilityRegistry],
+})
+export class CapabilityModule {}

--- a/src/modules/confirmation/confirmation.service.ts
+++ b/src/modules/confirmation/confirmation.service.ts
@@ -4,6 +4,7 @@ import { ethers } from "ethers";
 import { randomBytes } from "crypto";
 import { PackedUserOp } from "../blockchain/blockchain.service.js";
 import { NotificationService } from "../notification/notification.service.js";
+import { CapabilityRegistry } from "../capability/capability-registry.service.js";
 
 /** Result of the confirmation gate for a co-sign request. */
 export type GateResult = "not_required" | "confirmed" | "pending" | "undeliverable";
@@ -48,11 +49,18 @@ export class ConfirmationService {
 
   constructor(
     configService: ConfigService,
-    private readonly notificationService: NotificationService
+    private readonly notificationService: NotificationService,
+    capabilityRegistry?: CapabilityRegistry
   ) {
     this.enabled = configService.get<boolean>("confirmEnabled") === true;
     this.thresholdWei = BigInt(configService.get<string>("confirmThresholdWei") ?? "0");
     this.ttlMs = configService.get<number>("confirmTtlMs") ?? 600_000; // 10 min default
+    capabilityRegistry?.register({
+      name: "confirm",
+      class: "infra-app",
+      description: "Out-of-band confirmation gate for high-value ops (#50 ⑤)",
+      enabled: this.enabled,
+    });
     if (this.enabled) {
       this.logger.log(
         `Out-of-band confirmation ENABLED — threshold=${this.thresholdWei} wei, ttl=${this.ttlMs}ms`

--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from "@nestjs/config";
 import { ethers } from "ethers";
 import { existsSync, readFileSync } from "fs";
 import { PackedUserOp } from "../blockchain/blockchain.service.js";
+import { CapabilityRegistry } from "../capability/capability-registry.service.js";
 
 /** Per-account contact targets (loaded from a git-ignored file, never committed). */
 export interface Contact {
@@ -57,10 +58,17 @@ export class NotificationService {
     configService: ConfigService,
     /** Test seam: inject channels/contacts; production builds them from config. */
     channels?: NotificationChannel[],
-    contacts?: Map<string, Contact>
+    contacts?: Map<string, Contact>,
+    capabilityRegistry?: CapabilityRegistry
   ) {
     this.enabled = configService.get<boolean>("notifyEnabled") === true;
     this.thresholdWei = BigInt(configService.get<string>("notifyThresholdWei") ?? "0");
+    capabilityRegistry?.register({
+      name: "notify",
+      class: "infra-app",
+      description: "Large-spend Telegram notification, fire-and-forget (#52)",
+      enabled: this.enabled,
+    });
 
     if (channels) {
       this.channels = channels;

--- a/src/modules/policy/policy.service.ts
+++ b/src/modules/policy/policy.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { ethers } from "ethers";
 import { PackedUserOp, BlockchainService } from "../blockchain/blockchain.service.js";
+import { CapabilityRegistry } from "../capability/capability-registry.service.js";
 
 /**
  * Fix 2 Stage 2 — DVT node INDEPENDENT policy gate (owner-compromise protection).
@@ -97,9 +98,16 @@ export class PolicyService {
 
   constructor(
     private readonly configService: ConfigService,
-    private readonly blockchainService: BlockchainService
+    private readonly blockchainService: BlockchainService,
+    capabilityRegistry?: CapabilityRegistry
   ) {
     this.enabled = this.configService.get<boolean>("policyEnabled") === true;
+    capabilityRegistry?.register({
+      name: "policy",
+      class: "infra-core",
+      description: "DVT independent signing policy gate (Fix 2 Stage 2, #40)",
+      enabled: this.enabled,
+    });
     const max = this.configService.get<string>("policyPerTxMaxWei");
     this.perTxMaxWei = max ? BigInt(max) : null;
     const allow = this.configService.get<string[]>("policyRecipientAllowlist") ?? [];


### PR DESCRIPTION
## Summary

- Introduces `Capability` descriptor type (`infra-core` | `infra-app`) and `CapabilityRegistry` global singleton (arch #67)
- Three optional capabilities self-register at construction time: `policy` (infra-core), `notify` (infra-app), `confirm` (infra-app)
- `CapabilityModule` is `@Global()` — any future module injects `CapabilityRegistry` without re-importing
- Optional `capabilityRegistry?` param pattern: existing tests unchanged; production NestJS DI injects the registry

## Files

| File | Change |
|------|--------|
| `src/modules/capability/capability.interface.ts` | `CapabilityClass` + `Capability` types |
| `src/modules/capability/capability-registry.service.ts` | `register / list / isEnabled` |
| `src/modules/capability/capability.module.ts` | `@Global()` NestJS module |
| `src/modules/capability/capability-registry.service.spec.ts` | 7 unit tests |
| `src/app.module.ts` | `CapabilityModule` imported before optional modules |
| `PolicyService / NotificationService / ConfirmationService` | self-register via optional param |

## Test plan

- [x] `npm run type-check` — clean
- [x] `jest` — 8 suites / 64 tests green (+1 suite +7 tests)
- [x] Existing policy / notification / confirmation specs unchanged — no breaking change

Targets `release/v1.4.0` aggregation branch.