### PR TITLE
chore: migrate to airaccount-contract v0.20.0 BLS validator (re-pin + env unify)

### DIFF
--- a/docs/TESTNET_RELEASE_PLAN.md
+++ b/docs/TESTNET_RELEASE_PLAN.md
@@ -33,12 +33,12 @@
 
 ### 1.1 依赖清单（本节点绑定的上下游，来源 `scripts/check-deps.mjs`）
 
-| 角色     | 仓库                | 绑定物                                          | 当前 pin                         | 校验维度               |
-| -------- | ------------------- | ----------------------------------------------- | -------------------------------- | ---------------------- |
-| **上游** | SuperPaymaster      | `PolicyRegistry.checkPolicy`（layer-1 策略）    | `v5.4.0-beta.1` · `0x8c2488…`    | 地址 + 源码 diff + ABI |
-| **下游** | airaccount-contract | `AAStarBLSAlgorithm.validate`（链上验聚合签名） | `v0.19.0-beta.2` · `0x68c381Ad…` | 地址 + 源码 diff + ABI |
-| **上游** | AirAccount (KMS)    | owner secp256k1 `ownerAuth`（Stage-1 验签）     | TA `0.5.0`                       | TA/签名方案版本守卫    |
-| 规范     | EntryPoint v0.7     | `getUserOpHash`                                 | `0x0000…71727De2…`               | 固定规范地址           |
+| 角色     | 仓库                | 绑定物                                          | 当前 pin                      | 校验维度               |
+| -------- | ------------------- | ----------------------------------------------- | ----------------------------- | ---------------------- |
+| **上游** | SuperPaymaster      | `PolicyRegistry.checkPolicy`（layer-1 策略）    | `v5.4.0-beta.1` · `0x8c2488…` | 地址 + 源码 diff + ABI |
+| **下游** | airaccount-contract | `AAStarBLSAlgorithm.validate`（链上验聚合签名） | `v0.20.0` · `0xAF525A…`       | 地址 + 源码 diff + ABI |
+| **上游** | AirAccount (KMS)    | owner secp256k1 `ownerAuth`（Stage-1 验签）     | TA `0.5.0`                    | TA/签名方案版本守卫    |
+| 规范     | EntryPoint v0.7     | `getUserOpHash`                                 | `0x0000…71727De2…`            | 固定规范地址           |
 
 ### 1.2 "如何确定是最新且与我一致的版本"
 
@@ -77,8 +77,9 @@
 3. **`.github/workflows/deps-watch.yml`**（新）：**定时**（如每日）跑
    `check-deps`，发现 drift
    **自动开 issue**（标题含 dep + 漂移类型）→ 这就是"自动发现上游变动"。
-4. **统一 env 源**：消除 `realnode-e2e.mjs` 用 `V018` 而 pin 是 `V019`
-   的不一致（见 §2.2），单一 `.env.sepolia` key 为准。
+4. **统一 env 源**（本轮已把 `realnode-e2e.mjs`/`dvt-nodes.sh`/`common.env` 统一到 v0.20.0
+   canonical 地址，见 §2.2）：进一步收敛为"单一真相源"（脚本地址 == `check-deps` pin）由
+   `release-preflight` 校验，杜绝多版本 key 散落。
 
 ---
 
@@ -86,26 +87,32 @@
 
 ### 2.1 权威地址（以 `check-deps` 为准，发布前重新核对）
 
-| 用途                                | 地址                                         | 版本                               |
-| ----------------------------------- | -------------------------------------------- | ---------------------------------- |
-| BLS 验证器（下游消费聚合签名）      | `0x68c381Ad3A2e3380F22840008027E9Ec2783F43A` | airaccount-contract v0.19.0-beta.2 |
-| PolicyRegistry（上游 layer-1 策略） | `0x8c2488d46d5447418558c38AA6441720df656094` | SuperPaymaster v5.4.0-beta.1       |
-| EntryPoint v0.7                     | `0x0000000071727De22E5E9d8BAf0edAc6f37da032` | 规范                               |
+| 用途                                | 地址                                         | 版本                            |
+| ----------------------------------- | -------------------------------------------- | ------------------------------- |
+| BLS 验证器（下游消费聚合签名）      | `0xAF525A161CB17e0A1b6254ef0B8d8473bdA05174` | airaccount-contract **v0.20.0** |
+| PolicyRegistry（上游 layer-1 策略） | `0x8c2488d46d5447418558c38AA6441720df656094` | SuperPaymaster v5.4.0-beta.1    |
+| EntryPoint v0.7                     | `0x0000000071727De22E5E9d8BAf0edAc6f37da032` | 规范                            |
 
-### 2.2 ⚠️ 必须先消除的不一致
+### 2.2 版本漂移历史（已处理）
 
-- `realnode-e2e.mjs` / `.e2e/common.env` 历史用
-  **V018**（`AIRACCOUNT_V018_BLS_ALGORITHM`），但 canonical 最新是
-  **V019**。本轮已把集群 `common.env`
-  切到 V019、node3 注册到 V019；**发布前要把 E2E 脚本与所有 env 统一到 V019（canonical）**，否则 validate 会对错合约。
+- 验证器经历 V018 → V019（`0x68c381Ad`）→
+  **v0.20.0（`0xAF525A`，redeploy，源码 identical）**。每次 redeploy 都换地址但接口不变（纯地址漂移）。
+- **2026-06-20 已迁移到 v0.20.0**：re-pin `check-deps`、统一
+  `dvt-nodes.sh`/`realnode-e2e.mjs`/`common.env` 到 `0xAF525A`、re-register
+  node3、集群切换重启。**发布前以 `check-deps` 绿为准**（任何后续 redeploy 由
+  `deps-watch.yml` 自动发现）。
 
 ### 2.3 节点链上注册流程
 
-- 每个节点用 `registerPublicKey(bytes32 nodeId, bytes publicKey)` 注册到
-  **V019**（`onlyOwner`；publicKey 为 **128-byte EIP-2537 G1**
-  编码，非 48-byte 压缩——见本轮 node3 注册经验）。
-- 发布需登记的节点集合（建议 ≥3 独立实例）全部
-  `isRegistered=true`，`getRegisteredNodeCount` 匹配。
+- 每个节点用 `registerPublicKey(bytes32 nodeId, bytes publicKey)`
+  注册到当前 canonical validator（`onlyOwner`；publicKey 为 **128-byte EIP-2537
+  G1** 编码，非 48-byte 压缩——见 node3 注册经验）。
+- 发布需登记的节点集合（≥3）全部 `isRegistered=true`，`getRegisteredNodeCount`
+  匹配。
+- 🔑
+  **testnet 用 3 套独立、保密的 BLS 私钥，各自 register**——**不复用公开测试夹具
+  `BLS_TEST_1/2`** （其私钥在 `.env.sepolia`
+  公开，任何人可签）。复用夹具只是"3 个进程"，不是"3 个独立运营方"；真·多方运营要求每节点密钥独立保密（与 §8 决策 5"模拟真实多方运营"配套）。本地调试集群可继续用夹具图方便。
 
 ### 2.4 账户与依赖（已定，见 §8）
 

--- a/docs/TESTNET_RELEASE_PLAN.md
+++ b/docs/TESTNET_RELEASE_PLAN.md
@@ -77,9 +77,10 @@
 3. **`.github/workflows/deps-watch.yml`**（新）：**定时**（如每日）跑
    `check-deps`，发现 drift
    **自动开 issue**（标题含 dep + 漂移类型）→ 这就是"自动发现上游变动"。
-4. **统一 env 源**（本轮已把 `realnode-e2e.mjs`/`dvt-nodes.sh`/`common.env` 统一到 v0.20.0
-   canonical 地址，见 §2.2）：进一步收敛为"单一真相源"（脚本地址 == `check-deps` pin）由
-   `release-preflight` 校验，杜绝多版本 key 散落。
+4. **统一 env 源**（本轮已把 `realnode-e2e.mjs`/`dvt-nodes.sh`/`common.env`
+   统一到 v0.20.0
+   canonical 地址，见 §2.2）：进一步收敛为"单一真相源"（脚本地址 == `check-deps`
+   pin）由 `release-preflight` 校验，杜绝多版本 key 散落。
 
 ---
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,6 +32,7 @@ export default [
         clearImmediate: "readonly",
         atob: "readonly",
         btoa: "readonly",
+        fetch: "readonly", // Node 18+ global fetch (used by notification.service.ts)
         jest: "readonly",
         describe: "readonly",
         it: "readonly",

--- a/scripts/check-deps.mjs
+++ b/scripts/check-deps.mjs
@@ -71,14 +71,14 @@ const DEPS = [
     repo: "AAStarCommunity/airaccount-contract",
     relationship:
       "COLLABORATOR — on-chain CONSUMER of node's aggregated BLS sig (AAStarBLSAlgorithm.validate)",
-    version: "v0.19.0-beta.2",
+    version: "v0.20.0",
     configPath: null,
     configKey: null,
     addressLabel: "BLSAlgorithm",
-    address: "0x68c381Ad3A2e3380F22840008027E9Ec2783F43A",
+    address: "0xAF525A161CB17e0A1b6254ef0B8d8473bdA05174",
     deep: {
       sourcePath: "src/validators/AAStarBLSAlgorithm.sol",
-      baselineRef: "v0.19.0-beta.2",
+      baselineRef: "v0.20.0",
       abiSig: "function validate(bytes32 hash, bytes calldata signature)",
     },
   },

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -9,7 +9,7 @@ etc.). See `#42` and `docs/design/dvt-e2e-and-production.md`.
 ## Prereqs
 
 - `.env.sepolia` at repo root with: `SEPOLIA_RPC_URL[,2,3]`,
-  `ENTRY_POINT_ADDRESS`, `AIRACCOUNT_V018_BLS_ALGORITHM`,
+  `ENTRY_POINT_ADDRESS`, `AIRACCOUNT_V020_BLS_ALGORITHM`,
   `BLS_TEST_NODE_ID_1/2`, `BLS_TEST_PRIVATE_KEY_1/2`, `PRIVATE_KEY_SUPPLIER` (=
   the test account's ECDSA `owner()`).
 - `npm run build` (the manager runs it automatically if `dist/` is missing).

--- a/scripts/e2e/dvt-nodes.sh
+++ b/scripts/e2e/dvt-nodes.sh
@@ -16,7 +16,7 @@ ensure() {
   [ -f "$DIST" ] || { echo "build dist..."; npm run build >/dev/null; }
   [ -f "$E2E/node1/node_state.json" ] || { echo "gen node keys..."; node scripts/e2e/gen-nodes.mjs; }
   if [ ! -f "$E2E/common.env" ]; then
-    node -e 'const fs=require("fs");const s=x=>x.replace(/^["\x27]|["\x27]$/g,"");const e=Object.fromEntries(fs.readFileSync(".env.sepolia","utf8").split("\n").filter(l=>l.includes("=")).map(l=>{const i=l.indexOf("=");return [l.slice(0,i).trim(),s(l.slice(i+1).trim())]}));fs.writeFileSync(".e2e/common.env",["ETH_RPC_URL="+(e.SEPOLIA_RPC_URL||e.RPC_URL),"VALIDATOR_CONTRACT_ADDRESS="+e.AIRACCOUNT_V018_BLS_ALGORITHM,"ENTRY_POINT_ADDRESS="+(e.ENTRY_POINT_ADDRESS||e.ENTRYPOINT_ADDRESS),"POLICY_ENABLED=false",""].join("\n"))'
+    node -e 'const fs=require("fs");const s=x=>x.replace(/^["\x27]|["\x27]$/g,"");const e=Object.fromEntries(fs.readFileSync(".env.sepolia","utf8").split("\n").filter(l=>l.includes("=")).map(l=>{const i=l.indexOf("=");return [l.slice(0,i).trim(),s(l.slice(i+1).trim())]}));fs.writeFileSync(".e2e/common.env",["ETH_RPC_URL="+(e.SEPOLIA_RPC_URL||e.RPC_URL),"VALIDATOR_CONTRACT_ADDRESS="+(e.AIRACCOUNT_V020_BLS_ALGORITHM||"0xAF525A161CB17e0A1b6254ef0B8d8473bdA05174"),"ENTRY_POINT_ADDRESS="+(e.ENTRY_POINT_ADDRESS||e.ENTRYPOINT_ADDRESS),"POLICY_ENABLED=false",""].join("\n"))'
   fi
 }
 start() {

--- a/scripts/e2e/realnode-e2e.mjs
+++ b/scripts/e2e/realnode-e2e.mjs
@@ -2,7 +2,7 @@
 // aggregate, verify off-chain, and verify on-chain via the deployed AAStarBLSAlgorithm.
 //
 // Prereq: gen-nodes.mjs run, then 3 instances started (see scripts/e2e/README.md), and
-// a .env.sepolia with SEPOLIA_RPC_URL[,2,3], ENTRY_POINT_ADDRESS, AIRACCOUNT_V018_BLS_ALGORITHM,
+// a .env.sepolia with SEPOLIA_RPC_URL[,2,3], ENTRY_POINT_ADDRESS, AIRACCOUNT_V020_BLS_ALGORITHM,
 // BLS_TEST_NODE_ID_1/2, PRIVATE_KEY_SUPPLIER (= the test account's ECDSA owner).
 // Usage: node scripts/e2e/realnode-e2e.mjs
 import { ethers } from "ethers";
@@ -22,12 +22,12 @@ const env = Object.fromEntries(
 );
 const RPCS = [env.SEPOLIA_RPC_URL].filter(Boolean); // others rotated/dead
 const ENTRY = env.ENTRY_POINT_ADDRESS || env.ENTRYPOINT_ADDRESS;
-// Pinned current AAStarBLSAlgorithm (airaccount-contract v0.19.0-beta.2). The pinned
+// Pinned current AAStarBLSAlgorithm (airaccount-contract v0.20.0). The pinned
 // constant is authoritative; only an EXPLICIT, version-matched override is honored.
 // NB: we deliberately do NOT fall back to the generic `AIRACCOUNT_BLS_ALGORITHM` — that
-// var in older .env files points at a stale contract (a pre-v0.18 deploy) where these
+// var in older .env files points at a stale contract (an earlier deploy) where these
 // test nodes are not registered, which silently makes validate() return 1 (reject).
-const BLS_ALG = env.AIRACCOUNT_V019_BLS_ALGORITHM || "0x68c381Ad3A2e3380F22840008027E9Ec2783F43A";
+const BLS_ALG = env.AIRACCOUNT_V020_BLS_ALGORITHM || "0xAF525A161CB17e0A1b6254ef0B8d8473bdA05174";
 const ACCOUNT = process.env.E2E_ACCOUNT || "0x45Dfe3D5938fDf5a8D30641C3FDA9c9fb1F31ba9";
 const owner = new ethers.Wallet(env.PRIVATE_KEY_SUPPLIER);
 const PORTS = [3001, 3002, 3003];

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -374,9 +374,7 @@ export class BlockchainService {
    * Read SuperPaymaster's cached-price freshness info.
    * ABI confirmed against SuperPaymaster v5.4.x `getCachedPriceInfo()` + `priceStalenessThreshold()`.
    */
-  async getPriceInfo(
-    paymasterAddress: string
-  ): Promise<{ updatedAt: bigint; threshold: bigint }> {
+  async getPriceInfo(paymasterAddress: string): Promise<{ updatedAt: bigint; threshold: bigint }> {
     const abi = [
       "function getCachedPriceInfo() view returns (uint256 price, uint256 updatedAt)",
       "function priceStalenessThreshold() view returns (uint256)",

--- a/src/modules/bls/bls.service.spec.ts
+++ b/src/modules/bls/bls.service.spec.ts
@@ -25,7 +25,6 @@ jest.unstable_mockModule("../../utils/bls.util.js", () => {
 
 const { BlsService } = await import("./bls.service.js");
 const { BlockchainService } = await import("../blockchain/blockchain.service.js");
-type BlockchainService = InstanceType<typeof BlockchainService>;
 // LocalKeySigner imports the (mocked) bls.util sigs — must load AFTER the mock above.
 const { LocalKeySigner } = await import("../signer/local-key.signer.js");
 import type { PackedUserOp } from "../blockchain/blockchain.service.js";
@@ -88,7 +87,10 @@ describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
   beforeEach(() => {
     getAccountOwner = jest.fn<(account: string) => Promise<string>>();
     getUserOpHash = jest.fn<(userOp: PackedUserOp) => Promise<string>>();
-    const blockchain = { getAccountOwner, getUserOpHash } as unknown as BlockchainService;
+    const blockchain = {
+      getAccountOwner,
+      getUserOpHash,
+    } as unknown as InstanceType<typeof BlockchainService>;
     // Default local-key signer (byte-identical to the pre-port signing path).
     const signer = {
       forNode: (n: { privateKey: string }) => new LocalKeySigner(n.privateKey),

--- a/src/modules/capability/capability-registry.service.spec.ts
+++ b/src/modules/capability/capability-registry.service.spec.ts
@@ -12,7 +12,12 @@ describe("CapabilityRegistry", () => {
   });
 
   it("registers and lists a capability", () => {
-    registry.register({ name: "policy", class: "infra-core", description: "DVT policy gate", enabled: true });
+    registry.register({
+      name: "policy",
+      class: "infra-core",
+      description: "DVT policy gate",
+      enabled: true,
+    });
     const list = registry.list();
     expect(list).toHaveLength(1);
     expect(list[0].name).toBe("policy");
@@ -20,12 +25,22 @@ describe("CapabilityRegistry", () => {
   });
 
   it("isEnabled returns true for an enabled capability", () => {
-    registry.register({ name: "notify", class: "infra-app", description: "notifications", enabled: true });
+    registry.register({
+      name: "notify",
+      class: "infra-app",
+      description: "notifications",
+      enabled: true,
+    });
     expect(registry.isEnabled("notify")).toBe(true);
   });
 
   it("isEnabled returns false for a disabled capability", () => {
-    registry.register({ name: "confirm", class: "infra-app", description: "OOB confirm", enabled: false });
+    registry.register({
+      name: "confirm",
+      class: "infra-app",
+      description: "OOB confirm",
+      enabled: false,
+    });
     expect(registry.isEnabled("confirm")).toBe(false);
   });
 


### PR DESCRIPTION
## 背景
airaccount-contract 今天（2026-06-20）发布 **v0.20.0**，把 BLS validator **redeploy 到新地址 `0xAF525A…`**（`AAStarBLSAlgorithm.sol` 与 v0.19.0-beta.2 **identical** → 纯地址漂移，无 ABI/wire 变化）。`check-deps` 标了 **MOVED + REDEPLOYED**。这是方案定稿后第一个真实 drift，按 Drift Playbook 处理。

## 改动（re-pin + env 统一）
- **re-pin** `check-deps.mjs` DEPS：`v0.19.0-beta.2 → v0.20.0`、`0x68c381Ad… → 0xAF525A…`
- **统一脚本/env 到 v0.20.0 canonical 地址**：`dvt-nodes.sh`（common.env 生成）、`realnode-e2e.mjs`（pinned 常量 + 注释）、`scripts/e2e/README.md`
- **文档** `TESTNET_RELEASE_PLAN` §2.1/§2.2/§2.3 更新；新增"**testnet 用 3 套独立保密密钥、不复用公开夹具 `BLS_TEST_1/2`**"要求（呼应 §8 决策 5）

## 已在链上/运行态完成（PR 外）
- **node3 已 re-register 到 `0xAF525A`**（tx `0xe7a9c071…`，block 11099113，status 1；nodeCount=3）。node1/2 是部署脚本自动注册的 BLS_TEST 夹具。
- **本地集群 `.e2e/common.env` 已切 `0xAF525A` + 重启**，三节点 UP。

## 验证
- `npm run check-deps` **全绿**：pinned v0.20.0 == latest release、地址匹配、源码 identical、链上有代码。

**请独立 review，勿自合。**
