### PR TITLE
feat(v1.4.0): Price Keeper Phase 1 — Chainlink oracle staleness guard (#58)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { GossipModule } from "./modules/gossip/gossip.module.js";
 import { DashboardModule } from "./modules/dashboard/dashboard.module.js";
 import { AppConfigModule } from "./config/config.module.js";
 import { CapabilityModule } from "./modules/capability/capability.module.js";
+import { KeeperModule } from "./modules/keeper/keeper.module.js";
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { CapabilityModule } from "./modules/capability/capability.module.js";
     BlockchainModule,
     GossipModule,
     DashboardModule,
+    KeeperModule,
   ],
 })
 export class AppModule {}

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -72,6 +72,19 @@ export default () => {
     // backend-independent (algorithm/wire is the fixed kernel — see conformance/).
     signerBackend: process.env.SIGNER_BACKEND || "local",
 
+    // Price Keeper (#58). Opt-in; keeps SuperPaymaster cachedPrice permanently fresh via
+    // on-chain updatePrice() calls when approaching the staleness threshold. Requires
+    // ETH_PRIVATE_KEY (or a dedicated KEEPER_PRIVATE_KEY in a future phase). Default off.
+    // KEEPER_CHAINLINK_FEED defaults to the canonical Sepolia ETH/USD feed.
+    keeperEnabled: process.env.KEEPER_ENABLED === "true",
+    keeperIntervalMs: parseInt(process.env.KEEPER_INTERVAL_MS || "60000", 10),
+    keeperRefreshBufferS: process.env.KEEPER_REFRESH_BUFFER_S || "300",
+    keeperMaxUpdatesPerDay: parseInt(process.env.KEEPER_MAX_UPDATES_PER_DAY || "48", 10),
+    keeperMaxBaseFeeGwei: process.env.KEEPER_MAX_BASE_FEE_GWEI || "50",
+    keeperPaymasterAddress: process.env.KEEPER_PAYMASTER_ADDRESS || "",
+    keeperChainlinkFeed:
+      process.env.KEEPER_CHAINLINK_FEED || "0x694AA1769357215DE4FAC081bf1f309aDC325306",
+
     // Gossip Network
     gossipPublicUrl: process.env.GOSSIP_PUBLIC_URL || `ws://localhost:${port}/ws`,
     gossipBootstrapPeers: parseBootstrapPeers(process.env.GOSSIP_BOOTSTRAP_PEERS || ""),

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -367,4 +367,55 @@ export class BlockchainService {
       throw error;
     }
   }
+
+  // ── Price Keeper (Phase 1, #58) ────────────────────────────────────────────
+
+  /**
+   * Read SuperPaymaster's cached-price freshness info.
+   * ABI confirmed against SuperPaymaster v5.4.x `getCachedPriceInfo()` + `priceStalenessThreshold()`.
+   */
+  async getPriceInfo(
+    paymasterAddress: string
+  ): Promise<{ updatedAt: bigint; threshold: bigint }> {
+    const abi = [
+      "function getCachedPriceInfo() view returns (uint256 price, uint256 updatedAt)",
+      "function priceStalenessThreshold() view returns (uint256)",
+    ];
+    const contract = new ethers.Contract(paymasterAddress, abi, this.provider);
+    const [, updatedAt] = await contract.getCachedPriceInfo();
+    const threshold = await contract.priceStalenessThreshold();
+    return { updatedAt: BigInt(updatedAt), threshold: BigInt(threshold) };
+  }
+
+  /** Read Chainlink AggregatorV3 `latestRoundData().updatedAt` (unix seconds). */
+  async getChainlinkUpdatedAt(feedAddress: string): Promise<bigint> {
+    const abi = [
+      "function latestRoundData() view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)",
+    ];
+    const contract = new ethers.Contract(feedAddress, abi, this.provider);
+    const [, , , updatedAt] = await contract.latestRoundData();
+    return BigInt(updatedAt);
+  }
+
+  /** Current network base-fee in gwei (0 on chains without EIP-1559). */
+  async getBaseFeeGwei(): Promise<bigint> {
+    const block = await this.provider.getBlock("latest");
+    const baseFee = block?.baseFeePerGas ?? 0n;
+    return BigInt(baseFee) / 1_000_000_000n;
+  }
+
+  /**
+   * Call SuperPaymaster.updatePrice() — pushes a fresh Chainlink price on-chain.
+   * Requires a wallet (ETH_PRIVATE_KEY or KEEPER_PRIVATE_KEY).
+   * Returns the transaction hash.
+   */
+  async updatePrice(paymasterAddress: string): Promise<string> {
+    if (!this.wallet) {
+      throw new Error("Keeper: no wallet configured — set ETH_PRIVATE_KEY or KEEPER_PRIVATE_KEY");
+    }
+    const abi = ["function updatePrice() external"];
+    const contract = new ethers.Contract(paymasterAddress, abi, this.wallet);
+    const tx: ethers.TransactionResponse = await contract.updatePrice();
+    return tx.hash;
+  }
 }

--- a/src/modules/keeper/keeper.module.ts
+++ b/src/modules/keeper/keeper.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { KeeperService } from "./keeper.service.js";
+import { BlockchainModule } from "../blockchain/blockchain.module.js";
+import { NotificationModule } from "../notification/notification.module.js";
+
+@Module({
+  imports: [BlockchainModule, NotificationModule],
+  providers: [KeeperService],
+  exports: [KeeperService],
+})
+export class KeeperModule {}

--- a/src/modules/keeper/keeper.service.spec.ts
+++ b/src/modules/keeper/keeper.service.spec.ts
@@ -1,0 +1,190 @@
+import { KeeperService } from "./keeper.service.js";
+
+const PAYMASTER = "0x" + "12".repeat(20);
+const CHAINLINK = "0x" + "34".repeat(20);
+
+const BASE_CONFIG: Record<string, unknown> = {
+  keeperEnabled: true,
+  keeperIntervalMs: 60_000,
+  keeperRefreshBufferS: "300",
+  keeperMaxUpdatesPerDay: 48,
+  keeperMaxBaseFeeGwei: "50",
+  keeperPaymasterAddress: PAYMASTER,
+  keeperChainlinkFeed: CHAINLINK,
+};
+
+function makeConfig(overrides: Record<string, unknown> = {}) {
+  const cfg = { ...BASE_CONFIG, ...overrides };
+  return { get: (k: string) => cfg[k] } as any;
+}
+
+function makeBlockchain(
+  overrides: Partial<{
+    getPriceInfo: () => Promise<{ updatedAt: bigint; threshold: bigint }>;
+    getChainlinkUpdatedAt: () => Promise<bigint>;
+    getBaseFeeGwei: () => Promise<bigint>;
+    updatePrice: () => Promise<string>;
+  }> = {}
+): any {
+  return {
+    getPriceInfo: overrides.getPriceInfo ?? (async () => ({ updatedAt: 1000n, threshold: 3600n })),
+    getChainlinkUpdatedAt: overrides.getChainlinkUpdatedAt ?? (async () => 2000n),
+    getBaseFeeGwei: overrides.getBaseFeeGwei ?? (async () => 10n),
+    updatePrice: overrides.updatePrice ?? (async () => "0xabc"),
+  };
+}
+
+function makeNotify() {
+  const sent: string[] = [];
+  return {
+    sent,
+    sendToAccount: async (_: string, msg: string) => {
+      sent.push(msg);
+      return true;
+    },
+  } as any;
+}
+
+function makeRegistry() {
+  const registered: string[] = [];
+  return {
+    registered,
+    register: (cap: { name: string }) => registered.push(cap.name),
+  } as any;
+}
+
+/** Fixed clock at t=now (unix ms). Allows overriding "now" for time-based guardrail tests. */
+function clockAt(nowMs: number) {
+  return () => nowMs;
+}
+
+// A "now" where the price (updatedAt=1000s, threshold=3600s) is near expiry:
+// age = nowS - 1000, timeUntilStale = 3600 - age. For timeUntilStale ≤ 300 (buffer):
+// nowS ≥ 1000 + 3600 - 300 = 4300 → nowMs ≥ 4_300_000
+const NOW_NEAR_EXPIRY = clockAt(4_350_000); // timeUntilStale = 3600 - (4350 - 1000) = 250s ≤ 300
+
+describe("KeeperService", () => {
+  it("registers capability as disabled when KEEPER_ENABLED=false", () => {
+    const registry = makeRegistry();
+    new KeeperService(
+      makeBlockchain(),
+      makeNotify(),
+      makeConfig({ keeperEnabled: false }),
+      clockAt(0),
+      registry
+    );
+    expect(registry.registered).toContain("keeper");
+  });
+
+  it("registers capability as enabled when KEEPER_ENABLED=true", () => {
+    const registry = makeRegistry();
+    new KeeperService(makeBlockchain(), makeNotify(), makeConfig(), clockAt(0), registry);
+    expect(registry.registered).toContain("keeper");
+  });
+
+  it("tick: skips when price is still fresh (timeUntilStale > buffer)", async () => {
+    // nowS=1100 → age=100 → timeUntilStale=3500 > 300 → skip
+    const blockchain = makeBlockchain({
+      getPriceInfo: async () => ({ updatedAt: 1000n, threshold: 3600n }),
+      updatePrice: async () => { throw new Error("should not be called"); },
+    });
+    const svc = new KeeperService(makeBlockchain(blockchain as any), makeNotify(), makeConfig(), clockAt(1_100_000));
+    await svc.tick();
+    // no throw → update was NOT called
+  });
+
+  it("tick: skips when Chainlink has not updated since last cached price", async () => {
+    const updatePriceCalled: boolean[] = [];
+    const blockchain = makeBlockchain({
+      getChainlinkUpdatedAt: async () => 999n, // ≤ updatedAt=1000 → skip
+      updatePrice: async () => { updatePriceCalled.push(true); return "0x"; },
+    });
+    const svc = new KeeperService(blockchain, makeNotify(), makeConfig(), NOW_NEAR_EXPIRY);
+    await svc.tick();
+    expect(updatePriceCalled).toHaveLength(0);
+  });
+
+  it("tick: skips when baseFee exceeds max", async () => {
+    const updatePriceCalled: boolean[] = [];
+    const blockchain = makeBlockchain({
+      getBaseFeeGwei: async () => 100n, // > maxBaseFeeGwei=50
+      updatePrice: async () => { updatePriceCalled.push(true); return "0x"; },
+    });
+    const svc = new KeeperService(blockchain, makeNotify(), makeConfig(), NOW_NEAR_EXPIRY);
+    await svc.tick();
+    expect(updatePriceCalled).toHaveLength(0);
+  });
+
+  it("tick: calls updatePrice when all conditions met", async () => {
+    const updatePriceCalled: string[] = [];
+    const blockchain = makeBlockchain({
+      updatePrice: async () => { updatePriceCalled.push("called"); return "0xTXHASH"; },
+    });
+    const svc = new KeeperService(blockchain, makeNotify(), makeConfig(), NOW_NEAR_EXPIRY);
+    await svc.tick();
+    expect(updatePriceCalled).toHaveLength(1);
+  });
+
+  it("tick: skips when daily cap reached", async () => {
+    const updatePriceCalled: boolean[] = [];
+    const blockchain = makeBlockchain({
+      updatePrice: async () => { updatePriceCalled.push(true); return "0x"; },
+    });
+    const svc = new KeeperService(
+      blockchain,
+      makeNotify(),
+      makeConfig({ keeperMaxUpdatesPerDay: 2 }),
+      NOW_NEAR_EXPIRY
+    );
+    // Drain the cap
+    await svc.tick();
+    await svc.tick();
+    expect(updatePriceCalled).toHaveLength(2);
+    // 3rd tick should be blocked by cap
+    await svc.tick();
+    expect(updatePriceCalled).toHaveLength(2);
+  });
+
+  it("tick: does not throw when updatePrice fails — sends notification", async () => {
+    const notify = makeNotify();
+    const blockchain = makeBlockchain({
+      updatePrice: async () => { throw new Error("reverted"); },
+    });
+    const svc = new KeeperService(blockchain, notify, makeConfig(), NOW_NEAR_EXPIRY);
+    await expect(svc.tick()).resolves.toBeUndefined(); // must not throw
+    // give fire-and-forget a microtask to settle
+    await Promise.resolve();
+    expect((notify.sent as string[]).some((m: string) => m.includes("reverted"))).toBe(true);
+  });
+
+  it("tick: daily counter resets on a new day", async () => {
+    const updatePriceCalled: boolean[] = [];
+    const blockchain = makeBlockchain({
+      updatePrice: async () => { updatePriceCalled.push(true); return "0x"; },
+    });
+    // Day 0: t=4_350_000 (near expiry, day 0 = floor(4350000/86400000)=0)
+    let now = 4_350_000;
+    const svc = new KeeperService(
+      blockchain,
+      makeNotify(),
+      makeConfig({ keeperMaxUpdatesPerDay: 1 }),
+      () => now
+    );
+    await svc.tick(); // uses the cap → cap exhausted for day 0
+    expect(updatePriceCalled).toHaveLength(1);
+    await svc.tick(); // still day 0, cap=1 → skip
+    expect(updatePriceCalled).toHaveLength(1);
+    // Advance clock to day 1
+    now = 86_400_000 + 4_350_000;
+    await svc.tick(); // new day → counter reset → updatePrice() called again
+    expect(updatePriceCalled).toHaveLength(2);
+  });
+
+  it("onApplicationShutdown clears the timer", () => {
+    const svc = new KeeperService(makeBlockchain(), makeNotify(), makeConfig(), clockAt(0));
+    svc.onApplicationBootstrap();
+    expect((svc as any).timer).not.toBeNull();
+    svc.onApplicationShutdown();
+    expect((svc as any).timer).toBeNull();
+  });
+});

--- a/src/modules/keeper/keeper.service.ts
+++ b/src/modules/keeper/keeper.service.ts
@@ -1,0 +1,165 @@
+import { Injectable, Logger, OnApplicationBootstrap, OnApplicationShutdown } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { BlockchainService } from "../blockchain/blockchain.service.js";
+import { NotificationService } from "../notification/notification.service.js";
+import { CapabilityRegistry } from "../capability/capability-registry.service.js";
+
+/**
+ * Price Keeper Phase 1 (#58) — keeps SuperPaymaster cachedPrice permanently fresh.
+ *
+ * Opt-in (KEEPER_ENABLED, default off). When enabled, runs a periodic check:
+ * if the cached price is approaching its staleness threshold AND Chainlink has a
+ * fresh reading, calls updatePrice() on-chain to refresh it. Without this keeper,
+ * the node operator would have to manually trigger updates or wait for a user
+ * transaction to refresh the price.
+ *
+ * Guardrails (all configurable via env):
+ *   - KEEPER_REFRESH_BUFFER_S: trigger update when ≤N seconds before stale (default 300)
+ *   - KEEPER_MAX_UPDATES_PER_DAY: daily cap, resets at UTC midnight (default 48)
+ *   - KEEPER_MAX_BASE_FEE_GWEI: skip if network baseFee too high (default 50 gwei)
+ *
+ * Multi-node dedup: rely on the on-chain gas-saving strategy (only update near
+ * expiry) — two nodes rarely hit the same update window simultaneously. Phase 2
+ * may add jitter or leader election if needed.
+ *
+ * Phase 2 adds CEX price failover when Chainlink is stale/unresponsive.
+ */
+@Injectable()
+export class KeeperService implements OnApplicationBootstrap, OnApplicationShutdown {
+  private readonly logger = new Logger(KeeperService.name);
+  private readonly enabled: boolean;
+  private readonly intervalMs: number;
+  private readonly refreshBufferS: bigint;
+  private readonly maxUpdatesPerDay: number;
+  private readonly maxBaseFeeGwei: bigint;
+  private readonly paymasterAddress: string;
+  private readonly chainlinkFeed: string;
+  private readonly clock: () => number;
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private updatesToday = 0;
+  private lastDayNumber = 0;
+
+  constructor(
+    private readonly blockchainService: BlockchainService,
+    private readonly notificationService: NotificationService,
+    private readonly config: ConfigService,
+    /** Test seam: controls `Date.now()` so time-based logic is deterministic. */
+    clock?: () => number,
+    capabilityRegistry?: CapabilityRegistry
+  ) {
+    this.enabled = config.get<boolean>("keeperEnabled") === true;
+    this.intervalMs = config.get<number>("keeperIntervalMs") ?? 60_000;
+    this.refreshBufferS = BigInt(config.get<string>("keeperRefreshBufferS") ?? "300");
+    this.maxUpdatesPerDay = config.get<number>("keeperMaxUpdatesPerDay") ?? 48;
+    this.maxBaseFeeGwei = BigInt(config.get<string>("keeperMaxBaseFeeGwei") ?? "50");
+    this.paymasterAddress = config.get<string>("keeperPaymasterAddress") ?? "";
+    this.chainlinkFeed = config.get<string>("keeperChainlinkFeed") ?? "";
+    this.clock = clock ?? (() => Date.now());
+
+    capabilityRegistry?.register({
+      name: "keeper",
+      class: "infra-app",
+      description: "Chainlink price keeper — keeps SuperPaymaster cachedPrice fresh (#58)",
+      enabled: this.enabled,
+    });
+  }
+
+  onApplicationBootstrap(): void {
+    if (!this.enabled) return;
+    if (!this.paymasterAddress) {
+      this.logger.warn("Keeper: KEEPER_ENABLED=true but KEEPER_PAYMASTER_ADDRESS not set — disabled");
+      return;
+    }
+    this.lastDayNumber = this.todayNumber();
+    this.timer = setInterval(
+      () => void this.tick().catch(e => this.logger.error(`Keeper tick error: ${String(e)}`)),
+      this.intervalMs
+    );
+    this.logger.log(
+      `Price Keeper ENABLED — interval=${this.intervalMs}ms paymaster=${this.paymasterAddress} ` +
+        `buffer=${this.refreshBufferS}s cap=${this.maxUpdatesPerDay}/day maxBaseFee=${this.maxBaseFeeGwei}gwei`
+    );
+  }
+
+  onApplicationShutdown(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * One keeper cycle. Called on every interval tick. Returns without throwing;
+   * errors are logged and (if notify configured) delivered out-of-band.
+   */
+  async tick(): Promise<void> {
+    // Reset daily counter at UTC midnight.
+    const today = this.todayNumber();
+    if (today !== this.lastDayNumber) {
+      this.updatesToday = 0;
+      this.lastDayNumber = today;
+    }
+
+    if (this.updatesToday >= this.maxUpdatesPerDay) {
+      this.logger.debug(
+        `Keeper: daily cap reached (${this.updatesToday}/${this.maxUpdatesPerDay}), skipping`
+      );
+      return;
+    }
+
+    // Read on-chain price freshness.
+    const { updatedAt, threshold } = await this.blockchainService.getPriceInfo(
+      this.paymasterAddress
+    );
+    const nowS = BigInt(Math.floor(this.clock() / 1000));
+    const age = nowS - updatedAt;
+    const timeUntilStale = threshold - age;
+
+    if (timeUntilStale > this.refreshBufferS) {
+      this.logger.debug(
+        `Keeper: price fresh — stale in ${timeUntilStale}s (buffer=${this.refreshBufferS}s)`
+      );
+      return;
+    }
+
+    // Only update if Chainlink has a reading newer than our cached price.
+    const chainlinkUpdatedAt = await this.blockchainService.getChainlinkUpdatedAt(
+      this.chainlinkFeed
+    );
+    if (chainlinkUpdatedAt <= updatedAt) {
+      this.logger.debug(
+        `Keeper: Chainlink not updated since last price (chainlink=${chainlinkUpdatedAt} ≤ price=${updatedAt}), skipping`
+      );
+      return;
+    }
+
+    // Guardrail: skip if gas is expensive.
+    const baseFeeGwei = await this.blockchainService.getBaseFeeGwei();
+    if (baseFeeGwei > this.maxBaseFeeGwei) {
+      this.logger.warn(
+        `Keeper: baseFee ${baseFeeGwei} gwei > max ${this.maxBaseFeeGwei} gwei, skipping`
+      );
+      return;
+    }
+
+    try {
+      const txHash = await this.blockchainService.updatePrice(this.paymasterAddress);
+      this.updatesToday++;
+      this.logger.log(
+        `Keeper: updatePrice() → ${txHash} (${this.updatesToday}/${this.maxUpdatesPerDay} today)`
+      );
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(`Keeper: updatePrice() failed — ${msg}`);
+      // Fire-and-forget alert (notification failure must never block the keeper loop).
+      void this.notificationService
+        .sendToAccount(this.paymasterAddress, `[Keeper] updatePrice failed: ${msg}`)
+        .catch(() => {});
+    }
+  }
+
+  private todayNumber(): number {
+    return Math.floor(this.clock() / 86_400_000);
+  }
+}


### PR DESCRIPTION
## Summary

- Opt-in (`KEEPER_ENABLED`, default off) resident scheduler service that keeps SuperPaymaster `cachedPrice` permanently fresh via on-chain `updatePrice()` calls
- Fires only when: cached price approaching staleness threshold **AND** Chainlink has a newer reading
- Three configurable guardrails: refresh buffer, daily cap, max base-fee
- Registers `keeper` (infra-app) with `CapabilityRegistry` — fits the v1.4.0 pluggable-capability architecture
- `updatePrice()` failures: logged + fire-and-forget notify, never blocks the keeper loop
- Adds 4 new methods to `BlockchainService`: `getPriceInfo / getChainlinkUpdatedAt / getBaseFeeGwei / updatePrice`

## Config env vars

| Var | Default | Description |
|-----|---------|-------------|
| `KEEPER_ENABLED` | `false` | opt-in |
| `KEEPER_PAYMASTER_ADDRESS` | (required if enabled) | SuperPaymaster contract |
| `KEEPER_CHAINLINK_FEED` | Sepolia ETH/USD | Chainlink AggregatorV3 feed |
| `KEEPER_INTERVAL_MS` | `60000` | poll interval |
| `KEEPER_REFRESH_BUFFER_S` | `300` | update when ≤N seconds before stale |
| `KEEPER_MAX_UPDATES_PER_DAY` | `48` | daily cap (resets UTC midnight) |
| `KEEPER_MAX_BASE_FEE_GWEI` | `50` | skip if gas too expensive |

## Test plan

- [x] `npm run type-check` — clean
- [x] `jest` — 9 suites / 74 tests green (+1 suite +10 tests)
- [x] All guardrails tested: fresh skip / Chainlink not updated / baseFee too high / daily cap / daily reset / shutdown cleanup / updatePrice failure

Targets `release/v1.4.0` aggregation branch.