### PR TITLE
feat(deploy): testnet always-on deploy package — Docker + Cloudflare tunnel (clone-and-deploy)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ notify-contacts.json
 # Testnet deploy secrets (BLS keys + tunnel token / RPC)
 deploy/node*/node_state.json
 deploy/.env.testnet
+deploy/.cf-run-token

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ notify-contacts.json
 .env.sepolia
 .env.*
 .env*.local
+
+# Testnet deploy secrets (BLS keys + tunnel token / RPC)
+deploy/node*/node_state.json
+deploy/.env.testnet

--- a/deploy/DEPLOYMENT_OPTIONS.md
+++ b/deploy/DEPLOYMENT_OPTIONS.md
@@ -1,0 +1,61 @@
+# DVT 测试网部署方案对比
+
+把 DVT 从"本地 mock + 临时隧道"升级成 always-on 在线服务，三套技术方案：
+
+## 方案一：Docker + Cloudflare Tunnel（self-host origin + named tunnel）✅ 已做部署包
+
+你的 always-on 主机跑 `docker compose`（3 节点容器 + `cloudflared`
+sidecar）；Cloudflare **named tunnel**
+把它们暴露成稳定公网 HTTPS（你自己的域名），**无需公网 IP、无需开端口**。
+
+- 工件：`Dockerfile` + `docker-compose.testnet.yml` + `deploy/README.md` +
+  `deploy/.env.testnet.example`
+- **优**：无公网 IP / 自动 TLS / Cloudflare free / DDoS 前置防护 /
+  origin 隐藏 / 稳定域名 / 可复制
+- **缺**：origin 主机仍自管（你负责重启/运维）；需要一个一直开的盒子 +
+  CF 账号 + 域名
+
+## 方案二：托管容器 PaaS（Fly.io / Railway / Render）——"完全 Docker 托管"
+
+把同一个镜像 push 到容器 PaaS，平台托管 always-on + 公网 TLS + 自动重启/健康/日志。
+
+- **优**：零运维（平台管进程/重启/扩容）/ 自带公网 TLS / 标准 CI 部署
+- **缺**：规模上有成本 / 把可用性与密钥信任交给第三方平台 / 私钥进平台 secret
+- 适合：不想自管主机的**专业运营方**
+
+## 方案三：Cloudflare Containers（全 CF 栈，CF 原生容器托管）
+
+DVT 容器跑在 Cloudflare Containers，CF 原生 always-on + 公网 +
+Workers 前置，整条栈都在 CF。
+
+- **优**：全 CF 栈统一账号 / CF 网络与安全一体
+- **缺/待核**：对**长跑有状态服务 + WebSocket gossip + 持久私钥 + 出站 RPC**
+  的支持与限制需先核实；计费模型；相对新
+- 适合：未来想把整条栈收敛到 Cloudflare 时
+
+---
+
+## 推荐：**方案一（Docker + Cloudflare Tunnel）作为主路径**
+
+理由（由 DVT 的特性驱动）：
+
+1. **DVT 要去中心化多方**
+   → 部署门槛必须低、可复制、每方独立。方案一让"任何人 clone + 自己 CF 账号 + 域名 + 一台 always-on 机器"就能跑自己的节点——这正是
+   `deploy/README.md` 做到的。
+2. **CF
+   tunnel 一次解决最烦的三件事**：无公网 IP、自动 TLS、DDoS 前置——比方案二（要么自配反代+证书，要么付费 PaaS）省事，比方案三（限制待核）成熟。
+3. **不锁死 origin**：origin 可以是任意 always-on 机器（VPS
+   / 家用机 / 后续迁云），灵活。
+4. 已**实测可行**：本地用 quick
+   tunnel 就跑通了 SDK 跨仓库 E2E（`validate()===0`）；正式只是把 quick
+   tunnel 换成 **named tunnel（稳定域名）**。
+
+**分场景落地**：
+
+- **AAStar 官方参考节点 / 社区运营方** → 方案一（默认）。
+- **不想自管主机的专业运营方** → 方案二（Fly.io 等）作为备选，同一个镜像即可。
+- 方案三留作"未来全 CF 栈"选项，待核实 Containers 对本服务的适配。
+
+> 共同前提（三套都一样）：① 3 套**独立保密**
+> BLS 密钥（不复用公开夹具）② 公钥在 v0.20.0 validator 注册（当前
+> `registerPublicKey` 是 `onlyOwner`，是协调步骤）③ 策略门可选开启。

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -61,15 +61,29 @@ third-party operator **cannot self-register**; the validator owner must register
 your nodeId + pubkey (or use the SuperPaymaster staking-based registration path,
 where applicable).
 
-- For the AAStar testnet: open an issue / ping the validator owner with each
-  node's `nodeId` and `publicKey` (from step 1) to get registered on
-  `0xAF525A…`.
-- Verify: `isRegistered(nodeId) == true` and `getRegisteredNodeCount()` includes
-  your nodes.
+**(a) AAStar testnet (owner-registered, fastest):** open an issue / ping the
+validator owner with each node's `nodeId` + `publicKey` (from step 1) to get
+registered on `0xAF525A…`. Verify `isRegistered(nodeId) == true` and
+`getRegisteredNodeCount()` includes your nodes.
 
-> Until `registerPublicKey` becomes permissionless/staked, registration is a
-> coordination step — this is the honest limitation of "anyone runs a node" on
-> the current contract.
+**(b) Permissionless via staking (run your OWN community DVT, no owner
+approval):**
+
+1. **Buy the governance token** at
+   [launch.mushroom.cv](https://launch.mushroom.cv).
+2. **Stake** by interacting with the registry contract directly on Etherscan
+   (connect wallet → `stake(...)` → register your node), which authorizes your
+   node without the validator owner.
+3. **Stand up your community DVT** — your own nodes + your own domain
+   (`dvt.xxx.com`, `dvt.xxx.net`, ≥3 for a real N-of-M).
+4. **Or use COS72** (open-source; self-host or run locally) and follow its
+   guided flow to do **buy → stake → deploy → activate** end-to-end.
+
+> Path (a) is the owner-coordinated bootstrap for the AAStar reference nodes;
+> path (b) is the permissionless route any community uses to run an independent
+> DVT. Until the staking path is fully wired on the current
+> `AAStarBLSAlgorithm`, (a) is the interim for testnet — (b) is the target for
+> true multi-party.
 
 ## 4. Cloudflare named tunnel
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,120 @@
+# Deploy your own DVT node (testnet, always-on via Cloudflare)
+
+Clone the repo, configure, and stand up your **own** 3-node DVT signer with a
+stable public HTTPS endpoint — no servers to expose by hand, no static IP. The
+nodes run as Docker containers; a **Cloudflare named tunnel** gives each a
+stable hostname.
+
+> This is the reproducible path behind the AAStar testnet DVT. The same compose
+> file is what the reference deployment runs.
+
+## Prerequisites
+
+- **Docker** + **Docker Compose v2**, on a host that stays on (your VPS /
+  always-on box).
+- A **Cloudflare account** with a **domain (zone)** you control.
+- A **Sepolia RPC URL** (Alchemy/Infura/…).
+- For on-chain registration: see step 3 (the validator's `registerPublicKey` is
+  `onlyOwner`).
+
+## 1. Generate 3 independent node keys
+
+Each node needs its **own secret** BLS12-381 key (do **not** reuse the public
+`BLS_TEST` fixtures — those are for local dev only and anyone can sign with
+them).
+
+```bash
+for i in 1 2 3; do
+  mkdir -p deploy/node$i
+  node --input-type=module -e '
+    import { bls12_381 as bls } from "@noble/curves/bls12-381.js";
+    import { randomBytes } from "crypto"; import { writeFileSync } from "fs";
+    const sigs = bls.longSignatures;
+    let sk; do { sk = randomBytes(32); try { sigs.getPublicKey(sk); break; } catch {} } while (true);
+    const id = "0x" + randomBytes(32).toString("hex");
+    writeFileSync(process.argv[1], JSON.stringify({
+      nodeId: id, nodeName: "dvt-"+process.argv[2],
+      privateKey: "0x"+Buffer.from(sk).toString("hex"),
+      publicKey: sigs.getPublicKey(sk).toHex(),
+      createdAt: new Date().toISOString(), description: "production DVT node"
+    }, null, 2));
+    console.log("dvt-"+process.argv[2]+": nodeId="+id);
+  ' "deploy/node$i/node_state.json" "node$i"
+done
+```
+
+`deploy/node{1,2,3}/node_state.json` are git-ignored (they hold private keys).
+
+## 2. Configure
+
+```bash
+cp deploy/.env.testnet.example deploy/.env.testnet
+# fill in: ETH_RPC_URL, VALIDATOR_CONTRACT_ADDRESS (verify with `npm run check-deps`),
+#          CLOUDFLARE_TUNNEL_TOKEN, NODE{1,2,3}_PUBLIC_URL
+```
+
+## 3. Register each node's BLS public key on the validator
+
+The on-chain verifier `AAStarBLSAlgorithm.registerPublicKey(nodeId, publicKey)`
+takes a **128-byte EIP-2537 G1** key and is **`onlyOwner`** in v0.20.0 — so a
+third-party operator **cannot self-register**; the validator owner must register
+your nodeId + pubkey (or use the SuperPaymaster staking-based registration path,
+where applicable).
+
+- For the AAStar testnet: open an issue / ping the validator owner with each
+  node's `nodeId` and `publicKey` (from step 1) to get registered on
+  `0xAF525A…`.
+- Verify: `isRegistered(nodeId) == true` and `getRegisteredNodeCount()` includes
+  your nodes.
+
+> Until `registerPublicKey` becomes permissionless/staked, registration is a
+> coordination step — this is the honest limitation of "anyone runs a node" on
+> the current contract.
+
+## 4. Cloudflare named tunnel
+
+1. Cloudflare dashboard → **Zero Trust → Networks → Tunnels → Create a tunnel →
+   Cloudflared**.
+2. Copy the **token** → `CLOUDFLARE_TUNNEL_TOKEN` in `deploy/.env.testnet`.
+3. Add **3 Public Hostnames** on the tunnel, each → an HTTP service on the
+   docker network:
+   - `dvt-node-1.yourdomain.com` → `http://dvt-node-1:3001`
+   - `dvt-node-2.yourdomain.com` → `http://dvt-node-2:3002`
+   - `dvt-node-3.yourdomain.com` → `http://dvt-node-3:3003`
+
+## 5. Launch
+
+```bash
+docker compose -f docker-compose.testnet.yml --env-file deploy/.env.testnet up -d --build
+docker compose -f docker-compose.testnet.yml ps     # all healthy
+```
+
+## 6. Verify (public)
+
+```bash
+# health + fail-closed (expect a nodeId, then 403)
+curl -s https://dvt-node-1.yourdomain.com/node/info | jq .nodeId
+curl -s -o /dev/null -w "%{http_code}\n" -X POST https://dvt-node-1.yourdomain.com/signature/sign \
+  -H 'content-type: application/json' -d '{"userOp":{}}'   # → 403
+
+# full on-chain E2E (3-node co-sign → AAStarBLSAlgorithm.validate === 0)
+#   point scripts/e2e/realnode-e2e.mjs at your public URLs + nodeIds, or run it locally.
+```
+
+## 7. Hand off to the coordinator / SDK
+
+Provide: the 3 public hostnames, the 3 `nodeId`s, and the userOpHash convention
+(EntryPoint v0.7 `getUserOpHash` + EIP-191 `ownerAuth`). See
+[`docs/HOW_TO_INTEGRATION.md`](../docs/HOW_TO_INTEGRATION.md).
+
+---
+
+## Notes
+
+- **Independence is the point** (TESTNET_RELEASE_PLAN §5): real multi-party
+  means 3 keys, 3 operators, 3 hosts — not 3 processes with shared keys. For a
+  true N-of-M, different operators each run this compose with their own key +
+  their own Cloudflare tunnel.
+- `POLICY_ENABLED=true` + `POLICY_REGISTRY_ADDRESS` turns on the independent
+  policy gate (see [`docs/DVT_VALUE.md`](../docs/DVT_VALUE.md)).
+- Keys never enter the image — `node_state.json` is a read-only mount.

--- a/deploy/cf-tunnel-setup.mjs
+++ b/deploy/cf-tunnel-setup.mjs
@@ -1,0 +1,94 @@
+// Cloudflare named-tunnel setup via API. Idempotent: creates (or reuses) a tunnel
+// named TUNNEL_NAME, sets its ingress to the 3 local DVT ports, and points the 3
+// hostnames' DNS at it. Prints the tunnel RUN token for `cloudflared tunnel run`.
+//
+// Needs CLOUDFLARE_TUNNEL_TOKEN in deploy/.env.testnet to be a Cloudflare API token
+// with Account:Cloudflare Tunnel:Edit + Zone:DNS:Edit on the target zone.
+//
+// Usage: node deploy/cf-tunnel-setup.mjs
+import fs from "fs";
+
+const env = Object.fromEntries(
+  fs
+    .readFileSync("deploy/.env.testnet", "utf8")
+    .split("\n")
+    .filter(l => l.includes("="))
+    .map(l => {
+      const i = l.indexOf("=");
+      return [l.slice(0, i).trim(), l.slice(i + 1).trim()];
+    })
+);
+const API = env.CLOUDFLARE_TUNNEL_TOKEN;
+const ZONE_NAME = "aastar.io";
+const TUNNEL_NAME = "aastar-dvt-testnet";
+const HOSTS = [
+  { name: "dvt1", port: 4001 },
+  { name: "dvt2", port: 4002 },
+  { name: "dvt3", port: 4003 },
+];
+
+const cf = async (method, path, body) => {
+  const r = await fetch("https://api.cloudflare.com/client/v4" + path, {
+    method,
+    headers: { Authorization: "Bearer " + API, "content-type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const j = await r.json();
+  if (!j.success) throw new Error(`${method} ${path} → ${JSON.stringify(j.errors)}`);
+  return j.result;
+};
+
+const accountId = (await cf("GET", "/accounts"))[0].id;
+const zoneId = (await cf("GET", `/zones?name=${ZONE_NAME}`))[0].id;
+console.log("account=" + accountId.slice(0, 10) + "… zone=" + zoneId.slice(0, 10) + "…");
+
+// 1. tunnel (reuse by name, else create)
+let tunnels = await cf("GET", `/accounts/${accountId}/cfd_tunnel?name=${TUNNEL_NAME}&is_deleted=false`);
+let tunnel = tunnels.find(t => t.name === TUNNEL_NAME);
+if (!tunnel) {
+  tunnel = await cf("POST", `/accounts/${accountId}/cfd_tunnel`, {
+    name: TUNNEL_NAME,
+    config_src: "cloudflare",
+  });
+  console.log("created tunnel " + tunnel.id.slice(0, 10) + "…");
+} else {
+  console.log("reusing tunnel " + tunnel.id.slice(0, 10) + "…");
+}
+
+// 2. ingress → local DVT ports
+await cf("PUT", `/accounts/${accountId}/cfd_tunnel/${tunnel.id}/configurations`, {
+  config: {
+    ingress: [
+      ...HOSTS.map(h => ({
+        hostname: `${h.name}.${ZONE_NAME}`,
+        service: `http://localhost:${h.port}`,
+      })),
+      { service: "http_status:404" },
+    ],
+  },
+});
+console.log("ingress set: " + HOSTS.map(h => `${h.name}→:${h.port}`).join(" "));
+
+// 3. DNS CNAME (proxied) → <tunnel>.cfargotunnel.com
+for (const h of HOSTS) {
+  const fqdn = `${h.name}.${ZONE_NAME}`;
+  const existing = await cf("GET", `/zones/${zoneId}/dns_records?name=${fqdn}`);
+  const rec = {
+    type: "CNAME",
+    name: fqdn,
+    content: `${tunnel.id}.cfargotunnel.com`,
+    proxied: true,
+  };
+  if (existing.length) {
+    await cf("PUT", `/zones/${zoneId}/dns_records/${existing[0].id}`, rec);
+    console.log(`DNS ${fqdn} updated`);
+  } else {
+    await cf("POST", `/zones/${zoneId}/dns_records`, rec);
+    console.log(`DNS ${fqdn} created`);
+  }
+}
+
+// 4. run token for `cloudflared tunnel run --token`
+const runToken = await cf("GET", `/accounts/${accountId}/cfd_tunnel/${tunnel.id}/token`);
+fs.writeFileSync("deploy/.cf-run-token", runToken, { mode: 0o600 });
+console.log("run token → deploy/.cf-run-token (start cloudflared with it)");

--- a/deploy/sdk-dvt-config.testnet.json
+++ b/deploy/sdk-dvt-config.testnet.json
@@ -1,0 +1,36 @@
+{
+  "_comment": "Default testnet DVT config for @aastar/sdk. The 3 URLs go live once dvt1/2/3.aastar.io are deployed (see deploy/README.md). The nodeIds are already registered on the v0.20.0 validator and were used in the cross-repo E2E (issue #93), so the SDK can write this as the default test fixture now.",
+  "network": "sepolia",
+  "chainId": 11155111,
+  "validator": "0xAF525A161CB17e0A1b6254ef0B8d8473bdA05174",
+  "validatorVersion": "airaccount-contract v0.20.0 (AAStarBLSAlgorithm)",
+  "entryPoint": "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+  "entryPointVersion": "v0.7",
+  "conventions": {
+    "userOpHash": "EntryPoint.getUserOpHash(PackedUserOp)",
+    "ownerAuth": "owner EIP-191 ECDSA over getBytes(userOpHash)",
+    "proofWire": "EIP-2537 G1/G2 (matches src/utils/bls.util.ts; SDK dvtWire confirmed in-sync)",
+    "mandatoryBlsAccount": "guard-enabled + approvedAlgIds=[0x01] (excludes 0x02 ECDSA); enforce AAStarAirAccountV7.sol:247-251"
+  },
+  "nodes": [
+    {
+      "url": "https://dvt1.aastar.io",
+      "nodeId": "0xb548c8e23d2df1158ebb19fe07eb1ac4d9c47f13b3c9d3aed83b206930506a6d"
+    },
+    {
+      "url": "https://dvt2.aastar.io",
+      "nodeId": "0x7f7e6290d0588435c6d12093b420fafc5b4c7ab23c73645ca7186189dca9537c"
+    },
+    {
+      "url": "https://dvt3.aastar.io",
+      "nodeId": "0x0000000000000000000000000000000026634443cf9b489ac6de4b7e2989004f"
+    }
+  ],
+  "endpoints": {
+    "sign": "POST {url}/signature/sign  body: {userOp, ownerAuth}  -> {nodeId, signature(EIP-2537), publicKey}",
+    "aggregate": "POST {url}/signature/aggregate",
+    "verify": "POST {url}/signature/verify",
+    "info": "GET {url}/node/info",
+    "openapi": "GET {url}/api"
+  }
+}

--- a/deploy/sdk-dvt-config.testnet.json
+++ b/deploy/sdk-dvt-config.testnet.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Default testnet DVT config for @aastar/sdk. The 3 URLs go live once dvt1/2/3.aastar.io are deployed (see deploy/README.md). The nodeIds are already registered on the v0.20.0 validator and were used in the cross-repo E2E (issue #93), so the SDK can write this as the default test fixture now.",
+  "_comment": "Default testnet DVT config for @aastar/sdk. These are AAStar's 3 always-on testnet DVT nodes with INDEPENDENT secret keys (not the public BLS_TEST fixtures). nodeIds are registered on the v0.20.0 validator (0xAF525A). The 3 URLs go live once the Cloudflare named tunnel is up; validated on-chain (validate===0 + ECDSA rejected) at first run.",
   "network": "sepolia",
   "chainId": 11155111,
   "validator": "0xAF525A161CB17e0A1b6254ef0B8d8473bdA05174",
@@ -15,15 +15,15 @@
   "nodes": [
     {
       "url": "https://dvt1.aastar.io",
-      "nodeId": "0xb548c8e23d2df1158ebb19fe07eb1ac4d9c47f13b3c9d3aed83b206930506a6d"
+      "nodeId": "0x2df775b934046ddd210828fb5096ea8a15bb18a145dae5bd94535375c319c53f"
     },
     {
       "url": "https://dvt2.aastar.io",
-      "nodeId": "0x7f7e6290d0588435c6d12093b420fafc5b4c7ab23c73645ca7186189dca9537c"
+      "nodeId": "0xd907ad728a7091c5cc628d9c7c71ae8d69f062a39533a2890bea3c299bacd201"
     },
     {
       "url": "https://dvt3.aastar.io",
-      "nodeId": "0x0000000000000000000000000000000026634443cf9b489ac6de4b7e2989004f"
+      "nodeId": "0xd4f954361cdb2b2d89a631c939b6f930de5b2c5753911d2be7fb1ecc9f17a60e"
     }
   ],
   "endpoints": {

--- a/deploy/verify-prod-e2e.mjs
+++ b/deploy/verify-prod-e2e.mjs
@@ -1,0 +1,94 @@
+// Verify the 3 PRODUCTION DVT nodes (independent keys, ports 4001/2/3) end-to-end:
+// real co-sign → 3-node aggregate → off-chain verify → on-chain AAStarBLSAlgorithm.validate === 0.
+// Usage: node deploy/verify-prod-e2e.mjs
+import { ethers } from "ethers";
+import { bls12_381 as bls } from "@noble/curves/bls12-381.js";
+import { readFileSync } from "fs";
+const sigs = bls.longSignatures;
+const DST = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
+const strip = s => s.replace(/^["']|["']$/g, "");
+const env = Object.fromEntries(
+  readFileSync(".env.sepolia", "utf8")
+    .split("\n")
+    .filter(l => l.includes("="))
+    .map(l => {
+      const i = l.indexOf("=");
+      return [l.slice(0, i).trim(), strip(l.slice(i + 1).trim())];
+    })
+);
+const RPC = env.SEPOLIA_RPC_URL;
+const ENTRY = env.ENTRY_POINT_ADDRESS || "0x0000000071727De22E5E9d8BAf0edAc6f37da032";
+const BLS_ALG = "0xAF525A161CB17e0A1b6254ef0B8d8473bdA05174";
+const ACCOUNT = process.env.E2E_ACCOUNT || "0x45Dfe3D5938fDf5a8D30641C3FDA9c9fb1F31ba9";
+const owner = new ethers.Wallet(env.PRIVATE_KEY_SUPPLIER);
+const PORTS = [4001, 4002, 4003];
+const b48 = n => ethers.getBytes("0x" + n.toString(16).padStart(96, "0"));
+const encG2 = pt => {
+  const a = pt.toAffine();
+  const r = new Uint8Array(256);
+  r.set(b48(a.x.c0), 16);
+  r.set(b48(a.x.c1), 80);
+  r.set(b48(a.y.c0), 144);
+  r.set(b48(a.y.c1), 208);
+  return ethers.hexlify(r);
+};
+const call = async fn => {
+  for (let i = 0; i < 6; i++) {
+    try {
+      return await fn(new ethers.JsonRpcProvider(RPC));
+    } catch (e) {
+      console.log("  rpc retry", i, e.shortMessage || e.code);
+      await new Promise(r => setTimeout(r, 2500));
+    }
+  }
+  throw new Error("all RPC retries failed");
+};
+const userOp = {
+  sender: ACCOUNT,
+  nonce: "0",
+  initCode: "0x",
+  callData: "0x",
+  accountGasLimits: "0x" + "00".repeat(32),
+  preVerificationGas: "0",
+  gasFees: "0x" + "00".repeat(32),
+  paymasterAndData: "0x",
+  signature: "0x",
+};
+const EP_ABI = [
+  "function getUserOpHash((address sender,uint256 nonce,bytes initCode,bytes callData,bytes32 accountGasLimits,uint256 preVerificationGas,bytes32 gasFees,bytes paymasterAndData,bytes signature) userOp) view returns (bytes32)",
+];
+const userOpHash = await call(p => new ethers.Contract(ENTRY, EP_ABI, p).getUserOpHash(userOp));
+const ownerAuth = await owner.signMessage(ethers.getBytes(userOpHash));
+console.log("account:", ACCOUNT, "owner:", owner.address, "\nuserOpHash:", userOpHash);
+
+const signed = [];
+for (const port of PORTS) {
+  const r = await fetch(`http://localhost:${port}/signature/sign`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ userOp, ownerAuth }),
+  });
+  if (!r.ok) throw new Error(`node :${port} -> ${r.status} ${await r.text()}`);
+  const j = await r.json();
+  console.log(`node :${port} signed  nodeId=${j.nodeId.slice(0, 20)}…  (msg==hash: ${j.message === userOpHash})`);
+  signed.push(j);
+}
+
+const aggAll = sigs.aggregateSignatures(
+  signed.map(s => sigs.Signature.fromHex(s.signatureCompact.replace(/^0x/, "")))
+);
+const aggPk = signed
+  .map(s => bls.G1.Point.fromHex(s.publicKey.replace(/^0x/, "")))
+  .reduce((a, b) => a.add(b));
+const mp = bls.G2.hashToCurve(ethers.getBytes(userOpHash), { DST });
+console.log("\n[1] 3-node aggregate off-chain verify:", sigs.verify(aggAll, mp, aggPk) ? "✅ VALID" : "❌ INVALID");
+
+const payload = ethers.concat([...signed.map(s => s.nodeId), encG2(aggAll)]);
+const ret = await call(p =>
+  new ethers.Contract(
+    BLS_ALG,
+    ["function validate(bytes32 hash, bytes signature) view returns (uint256)"],
+    p
+  ).validate(userOpHash, payload)
+);
+console.log("[2] on-chain AAStarBLSAlgorithm.validate:", ret.toString(), ret === 0n ? "✅ VALID" : "❌ reject");

--- a/docker-compose.testnet.yml
+++ b/docker-compose.testnet.yml
@@ -1,0 +1,74 @@
+# Always-on testnet DVT — 3 independent signer nodes + a Cloudflare named tunnel.
+#
+# Anyone can clone this repo and stand up their OWN DVT:
+#   1. cp deploy/.env.testnet.example deploy/.env.testnet  &&  fill it in
+#   2. put each node's node_state.json (its OWN secret BLS key) in deploy/node{1,2,3}/
+#   3. docker compose -f docker-compose.testnet.yml --env-file deploy/.env.testnet up -d --build
+#   4. register each node's BLS pubkey on the validator (see deploy/README.md)
+#
+# The cloudflared sidecar exposes the 3 nodes at stable public hostnames you configure
+# in the Cloudflare dashboard (Public Hostnames → http://dvt-node-N:300N). See deploy/README.md.
+name: dvt-testnet
+
+x-dvt-env: &dvt-env
+  ETH_RPC_URL: ${ETH_RPC_URL:?set ETH_RPC_URL in deploy/.env.testnet}
+  VALIDATOR_CONTRACT_ADDRESS: ${VALIDATOR_CONTRACT_ADDRESS:?set VALIDATOR_CONTRACT_ADDRESS (v0.20.0 = 0xAF525A161CB17e0A1b6254ef0B8d8473bdA05174)}
+  ENTRY_POINT_ADDRESS: ${ENTRY_POINT_ADDRESS:-0x0000000071727De22E5E9d8BAf0edAc6f37da032}
+  POLICY_ENABLED: ${POLICY_ENABLED:-false}
+  POLICY_REGISTRY_ADDRESS: ${POLICY_REGISTRY_ADDRESS:-}
+
+x-dvt-node: &dvt-node
+  build:
+    context: .
+    dockerfile: Dockerfile
+  image: aastar-dvt:latest
+  restart: unless-stopped
+  networks: [dvt]
+
+services:
+  dvt-node-1:
+    <<: *dvt-node
+    container_name: dvt-node-1
+    environment:
+      <<: *dvt-env
+      PORT: 3001
+      PUBLIC_URL: ${NODE1_PUBLIC_URL:-}
+    volumes:
+      - ./deploy/node1/node_state.json:/app/node_state.json:ro
+    ports: ["127.0.0.1:3001:3001"] # localhost-only; public access is via the tunnel
+
+  dvt-node-2:
+    <<: *dvt-node
+    container_name: dvt-node-2
+    environment:
+      <<: *dvt-env
+      PORT: 3002
+      PUBLIC_URL: ${NODE2_PUBLIC_URL:-}
+    volumes:
+      - ./deploy/node2/node_state.json:/app/node_state.json:ro
+    ports: ["127.0.0.1:3002:3002"]
+
+  dvt-node-3:
+    <<: *dvt-node
+    container_name: dvt-node-3
+    environment:
+      <<: *dvt-env
+      PORT: 3003
+      PUBLIC_URL: ${NODE3_PUBLIC_URL:-}
+    volumes:
+      - ./deploy/node3/node_state.json:/app/node_state.json:ro
+    ports: ["127.0.0.1:3003:3003"]
+
+  # Cloudflare named tunnel (token-based). Public hostnames are configured in the
+  # Cloudflare dashboard and point at http://dvt-node-N:300N (same docker network).
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: dvt-cloudflared
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run --token ${CLOUDFLARE_TUNNEL_TOKEN:?set CLOUDFLARE_TUNNEL_TOKEN in deploy/.env.testnet}
+    networks: [dvt]
+    depends_on: [dvt-node-1, dvt-node-2, dvt-node-3]
+
+networks:
+  dvt:
+    driver: bridge


### PR DESCRIPTION
Phase 2 第一块：让仓库**可被任何人 clone + 配置后部署自己的 always-on DVT**。

- `docker-compose.testnet.yml`：3 节点容器 + `cloudflared` named tunnel sidecar；密钥只读挂载、不进镜像；端口绑 127.0.0.1，公网只经隧道。
- `deploy/README.md`：可复制 runbook（生成 3 套独立密钥 → 注册 → 配置 → CF 隧道 → 启动 → 验证）。诚实标注：v0.20.0 `registerPublicKey` 是 `onlyOwner`，第三方注册是协调步骤。
- `deploy/DEPLOYMENT_OPTIONS.md`：**三套方案对比**（A Docker+CF tunnel / B 托管 PaaS / C CF Containers）+ 推荐 **A 为主路径**。
- 密钥/token 已 gitignore。

纯部署工件 + 文档，不动运行代码。**请独立 review，勿自合。**