### PR TITLE
fix(v1.4.0): @Optional() on all DI test-seam params — v1.4.0 fails to boot without it

### DIFF
--- a/src/modules/confirmation/confirmation.service.ts
+++ b/src/modules/confirmation/confirmation.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable, Logger, Optional } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { ethers } from "ethers";
 import { randomBytes } from "crypto";
@@ -50,7 +50,7 @@ export class ConfirmationService {
   constructor(
     configService: ConfigService,
     private readonly notificationService: NotificationService,
-    capabilityRegistry?: CapabilityRegistry
+    @Optional() capabilityRegistry?: CapabilityRegistry
   ) {
     this.enabled = configService.get<boolean>("confirmEnabled") === true;
     this.thresholdWei = BigInt(configService.get<string>("confirmThresholdWei") ?? "0");

--- a/src/modules/keeper/keeper.service.ts
+++ b/src/modules/keeper/keeper.service.ts
@@ -1,4 +1,10 @@
-import { Injectable, Logger, OnApplicationBootstrap, OnApplicationShutdown } from "@nestjs/common";
+import {
+  Injectable,
+  Logger,
+  Optional,
+  OnApplicationBootstrap,
+  OnApplicationShutdown,
+} from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { BlockchainService } from "../blockchain/blockchain.service.js";
 import { NotificationService } from "../notification/notification.service.js";
@@ -51,10 +57,10 @@ export class KeeperService implements OnApplicationBootstrap, OnApplicationShutd
     private readonly notificationService: NotificationService,
     private readonly config: ConfigService,
     /** Test seam: controls `Date.now()` so time-based logic is deterministic. */
-    clock?: () => number,
-    capabilityRegistry?: CapabilityRegistry,
+    @Optional() clock?: () => number,
+    @Optional() capabilityRegistry?: CapabilityRegistry,
     /** Test seam: controls the startup phase jitter (default Math.random). */
-    random?: () => number
+    @Optional() random?: () => number
   ) {
     this.enabled = config.get<boolean>("keeperEnabled") === true;
     this.intervalMs = config.get<number>("keeperIntervalMs") ?? 60_000;

--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable, Logger, Optional } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { ethers } from "ethers";
 import { existsSync, readFileSync } from "fs";
@@ -57,9 +57,9 @@ export class NotificationService {
   constructor(
     configService: ConfigService,
     /** Test seam: inject channels/contacts; production builds them from config. */
-    channels?: NotificationChannel[],
-    contacts?: Map<string, Contact>,
-    capabilityRegistry?: CapabilityRegistry
+    @Optional() channels?: NotificationChannel[],
+    @Optional() contacts?: Map<string, Contact>,
+    @Optional() capabilityRegistry?: CapabilityRegistry
   ) {
     this.enabled = configService.get<boolean>("notifyEnabled") === true;
     this.thresholdWei = BigInt(configService.get<string>("notifyThresholdWei") ?? "0");

--- a/src/modules/policy/policy.service.ts
+++ b/src/modules/policy/policy.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable, Logger, Optional } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { ethers } from "ethers";
 import { PackedUserOp, BlockchainService } from "../blockchain/blockchain.service.js";
@@ -99,7 +99,7 @@ export class PolicyService {
   constructor(
     private readonly configService: ConfigService,
     private readonly blockchainService: BlockchainService,
-    capabilityRegistry?: CapabilityRegistry
+    @Optional() capabilityRegistry?: CapabilityRegistry
   ) {
     this.enabled = this.configService.get<boolean>("policyEnabled") === true;
     capabilityRegistry?.register({


### PR DESCRIPTION
## 问题
与 master 的 NotificationService DI bug（#84）同根，但 **release/v1.4.0 范围更大**：capability 工作 + keeper 给多个服务加了可选构造参数却没 `@Optional()`，NestJS DI 启动即抛 `UnknownDependenciesException` → **v1.4.0 根本起不来**。单测手动 `new` 构造绕过了 DI，所以一直没暴露。

## 修复（加 @Optional()）
- **KeeperService**：`clock?`、`capabilityRegistry?`、`random?`（Function 类型无法被 DI 解析；且排在 capabilityRegistry 前的参数会先崩）
- **NotificationService**：`channels?`、`contacts?`、`capabilityRegistry?`
- **PolicyService**：`capabilityRegistry?`
- **ConfirmationService**：`capabilityRegistry?`

无行为变化（参数为 undefined 时仍回退到 config / Date.now / Math.random）。

## 验证
- `npm run type-check` ✓
- 全套 **76 测试** ✓
- 🔬 **真实 boot 冒烟**：构建 v1.4.0 并实际启动一个节点 → 到达 `Nest application successfully started`，`UnknownDependenciesException` 计数 = **0**（修复前此处崩溃）；PolicyService / Gossip 正常初始化。

## 关系
- master 侧的对应修复是 #84（仅 NotificationService）。本 PR 覆盖 v1.4.0 全部受影响服务。

**请独立 review，勿自合。**