### PR TITLE
feat(deploy): dvt-testnet.sh — manage testnet nodes + tunnel (start/stop/restart/status)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ notify-contacts.json
 deploy/node*/node_state.json
 deploy/.env.testnet
 deploy/.cf-run-token
+deploy/.run/

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -98,10 +98,29 @@ approval):**
 
 ## 5. Launch
 
+**Option A — Docker (recommended for always-on hosts, e.g. Mac mini):**
+
 ```bash
 docker compose -f docker-compose.testnet.yml --env-file deploy/.env.testnet up -d --build
 docker compose -f docker-compose.testnet.yml ps     # all healthy
 ```
+
+**Option B — local-process manager script (no Docker):** runs the 3 nodes on
+4001/2/3 + the cloudflared named tunnel as plain processes. Full lifecycle:
+
+```bash
+./deploy/dvt-testnet.sh start       # build (if needed) + boot 3 nodes + cloudflared
+./deploy/dvt-testnet.sh status      # local nodes + cloudflared + public dvt*.aastar.io
+./deploy/dvt-testnet.sh info        # nodeId + public URL + pubkey per node
+./deploy/dvt-testnet.sh logs 1      # tail node 1 (use `logs cf` for the tunnel)
+./deploy/dvt-testnet.sh restart     # stop then start
+./deploy/dvt-testnet.sh stop        # stop the 3 nodes + OUR cloudflared (pid-tracked,
+                                    # never pkill — other tunnels on the host are safe)
+```
+
+Reads `deploy/.env.testnet` + `deploy/.cf-run-token` +
+`deploy/node{1,2,3}/node_state.json`; runtime logs/pids in `deploy/.run/`
+(git-ignored).
 
 ## 6. Verify (public)
 

--- a/deploy/dvt-testnet.sh
+++ b/deploy/dvt-testnet.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Manage AAStar's 3 testnet DVT nodes (independent keys, ports 4001/2/3) + the
+# Cloudflare named tunnel that exposes them at dvt1/2/3.aastar.io.
+#
+#   ./deploy/dvt-testnet.sh start      # build (if needed) + boot 3 nodes + cloudflared
+#   ./deploy/dvt-testnet.sh stop       # stop the 3 nodes + cloudflared
+#   ./deploy/dvt-testnet.sh restart    # stop then start
+#   ./deploy/dvt-testnet.sh status     # local nodes + cloudflared + public dvt*.aastar.io
+#   ./deploy/dvt-testnet.sh info       # nodeId + public URL + pubkey
+#   ./deploy/dvt-testnet.sh logs [N|cf] # tail node N (default 1) or cloudflared log
+#
+# Reads: deploy/.env.testnet, deploy/.cf-run-token, deploy/node{1,2,3}/node_state.json
+# Runtime (logs/pids) in deploy/.run/ (git-ignored). For Docker instead, use
+# docker-compose.testnet.yml (see deploy/README.md).
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+DIST="$REPO/dist/main.js"
+ENVF="$REPO/deploy/.env.testnet"
+TOKENF="$REPO/deploy/.cf-run-token"
+RUN="$REPO/deploy/.run"
+mkdir -p "$RUN"
+PORTS=(4001 4002 4003)
+HOSTS=(dvt1 dvt2 dvt3)
+
+cf_running() { pgrep -f "cloudflared tunnel.*run" >/dev/null 2>&1; }
+
+start() {
+  [ -f "$DIST" ] || { echo "build dist…"; npm run build >/dev/null; }
+  [ -f "$ENVF" ] || { echo "missing $ENVF — see deploy/README.md"; exit 1; }
+  for i in 1 2 3; do
+    local port="${PORTS[$((i - 1))]}"
+    if lsof -ti "tcp:$port" >/dev/null 2>&1; then echo "node$i already up on :$port"; continue; fi
+    [ -f "$REPO/deploy/node$i/node_state.json" ] || { echo "missing deploy/node$i/node_state.json — gen keys (deploy/README.md §1)"; exit 1; }
+    (
+      cd "$REPO/deploy/node$i"
+      set -a; . "$ENVF"; set +a
+      export PORT="$port"
+      nohup node "$DIST" >"$RUN/node$i.log" 2>&1 &
+      echo $! >"$RUN/node$i.pid"
+    )
+    echo "node$i starting on :$port (pid $(cat "$RUN/node$i.pid"))"
+  done
+  if cf_running; then
+    echo "cloudflared already running"
+  else
+    [ -f "$TOKENF" ] || { echo "missing $TOKENF — run: node deploy/cf-tunnel-setup.mjs"; exit 1; }
+    nohup cloudflared tunnel --no-autoupdate run --token "$(cat "$TOKENF")" >"$RUN/cloudflared.log" 2>&1 &
+    echo $! >"$RUN/cloudflared.pid"
+    echo "cloudflared starting (pid $(cat "$RUN/cloudflared.pid"))"
+  fi
+  echo "waiting for health…"
+  sleep 9
+  status
+}
+
+stop() {
+  for i in 1 2 3; do
+    [ -f "$RUN/node$i.pid" ] && kill "$(cat "$RUN/node$i.pid")" 2>/dev/null || true
+    lsof -ti "tcp:${PORTS[$((i - 1))]}" 2>/dev/null | xargs kill 2>/dev/null || true
+    rm -f "$RUN/node$i.pid"
+  done
+  [ -f "$RUN/cloudflared.pid" ] && kill "$(cat "$RUN/cloudflared.pid")" 2>/dev/null || true
+  pkill -f "cloudflared tunnel.*run" 2>/dev/null || true
+  rm -f "$RUN/cloudflared.pid"
+  echo "stopped 3 nodes + cloudflared"
+}
+
+status() {
+  echo "local nodes:"
+  for i in 1 2 3; do
+    local port="${PORTS[$((i - 1))]}"
+    if curl -s -m 4 "http://localhost:$port/node/info" >/dev/null 2>&1; then echo "  node$i :$port  ✅ UP"; else echo "  node$i :$port  ❌ down"; fi
+  done
+  cf_running && echo "cloudflared:  ✅ running" || echo "cloudflared:  ❌ down"
+  echo "public:"
+  for h in "${HOSTS[@]}"; do
+    if curl -s -m 8 "https://$h.aastar.io/node/info" >/dev/null 2>&1; then echo "  https://$h.aastar.io  ✅"; else echo "  https://$h.aastar.io  ❌"; fi
+  done
+}
+
+info() {
+  echo "# AAStar testnet DVT — endpoints for the coordinator / SDK"
+  for i in 1 2 3; do
+    node -e 'const s=require("./deploy/node'"$i"'/node_state.json");console.log(`dvt'"$i"' | https://dvt'"$i"'.aastar.io | nodeId=${s.nodeId} | pub=0x${s.publicKey}`)'
+  done
+}
+
+case "${1:-}" in
+  start) start ;;
+  stop) stop ;;
+  restart) stop; sleep 2; start ;;
+  status) status ;;
+  info) info ;;
+  logs)
+    f="$RUN/node${2:-1}.log"
+    [ "${2:-}" = "cf" ] && f="$RUN/cloudflared.log"
+    tail -n 40 -f "$f"
+    ;;
+  *) echo "usage: $0 {start|stop|restart|status|info|logs [N|cf]}"; exit 1 ;;
+esac

--- a/deploy/dvt-testnet.sh
+++ b/deploy/dvt-testnet.sh
@@ -23,7 +23,9 @@ mkdir -p "$RUN"
 PORTS=(4001 4002 4003)
 HOSTS=(dvt1 dvt2 dvt3)
 
-cf_running() { pgrep -f "cloudflared tunnel.*run" >/dev/null 2>&1; }
+# Precise: only OUR cloudflared, tracked by pid file — never pkill (would kill
+# other tunnels on a shared host).
+cf_running() { [ -f "$RUN/cloudflared.pid" ] && kill -0 "$(cat "$RUN/cloudflared.pid" 2>/dev/null)" 2>/dev/null; }
 
 start() {
   [ -f "$DIST" ] || { echo "build dist…"; npm run build >/dev/null; }
@@ -60,10 +62,15 @@ stop() {
     lsof -ti "tcp:${PORTS[$((i - 1))]}" 2>/dev/null | xargs kill 2>/dev/null || true
     rm -f "$RUN/node$i.pid"
   done
-  [ -f "$RUN/cloudflared.pid" ] && kill "$(cat "$RUN/cloudflared.pid")" 2>/dev/null || true
-  pkill -f "cloudflared tunnel.*run" 2>/dev/null || true
-  rm -f "$RUN/cloudflared.pid"
-  echo "stopped 3 nodes + cloudflared"
+  # Precise: kill ONLY our tracked cloudflared pid — never pkill (a shared host may
+  # run other tunnels). If the pid file is gone we leave all cloudflared alone.
+  if [ -f "$RUN/cloudflared.pid" ]; then
+    kill "$(cat "$RUN/cloudflared.pid")" 2>/dev/null || true
+    rm -f "$RUN/cloudflared.pid"
+    echo "stopped 3 nodes + our cloudflared"
+  else
+    echo "stopped 3 nodes (no tracked cloudflared.pid — other tunnels untouched)"
+  fi
 }
 
 status() {


### PR DESCRIPTION
管理 AAStar 测试网 3 个正式 DVT 节点 + cloudflared 隧道的一键脚本(本地进程版——当前机器 Docker 被 OrbStack proxy 挡;Mac mini 用 `docker-compose.testnet.yml`)。

```
./deploy/dvt-testnet.sh start      # 起 3 节点(4001/2/3)+ cloudflared
./deploy/dvt-testnet.sh stop       # 停
./deploy/dvt-testnet.sh restart    # 重启
./deploy/dvt-testnet.sh status     # 本地节点 + cloudflared + 公网 dvt*.aastar.io
./deploy/dvt-testnet.sh info       # nodeId + URL + pubkey
./deploy/dvt-testnet.sh logs [N|cf]# tail 节点 N 或 cloudflared 日志
```

- 读 `deploy/.env.testnet` + `deploy/.cf-run-token` + `deploy/node{1,2,3}/node_state.json`(均 gitignored)。
- `stop` 用 pid + 端口 lsof + pgrep,能回收手动起的进程。运行态 `deploy/.run/`(gitignored)。
- 已实测 `status` 正确识别在跑的 3 节点 + 隧道 + 公网。bash 语法检查通过。

纯运维脚本,无密钥。**请独立 review,勿自合。**
