### PR TITLE
feat(v1.4.0): keeper startup jitter — deconflict redundant multi-keeper updatePrice (#58)

### DIFF
--- a/src/modules/keeper/keeper.service.spec.ts
+++ b/src/modules/keeper/keeper.service.spec.ts
@@ -1,3 +1,4 @@
+import { jest } from "@jest/globals";
 import { KeeperService } from "./keeper.service.js";
 
 const PAYMASTER = "0x" + "12".repeat(20);
@@ -86,9 +87,16 @@ describe("KeeperService", () => {
     // nowS=1100 → age=100 → timeUntilStale=3500 > 300 → skip
     const blockchain = makeBlockchain({
       getPriceInfo: async () => ({ updatedAt: 1000n, threshold: 3600n }),
-      updatePrice: async () => { throw new Error("should not be called"); },
+      updatePrice: async () => {
+        throw new Error("should not be called");
+      },
     });
-    const svc = new KeeperService(makeBlockchain(blockchain as any), makeNotify(), makeConfig(), clockAt(1_100_000));
+    const svc = new KeeperService(
+      makeBlockchain(blockchain as any),
+      makeNotify(),
+      makeConfig(),
+      clockAt(1_100_000)
+    );
     await svc.tick();
     // no throw → update was NOT called
   });
@@ -97,7 +105,10 @@ describe("KeeperService", () => {
     const updatePriceCalled: boolean[] = [];
     const blockchain = makeBlockchain({
       getChainlinkUpdatedAt: async () => 999n, // ≤ updatedAt=1000 → skip
-      updatePrice: async () => { updatePriceCalled.push(true); return "0x"; },
+      updatePrice: async () => {
+        updatePriceCalled.push(true);
+        return "0x";
+      },
     });
     const svc = new KeeperService(blockchain, makeNotify(), makeConfig(), NOW_NEAR_EXPIRY);
     await svc.tick();
@@ -108,7 +119,10 @@ describe("KeeperService", () => {
     const updatePriceCalled: boolean[] = [];
     const blockchain = makeBlockchain({
       getBaseFeeGwei: async () => 100n, // > maxBaseFeeGwei=50
-      updatePrice: async () => { updatePriceCalled.push(true); return "0x"; },
+      updatePrice: async () => {
+        updatePriceCalled.push(true);
+        return "0x";
+      },
     });
     const svc = new KeeperService(blockchain, makeNotify(), makeConfig(), NOW_NEAR_EXPIRY);
     await svc.tick();
@@ -118,7 +132,10 @@ describe("KeeperService", () => {
   it("tick: calls updatePrice when all conditions met", async () => {
     const updatePriceCalled: string[] = [];
     const blockchain = makeBlockchain({
-      updatePrice: async () => { updatePriceCalled.push("called"); return "0xTXHASH"; },
+      updatePrice: async () => {
+        updatePriceCalled.push("called");
+        return "0xTXHASH";
+      },
     });
     const svc = new KeeperService(blockchain, makeNotify(), makeConfig(), NOW_NEAR_EXPIRY);
     await svc.tick();
@@ -128,7 +145,10 @@ describe("KeeperService", () => {
   it("tick: skips when daily cap reached", async () => {
     const updatePriceCalled: boolean[] = [];
     const blockchain = makeBlockchain({
-      updatePrice: async () => { updatePriceCalled.push(true); return "0x"; },
+      updatePrice: async () => {
+        updatePriceCalled.push(true);
+        return "0x";
+      },
     });
     const svc = new KeeperService(
       blockchain,
@@ -148,7 +168,9 @@ describe("KeeperService", () => {
   it("tick: does not throw when updatePrice fails — sends notification", async () => {
     const notify = makeNotify();
     const blockchain = makeBlockchain({
-      updatePrice: async () => { throw new Error("reverted"); },
+      updatePrice: async () => {
+        throw new Error("reverted");
+      },
     });
     const svc = new KeeperService(blockchain, notify, makeConfig(), NOW_NEAR_EXPIRY);
     await expect(svc.tick()).resolves.toBeUndefined(); // must not throw
@@ -160,7 +182,10 @@ describe("KeeperService", () => {
   it("tick: daily counter resets on a new day", async () => {
     const updatePriceCalled: boolean[] = [];
     const blockchain = makeBlockchain({
-      updatePrice: async () => { updatePriceCalled.push(true); return "0x"; },
+      updatePrice: async () => {
+        updatePriceCalled.push(true);
+        return "0x";
+      },
     });
     // Day 0: t=4_350_000 (near expiry, day 0 = floor(4350000/86400000)=0)
     let now = 4_350_000;
@@ -180,11 +205,68 @@ describe("KeeperService", () => {
     expect(updatePriceCalled).toHaveLength(2);
   });
 
-  it("onApplicationShutdown clears the timer", () => {
+  it("onApplicationShutdown clears the startup timer scheduled at bootstrap", () => {
     const svc = new KeeperService(makeBlockchain(), makeNotify(), makeConfig(), clockAt(0));
     svc.onApplicationBootstrap();
-    expect((svc as any).timer).not.toBeNull();
-    svc.onApplicationShutdown();
+    // First tick is phase-jittered via setTimeout, so the interval timer is not
+    // armed yet — the startup timer holds the pending first tick.
+    expect((svc as any).startupTimer).not.toBeNull();
     expect((svc as any).timer).toBeNull();
+    svc.onApplicationShutdown();
+    expect((svc as any).startupTimer).toBeNull();
+    expect((svc as any).timer).toBeNull();
+  });
+
+  it("computeJitterMs: phase offset stays within [0, intervalMs)", () => {
+    const mk = (rand: number) =>
+      new KeeperService(
+        makeBlockchain(),
+        makeNotify(),
+        makeConfig({ keeperIntervalMs: 60_000 }),
+        clockAt(0),
+        undefined,
+        () => rand
+      );
+    expect(mk(0).computeJitterMs()).toBe(0);
+    expect(mk(0.5).computeJitterMs()).toBe(30_000);
+    // random() is in [0,1); the offset must never reach the full interval.
+    expect(mk(0.999999).computeJitterMs()).toBeLessThan(60_000);
+    expect(mk(0.999999).computeJitterMs()).toBeGreaterThanOrEqual(0);
+  });
+
+  it("jitter: first tick fires after the offset, then the interval is armed", async () => {
+    jest.useFakeTimers();
+    try {
+      const updates: boolean[] = [];
+      const blockchain = makeBlockchain({
+        getPriceInfo: async () => ({ updatedAt: 1000n, threshold: 3600n }),
+        updatePrice: async () => {
+          updates.push(true);
+          return "0x";
+        },
+      });
+      const svc = new KeeperService(
+        blockchain,
+        makeNotify(),
+        makeConfig({ keeperIntervalMs: 60_000 }),
+        NOW_NEAR_EXPIRY,
+        undefined,
+        () => 0.5 // jitter = 30_000ms
+      );
+      svc.onApplicationBootstrap();
+      expect((svc as any).startupTimer).not.toBeNull();
+
+      // advanceTimersByTimeAsync flushes the awaited microtasks in tick()
+      // between timer callbacks, so the full async chain settles.
+      await jest.advanceTimersByTimeAsync(30_000);
+      expect(updates).toHaveLength(1);
+      expect((svc as any).startupTimer).toBeNull();
+      expect((svc as any).timer).not.toBeNull();
+
+      svc.onApplicationShutdown();
+      expect((svc as any).timer).toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/src/modules/keeper/keeper.service.ts
+++ b/src/modules/keeper/keeper.service.ts
@@ -18,9 +18,13 @@ import { CapabilityRegistry } from "../capability/capability-registry.service.js
  *   - KEEPER_MAX_UPDATES_PER_DAY: daily cap, resets at UTC midnight (default 48)
  *   - KEEPER_MAX_BASE_FEE_GWEI: skip if network baseFee too high (default 50 gwei)
  *
- * Multi-node dedup: rely on the on-chain gas-saving strategy (only update near
- * expiry) — two nodes rarely hit the same update window simultaneously. Phase 2
- * may add jitter or leader election if needed.
+ * Multi-node redundancy (3-5 keepers per chain for failover): each keeper is
+ * idempotent — it checks the on-chain price first and skips if still fresh, so
+ * once any keeper updates, the rest see a fresh price and skip. To stop several
+ * keepers that boot together from hitting the same staleness window in the same
+ * tick and firing duplicate updatePrice() txs, the first tick is phase-jittered
+ * across [0, intervalMs). A coordination registry / lease is deferred until the
+ * duplicate-tx rate actually warrants it.
  *
  * Phase 2 adds CEX price failover when Chainlink is stale/unresponsive.
  */
@@ -35,7 +39,9 @@ export class KeeperService implements OnApplicationBootstrap, OnApplicationShutd
   private readonly paymasterAddress: string;
   private readonly chainlinkFeed: string;
   private readonly clock: () => number;
+  private readonly random: () => number;
 
+  private startupTimer: ReturnType<typeof setTimeout> | null = null;
   private timer: ReturnType<typeof setInterval> | null = null;
   private updatesToday = 0;
   private lastDayNumber = 0;
@@ -46,7 +52,9 @@ export class KeeperService implements OnApplicationBootstrap, OnApplicationShutd
     private readonly config: ConfigService,
     /** Test seam: controls `Date.now()` so time-based logic is deterministic. */
     clock?: () => number,
-    capabilityRegistry?: CapabilityRegistry
+    capabilityRegistry?: CapabilityRegistry,
+    /** Test seam: controls the startup phase jitter (default Math.random). */
+    random?: () => number
   ) {
     this.enabled = config.get<boolean>("keeperEnabled") === true;
     this.intervalMs = config.get<number>("keeperIntervalMs") ?? 60_000;
@@ -56,6 +64,7 @@ export class KeeperService implements OnApplicationBootstrap, OnApplicationShutd
     this.paymasterAddress = config.get<string>("keeperPaymasterAddress") ?? "";
     this.chainlinkFeed = config.get<string>("keeperChainlinkFeed") ?? "";
     this.clock = clock ?? (() => Date.now());
+    this.random = random ?? (() => Math.random());
 
     capabilityRegistry?.register({
       name: "keeper",
@@ -68,25 +77,44 @@ export class KeeperService implements OnApplicationBootstrap, OnApplicationShutd
   onApplicationBootstrap(): void {
     if (!this.enabled) return;
     if (!this.paymasterAddress) {
-      this.logger.warn("Keeper: KEEPER_ENABLED=true but KEEPER_PAYMASTER_ADDRESS not set — disabled");
+      this.logger.warn(
+        "Keeper: KEEPER_ENABLED=true but KEEPER_PAYMASTER_ADDRESS not set — disabled"
+      );
       return;
     }
     this.lastDayNumber = this.todayNumber();
-    this.timer = setInterval(
-      () => void this.tick().catch(e => this.logger.error(`Keeper tick error: ${String(e)}`)),
-      this.intervalMs
-    );
+    // Phase-jitter the first tick across [0, intervalMs) so redundant keepers
+    // that boot together don't all fire updatePrice() in the same window.
+    const jitterMs = this.computeJitterMs();
+    this.startupTimer = setTimeout(() => {
+      this.startupTimer = null;
+      void this.tick().catch(e => this.logger.error(`Keeper tick error: ${String(e)}`));
+      this.timer = setInterval(
+        () => void this.tick().catch(e => this.logger.error(`Keeper tick error: ${String(e)}`)),
+        this.intervalMs
+      );
+    }, jitterMs);
     this.logger.log(
-      `Price Keeper ENABLED — interval=${this.intervalMs}ms paymaster=${this.paymasterAddress} ` +
-        `buffer=${this.refreshBufferS}s cap=${this.maxUpdatesPerDay}/day maxBaseFee=${this.maxBaseFeeGwei}gwei`
+      `Price Keeper ENABLED — interval=${this.intervalMs}ms jitter=${jitterMs}ms ` +
+        `paymaster=${this.paymasterAddress} buffer=${this.refreshBufferS}s ` +
+        `cap=${this.maxUpdatesPerDay}/day maxBaseFee=${this.maxBaseFeeGwei}gwei`
     );
   }
 
   onApplicationShutdown(): void {
+    if (this.startupTimer !== null) {
+      clearTimeout(this.startupTimer);
+      this.startupTimer = null;
+    }
     if (this.timer !== null) {
       clearInterval(this.timer);
       this.timer = null;
     }
+  }
+
+  /** Startup phase offset in [0, intervalMs). Visible for testing. */
+  computeJitterMs(): number {
+    return Math.floor(this.random() * this.intervalMs);
   }
 
   /**


### PR DESCRIPTION
## What

Phase-jitter the Price Keeper's **first** tick across `[0, intervalMs)` so that **3-5 redundant keepers per chain** (the failover/redundancy model — multiple keepers coexist) that boot together don't all hit the same staleness window in the same tick and fire **duplicate `updatePrice()` txs** (wasted gas, no correctness impact).

## Why

The keeper is already idempotent — `tick()` does **check-first**: it reads the on-chain price and skips if `timeUntilStale > buffer`. So once any keeper updates, the rest see a fresh price and skip. The only remaining waste is the **simultaneous-stale race**: N keepers started at the same millisecond all see stale on the same tick and each submit. Staggering the first tick by a random phase offset means whichever keeper fires first makes the price fresh, and the others skip on their next tick.

This is the cheap, no-shared-state mitigation. A coordination **registry / lease (soft leader)** is intentionally **deferred** until the duplicate-tx rate actually warrants the added state.

## Changes

- `onApplicationBootstrap` schedules the first tick via `setTimeout(jitterMs)`, then arms the regular `setInterval`. `onApplicationShutdown` clears **both** the startup timer and the interval.
- Jitter offset is injectable via a `random?: () => number` test seam (default `Math.random`), mirroring the existing `clock` seam — no DI change in spirit (trailing optional param).
- Docstring updated: the old "Phase 2 may add jitter" note is now implemented.

## Tests (12 pass, full suite 76 pass)

- `computeJitterMs` stays within `[0, intervalMs)` for random `0 / 0.5 / ~1`.
- Fake-timer test: first tick fires after the offset, then the interval is armed; shutdown clears it.
- Updated the shutdown test for the new `startupTimer` → `timer` two-phase lifecycle.

## Review notes

- Base is `release/v1.4.0` (aggregation branch; keeper landed there via #70).
- Local `npm run lint:check` can't run here (`@eslint/js` missing from local node_modules — pre-existing env gap, not in this diff); CI lint unaffected. `type-check` + `prettier --check` + full `jest` all green.
- **Do not self-merge** — needs independent review per branch-protection policy.