### PR TITLE
fix(notification): @Optional() on test-seam params — app fails to boot without it

### DIFF
--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable, Logger, Optional } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { ethers } from "ethers";
 import { existsSync, readFileSync } from "fs";
@@ -55,9 +55,13 @@ export class NotificationService {
 
   constructor(
     configService: ConfigService,
-    /** Test seam: inject channels/contacts; production builds them from config. */
-    channels?: NotificationChannel[],
-    contacts?: Map<string, Contact>
+    /**
+     * Test seam: inject channels/contacts; production builds them from config.
+     * @Optional() is REQUIRED — without it NestJS DI tries to resolve the Array/Map
+     * param types as providers and the app fails to boot (UnknownDependenciesException).
+     */
+    @Optional() channels?: NotificationChannel[],
+    @Optional() contacts?: Map<string, Contact>
   ) {
     this.enabled = configService.get<boolean>("notifyEnabled") === true;
     this.thresholdWei = BigInt(configService.get<string>("notifyThresholdWei") ?? "0");


### PR DESCRIPTION
## 问题
`NotificationService` 的可选测试 seam 参数 `channels?: NotificationChannel[]` / `contacts?: Map` 没有 `@Optional()`。NestJS DI 会把 `Array`/`Map` 当作 provider 去解析并抛 `UnknownDependenciesException`，导致 **应用一启动就崩**（NotificationModule 经 SignatureModule 被加载）。

单元测试是手动 `new NotificationService(...)` 构造的，绕过了 DI，所以一直没暴露这个回归。本地 DVT 集群重启时实测崩溃，日志：`Nest can't resolve dependencies of the NotificationService (ConfigService, ?, Map). argument Array at index [1]`。

## 修复
给两个可选参数加 `@Optional()`。无行为变化：参数为 undefined 时生产仍从配置构建 channels/contacts。

## 验证
- `npm run type-check` ✓
- notification 单测 5/5 ✓
- 本地 3 节点集群重建后 **全部 UP** ✓

## 注意（后续）
`release/v1.4.0` 分支有同类隐患：KeeperService 的 `clock?/random?/capabilityRegistry?` 及 capability 工作给 Notification/Policy/Confirmation 加的 `capabilityRegistry?` 同样缺 `@Optional()`，需要在 v1.4.0 合入前一并修，否则 v1.4.0 也无法启动。

**请独立 review，勿自合。**