### PR TITLE
feat(#98 relay): optional gasless purchase relay module (Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ deploy/node*/node_state.json
 deploy/.env.testnet
 deploy/.cf-run-token
 deploy/.run/
+
+# Per-node env overrides (independent keys: relay operator, keeper)
+deploy/node*/.env

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -140,6 +140,34 @@ Provide: the 3 public hostnames, the 3 `nodeId`s, and the userOpHash convention
 (EntryPoint v0.7 `getUserOpHash` + EIP-191 `ownerAuth`). See
 [`docs/HOW_TO_INTEGRATION.md`](../docs/HOW_TO_INTEGRATION.md).
 
+## 8. Optional: gasless purchase relay (#98)
+
+The node can also run the **launch token-sale relay** so the gasless
+GToken/aPNTs purchase flow stops depending on a single centralized Cloudflare
+Worker. When enabled it exposes `POST /v3/relay` (wire-compatible with the old
+Worker) and submits buys (EIP-3009 + BuyIntent → BuyHelper) paying gas from a
+dedicated hot wallet. Each node is an **independent relayer** — the SDK points
+`relayerUrl` at any node and fails over.
+
+This is orthogonal to BLS co-signing (buyer + operator are plain EOAs; no
+UserOperation, no validator, no aggregation), so it never affects the 403
+owner-auth signing path.
+
+```bash
+# in deploy/.env.testnet (per node — use a SEPARATE funded key each):
+RELAY_ENABLED=true
+RELAY_OPERATOR_PK=0x<dedicated funded hot-wallet key>   # NOT the validator-owner key
+
+# verify after launch:
+curl -s https://dvt-node-1.yourdomain.com/relay/health | jq .   # {status:"ok", operator:0x…}
+```
+
+⚠️ `RELAY_OPERATOR_PK` is a **public-facing gas-paying key** — keep it
+dedicated, fund each node's key with Sepolia ETH, and never reuse the
+validator-owner key. Addresses default to the Sepolia Path-A sale stack;
+override `RELAY_*` for a different deployment. See
+[`.env.testnet.example`](./.env.testnet.example) for all knobs.
+
 ---
 
 ## Notes

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -153,17 +153,28 @@ This is orthogonal to BLS co-signing (buyer + operator are plain EOAs; no
 UserOperation, no validator, no aggregation), so it never affects the 403
 owner-auth signing path.
 
-```bash
-# in deploy/.env.testnet (per node — use a SEPARATE funded key each):
-RELAY_ENABLED=true
-RELAY_OPERATOR_PK=0x<dedicated funded hot-wallet key>   # NOT the validator-owner key
+Turn it on with a **separate, funded key per node**. `dvt-testnet.sh` loads the
+shared `deploy/.env.testnet` first, then overlays a per-node `deploy/node$i/.env`
+(git-ignored) — put each node's own relay key there:
 
-# verify after launch:
-curl -s https://dvt-node-1.yourdomain.com/relay/health | jq .   # {status:"ok", operator:0x…}
+```bash
+# shared, once — in deploy/.env.testnet:
+RELAY_ENABLED=true
+
+# per node — in deploy/node1/.env, deploy/node2/.env, deploy/node3/.env:
+RELAY_OPERATOR_PK=0x<this node's dedicated, funded hot-wallet key>   # NOT the validator-owner key
+
+# generate a fresh key + print its address to fund (repeat per node):
+node -e 'const w=require("ethers").Wallet.createRandom(); console.log("RELAY_OPERATOR_PK="+w.privateKey, "\naddress (fund with Sepolia ETH):", w.address)'
+
+./deploy/dvt-testnet.sh restart
+curl -s https://dvt1.aastar.io/relay/health | jq .     # {status:"ok", operator:0x…}
 ```
 
+Public relay endpoints: `https://dvt{1,2,3}.aastar.io/v3/relay`.
+
 ⚠️ `RELAY_OPERATOR_PK` is a **public-facing gas-paying key** — keep it
-dedicated, fund each node's key with Sepolia ETH, and never reuse the
+dedicated, fund each node's address with Sepolia ETH, and never reuse the
 validator-owner key. Addresses default to the Sepolia Path-A sale stack;
 override `RELAY_*` for a different deployment. See
 [`.env.testnet.example`](./.env.testnet.example) for all knobs.

--- a/deploy/dvt-testnet.sh
+++ b/deploy/dvt-testnet.sh
@@ -80,6 +80,17 @@ status() {
     if curl -s -m 4 "http://localhost:$port/node/info" >/dev/null 2>&1; then echo "  node$i :$port  ✅ UP"; else echo "  node$i :$port  ❌ down"; fi
   done
   cf_running && echo "cloudflared:  ✅ running" || echo "cloudflared:  ❌ down"
+  echo "relay (#98, optional):"
+  for i in 1 2 3; do
+    local port="${PORTS[$((i - 1))]}"
+    local body
+    body="$(curl -s -m 4 "http://localhost:$port/relay/health" 2>/dev/null || true)"
+    case "$body" in
+      *'"status":"ok"'*) echo "  node$i relay: ✅ enabled" ;;
+      *'"status":"disabled"'*) echo "  node$i relay: ⚪ disabled" ;;
+      *) echo "  node$i relay: ❌ down" ;;
+    esac
+  done
   echo "public:"
   for h in "${HOSTS[@]}"; do
     if curl -s -m 8 "https://$h.aastar.io/node/info" >/dev/null 2>&1; then echo "  https://$h.aastar.io  ✅"; else echo "  https://$h.aastar.io  ❌"; fi

--- a/deploy/dvt-testnet.sh
+++ b/deploy/dvt-testnet.sh
@@ -36,7 +36,13 @@ start() {
     [ -f "$REPO/deploy/node$i/node_state.json" ] || { echo "missing deploy/node$i/node_state.json — gen keys (deploy/README.md §1)"; exit 1; }
     (
       cd "$REPO/deploy/node$i"
-      set -a; . "$ENVF"; set +a
+      # Shared base env, then per-node overrides (deploy/node$i/.env) so each node
+      # can carry its OWN keys — e.g. an independent RELAY_OPERATOR_PK / keeper key
+      # — instead of sharing one. The per-node file is git-ignored.
+      set -a
+      . "$ENVF"
+      [ -f "$REPO/deploy/node$i/.env" ] && . "$REPO/deploy/node$i/.env"
+      set +a
       export PORT="$port"
       nohup node "$DIST" >"$RUN/node$i.log" 2>&1 &
       echo $! >"$RUN/node$i.pid"

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { DashboardModule } from "./modules/dashboard/dashboard.module.js";
 import { AppConfigModule } from "./config/config.module.js";
 import { CapabilityModule } from "./modules/capability/capability.module.js";
 import { KeeperModule } from "./modules/keeper/keeper.module.js";
+import { RelayModule } from "./modules/relay/relay.module.js";
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { KeeperModule } from "./modules/keeper/keeper.module.js";
     GossipModule,
     DashboardModule,
     KeeperModule,
+    RelayModule,
   ],
 })
 export class AppModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { AppConfigModule } from "./config/config.module.js";
 import { CapabilityModule } from "./modules/capability/capability.module.js";
 import { KeeperModule } from "./modules/keeper/keeper.module.js";
 import { RelayModule } from "./modules/relay/relay.module.js";
+import { HealthModule } from "./modules/health/health.module.js";
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { RelayModule } from "./modules/relay/relay.module.js";
     DashboardModule,
     KeeperModule,
     RelayModule,
+    HealthModule,
   ],
 })
 export class AppModule {}

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -85,6 +85,30 @@ export default () => {
     keeperChainlinkFeed:
       process.env.KEEPER_CHAINLINK_FEED || "0x694AA1769357215DE4FAC081bf1f309aDC325306",
 
+    // Gasless purchase relay (#98). Opt-in; ports the launch-sale relayer (v3:
+    // EIP-3009 + BuyIntent → BuyHelper) into the node so the token sale no longer
+    // depends on a single centralized Cloudflare Worker. Default off. Requires a
+    // DEDICATED RELAY_OPERATOR_PK (funded hot wallet that pays gas) — it does NOT
+    // fall back to ETH_PRIVATE_KEY, keeping the public-facing gas key isolated
+    // from the validator-owner key. Addresses default to the Sepolia Path-A stack.
+    relayEnabled: process.env.RELAY_ENABLED === "true",
+    relayOperatorPk: process.env.RELAY_OPERATOR_PK || undefined,
+    relayRpcUrl: process.env.RELAY_RPC_URL || undefined,
+    relayChainId: parseInt(process.env.RELAY_CHAIN_ID || "11155111", 10),
+    relayBuyHelper: process.env.RELAY_BUY_HELPER || undefined,
+    relayUsdc: process.env.RELAY_USDC || undefined,
+    relayGtoken: process.env.RELAY_GTOKEN || undefined,
+    relayApnts: process.env.RELAY_APNTS || undefined,
+    relayMaxPaymentAmount: process.env.RELAY_MAX_PAYMENT_USDC || undefined,
+    relayRateLimitPerAddressPerHour: parseInt(
+      process.env.RELAY_RATE_LIMIT_PER_ADDRESS_PER_HOUR || "5",
+      10
+    ),
+    relayRateLimitGlobalPerHour: parseInt(
+      process.env.RELAY_RATE_LIMIT_GLOBAL_PER_HOUR || "100",
+      10
+    ),
+
     // Gossip Network
     gossipPublicUrl: process.env.GOSSIP_PUBLIC_URL || `ws://localhost:${port}/ws`,
     gossipBootstrapPeers: parseBootstrapPeers(process.env.GOSSIP_BOOTSTRAP_PEERS || ""),

--- a/src/modules/health/health.controller.ts
+++ b/src/modules/health/health.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, Optional } from "@nestjs/common";
+import { ApiOperation, ApiTags } from "@nestjs/swagger";
+import { CapabilityRegistry } from "../capability/capability-registry.service.js";
+
+/**
+ * Top-level liveness endpoint. Plain `GET /health` is the conventional probe
+ * (Docker/Cloudflare/uptime monitors hit it); the node previously only exposed
+ * `/node/info` and `/relay/health`, so a bare `/health` 404'd. This always
+ * returns 200 while the process is up and lists which optional capabilities are
+ * enabled (relay, keeper, policy, …) from the global CapabilityRegistry.
+ */
+@ApiTags("health")
+@Controller("health")
+export class HealthController {
+  constructor(@Optional() private readonly capabilities?: CapabilityRegistry) {}
+
+  @Get()
+  @ApiOperation({ summary: "Liveness check + enabled capabilities" })
+  health(): { status: string; capabilities: Array<{ name: string; enabled: boolean }> } {
+    const caps = (this.capabilities?.list() ?? []).map(c => ({ name: c.name, enabled: c.enabled }));
+    return { status: "ok", capabilities: caps };
+  }
+}

--- a/src/modules/health/health.module.ts
+++ b/src/modules/health/health.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { HealthController } from "./health.controller.js";
+
+/**
+ * Always-on liveness endpoint (`GET /health`). The CapabilityRegistry it reads
+ * is a @Global singleton, so no import is needed here.
+ */
+@Module({
+  controllers: [HealthController],
+})
+export class HealthModule {}

--- a/src/modules/relay/dto/relay.dto.ts
+++ b/src/modules/relay/dto/relay.dto.ts
@@ -1,0 +1,54 @@
+import { IsObject, IsString } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
+
+/**
+ * POST /v3/relay request body — a gasless GToken / aPNTs purchase.
+ *
+ * Wire-compatible with the legacy Cloudflare Worker `/v3/relay` so the SDK
+ * (`@aastar/tokens` TokenSaleClient.buyGasless) only has to repoint `relayerUrl`
+ * at a DVT node. Payload: { intent, buyIntentSig, transferAuth }.
+ *
+ * Following the project convention (see sign.dto.ts): the nested objects are NOT
+ * field-validated by the DTO — only their top-level presence/type. All real
+ * validation (whitelist, caps, deadline, signature recovery) happens inside
+ * RelayService, which owns rejection and maps to the right HTTP status. This
+ * keeps the ValidationPipe from silently stripping nested fields.
+ */
+export class RelayV3Dto {
+  @ApiProperty({
+    description:
+      "BuyIntent fields: { buyer, paymentToken, paymentAmount, targetToken, " +
+      "recipient, minOut, deadline, nonce }. Amounts are decimal strings; nonce is 0x bytes32.",
+  })
+  @IsObject()
+  intent: {
+    buyer: string;
+    paymentToken: string;
+    paymentAmount: string;
+    targetToken: string;
+    recipient: string;
+    minOut: string;
+    deadline: number;
+    nonce: string;
+  };
+
+  @ApiProperty({
+    description: "65-byte ECDSA signature (0x r||s||v) over the BuyIntent EIP-712 digest.",
+    example: "0x" + "ab".repeat(65),
+  })
+  @IsString()
+  buyIntentSig: string;
+
+  @ApiProperty({
+    description:
+      "Extras for USDC.transferWithAuthorization (EIP-3009): { validAfter, v, r, s }. " +
+      "The remaining transfer params are derived from `intent`.",
+  })
+  @IsObject()
+  transferAuth: {
+    validAfter: number;
+    v: number;
+    r: string;
+    s: string;
+  };
+}

--- a/src/modules/relay/relay.constants.ts
+++ b/src/modules/relay/relay.constants.ts
@@ -1,0 +1,66 @@
+/**
+ * Wire constants for the gasless purchase relay (#98).
+ *
+ * Ported from the standalone Cloudflare Worker `mycelium/launch → services/relayer`
+ * (v3 path only: EIP-3009 + EIP-712 BuyIntent → BuyHelper.executeBuy). The v1
+ * (EIP-7702) and v2 paths are deprecated and intentionally NOT ported.
+ *
+ * Sepolia defaults are the Path-A canonical-bound sale stack (2026-06-21). All
+ * are overridable via env so a community operator can point the relay at a
+ * different sale deployment without a code change.
+ */
+
+/** EIP-712 typed-data field layout for BuyIntent — mirrors BuyHelper.sol. */
+export const BUY_INTENT_TYPES = {
+  BuyIntent: [
+    { name: "buyer", type: "address" },
+    { name: "paymentToken", type: "address" },
+    { name: "paymentAmount", type: "uint256" },
+    { name: "targetToken", type: "address" },
+    { name: "recipient", type: "address" },
+    { name: "minOut", type: "uint256" },
+    { name: "deadline", type: "uint256" },
+    { name: "nonce", type: "bytes32" },
+  ],
+} as const;
+
+/** EIP-712 domain name/version for BuyHelper (chainId + verifyingContract are dynamic). */
+export const BUY_INTENT_DOMAIN_NAME = "MyceliumBuyHelper";
+export const BUY_INTENT_DOMAIN_VERSION = "1";
+
+/**
+ * Human-readable ABI for BuyHelper.executeBuy. ethers v6 parses the named tuple
+ * components; args are passed positionally (see relay.service buildCallData).
+ */
+export const EXECUTE_BUY_FRAGMENT =
+  "function executeBuy(" +
+  "(address buyer,address paymentToken,uint256 paymentAmount,address targetToken," +
+  "address recipient,uint256 minOut,uint256 deadline,bytes32 nonce) intent," +
+  " bytes buyIntentSig," +
+  " (uint256 validAfter,uint8 v,bytes32 r,bytes32 s) transferAuth)";
+
+/** Sepolia Path-A canonical-bound stack (2026-06-21). Override via env in prod. */
+export const SEPOLIA_DEFAULTS = {
+  usdc: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
+  gtoken: "0x20a051502a7AE6e40cfFd6EBe59057538E698984",
+  apnts: "0x9e66B457E0ABb1F139FD8A596d00f784eBA2873b",
+  buyHelper: "0x0EA2AEd239574F4e875Ae570C67825da845E7e66",
+  chainId: 11155111,
+} as const;
+
+/** $864 in 6-decimal USDC — matches on-chain SaleContractV2.perPersonCapUSD. */
+export const DEFAULT_MAX_PAYMENT_USDC_6DEC = "864000000";
+
+/** Discriminated result of a relay attempt. */
+export type RelayResult =
+  | { ok: true; txHash: string; matchedRule: string }
+  | { ok: false; code: RelayErrorCode; reason: string };
+
+export type RelayErrorCode =
+  | "INVALID_SHAPE"
+  | "EXPIRED"
+  | "SIGNATURE_INVALID"
+  | "NOT_WHITELISTED"
+  | "RATE_LIMITED"
+  | "SUBMIT_FAILED"
+  | "INFRA_NOT_READY";

--- a/src/modules/relay/relay.controller.ts
+++ b/src/modules/relay/relay.controller.ts
@@ -1,0 +1,61 @@
+import { Body, Controller, Get, HttpException, Post } from "@nestjs/common";
+import { ApiOperation, ApiTags } from "@nestjs/swagger";
+import { RelayService } from "./relay.service.js";
+import { RelayV3Dto } from "./dto/relay.dto.js";
+import type { RelayErrorCode } from "./relay.constants.js";
+
+/**
+ * Gasless purchase relay endpoints (#98). Wire-compatible with the legacy
+ * Cloudflare Worker so the SDK only repoints `relayerUrl` at a DVT node.
+ *
+ *   GET  /relay/health  — readiness + operator address
+ *   POST /v3/relay      — submit a gasless GToken / aPNTs purchase
+ */
+@ApiTags("relay")
+@Controller()
+export class RelayController {
+  constructor(private readonly relayService: RelayService) {}
+
+  @Get("relay/health")
+  @ApiOperation({ summary: "Relay readiness check" })
+  health(): { status: string; operator: string | null; chainId?: number } {
+    return {
+      status: this.relayService.isEnabled() ? "ok" : "disabled",
+      operator: this.relayService.operatorAddress(),
+    };
+  }
+
+  @Post("v3/relay")
+  @ApiOperation({ summary: "Gasless GToken/aPNTs purchase via BuyHelper (EIP-3009 + BuyIntent)" })
+  async relayV3(
+    @Body() body: RelayV3Dto
+  ): Promise<{ txHash: string; matchedRule: string; status: string }> {
+    const result = await this.relayService.relay(body);
+    if (!result.ok) {
+      throw new HttpException(
+        { error: result.reason, code: result.code },
+        this.httpStatus(result.code)
+      );
+    }
+    return { txHash: result.txHash, matchedRule: result.matchedRule, status: "submitted" };
+  }
+
+  private httpStatus(code: RelayErrorCode): number {
+    switch (code) {
+      case "INVALID_SHAPE":
+      case "EXPIRED":
+      case "SIGNATURE_INVALID":
+        return 400;
+      case "NOT_WHITELISTED":
+        return 403;
+      case "RATE_LIMITED":
+        return 429;
+      case "INFRA_NOT_READY":
+        return 503;
+      case "SUBMIT_FAILED":
+        return 502;
+      default:
+        return 500;
+    }
+  }
+}

--- a/src/modules/relay/relay.module.ts
+++ b/src/modules/relay/relay.module.ts
@@ -1,0 +1,16 @@
+import { Module } from "@nestjs/common";
+import { RelayService } from "./relay.service.js";
+import { RelayController } from "./relay.controller.js";
+
+/**
+ * Optional gasless purchase relay (#98). Opt-in via RELAY_ENABLED. The
+ * CapabilityRegistry it self-registers into is a @Global singleton, so no
+ * explicit import is needed here. Always loaded; the endpoint returns 503 until
+ * RELAY_ENABLED + a valid RELAY_OPERATOR_PK make the operator wallet live.
+ */
+@Module({
+  providers: [RelayService],
+  controllers: [RelayController],
+  exports: [RelayService],
+})
+export class RelayModule {}

--- a/src/modules/relay/relay.service.spec.ts
+++ b/src/modules/relay/relay.service.spec.ts
@@ -1,0 +1,188 @@
+import { ethers } from "ethers";
+import { RelayService } from "./relay.service.js";
+import { BUY_INTENT_TYPES } from "./relay.constants.js";
+
+const CHAIN_ID = 11155111;
+const BUY_HELPER = ethers.getAddress("0x" + "ab".repeat(20));
+const USDC = ethers.getAddress("0x" + "11".repeat(20));
+const GTOKEN = ethers.getAddress("0x" + "22".repeat(20));
+const APNTS = ethers.getAddress("0x" + "33".repeat(20));
+const RECIPIENT = ethers.getAddress("0x" + "44".repeat(20));
+const NONCE = "0x" + "55".repeat(32);
+
+// Fixed buyer so signatures are deterministic.
+const buyer = new ethers.Wallet("0x" + "11".repeat(32));
+const stranger = new ethers.Wallet("0x" + "22".repeat(32));
+
+// Clock fixed at t = 1e12 ms → nowSec = 1e9 s. Deadlines below use 2e9 s (future).
+const NOW_MS = 1_000_000_000_000;
+const FUTURE_DEADLINE = 2_000_000_000;
+
+const BASE_CONFIG: Record<string, unknown> = {
+  relayEnabled: true,
+  relayChainId: CHAIN_ID,
+  relayBuyHelper: BUY_HELPER,
+  relayUsdc: USDC,
+  relayGtoken: GTOKEN,
+  relayApnts: APNTS,
+  relayMaxPaymentAmount: "864000000",
+  relayRateLimitPerAddressPerHour: 2,
+  relayRateLimitGlobalPerHour: 3,
+};
+
+function makeConfig(overrides: Record<string, unknown> = {}) {
+  const cfg = { ...BASE_CONFIG, ...overrides };
+  return { get: (k: string) => cfg[k] } as any;
+}
+
+function makeRegistry() {
+  const registered: Array<{ name: string; enabled: boolean }> = [];
+  return { registered, register: (cap: any) => registered.push(cap) } as any;
+}
+
+const DOMAIN = {
+  name: "MyceliumBuyHelper",
+  version: "1",
+  chainId: CHAIN_ID,
+  verifyingContract: BUY_HELPER,
+};
+
+async function signedBody(
+  signer: ethers.Wallet = buyer,
+  intentOverrides: Record<string, unknown> = {}
+): Promise<any> {
+  const intent = {
+    buyer: buyer.address,
+    paymentToken: USDC,
+    paymentAmount: "1000000",
+    targetToken: GTOKEN,
+    recipient: RECIPIENT,
+    minOut: "0",
+    deadline: FUTURE_DEADLINE,
+    nonce: NONCE,
+    ...intentOverrides,
+  };
+  const message = {
+    buyer: intent.buyer,
+    paymentToken: intent.paymentToken,
+    paymentAmount: BigInt(intent.paymentAmount as string),
+    targetToken: intent.targetToken,
+    recipient: intent.recipient,
+    minOut: BigInt(intent.minOut as string),
+    deadline: BigInt(intent.deadline as number),
+    nonce: intent.nonce,
+  };
+  const buyIntentSig = await signer.signTypedData(DOMAIN, BUY_INTENT_TYPES as any, message);
+  return {
+    intent,
+    buyIntentSig,
+    transferAuth: { validAfter: 0, v: 27, r: "0x" + "00".repeat(32), s: "0x" + "00".repeat(32) },
+  };
+}
+
+function makeService(overrides: Record<string, unknown> = {}) {
+  return new RelayService(makeConfig(overrides), makeRegistry(), () => NOW_MS);
+}
+
+/** EXECUTE_BUY_FRAGMENT selector for executeBuy(...). */
+const EXECUTE_BUY_SELECTOR = new ethers.Interface([
+  "function executeBuy((address,address,uint256,address,address,uint256,uint256,bytes32),bytes,(uint256,uint8,bytes32,bytes32))",
+]).getFunction("executeBuy")!.selector;
+
+describe("RelayService", () => {
+  it("registers capability reflecting RELAY_ENABLED", () => {
+    const reg = makeRegistry();
+    new RelayService(makeConfig({ relayEnabled: false }), reg, () => NOW_MS);
+    expect(reg.registered).toEqual([expect.objectContaining({ name: "relay", enabled: false })]);
+  });
+
+  it("is disabled (no wallet) until bootstrap validates a key", () => {
+    const svc = makeService();
+    expect(svc.isEnabled()).toBe(false);
+    expect(svc.operatorAddress()).toBeNull();
+  });
+
+  it("relay() returns INFRA_NOT_READY when the operator wallet is not live", async () => {
+    const svc = makeService();
+    const res = await svc.relay(await signedBody());
+    expect(res).toEqual({ ok: false, code: "INFRA_NOT_READY", reason: expect.any(String) });
+  });
+
+  describe("validateAndBuild", () => {
+    it("accepts a valid GToken purchase and encodes executeBuy", async () => {
+      const svc = makeService();
+      const res = svc.validateAndBuild(await signedBody());
+      expect(res.ok).toBe(true);
+      if (res.ok) {
+        expect(res.matchedRule).toBe("TOKEN_BUY → GToken");
+        expect(res.callData.startsWith(EXECUTE_BUY_SELECTOR)).toBe(true);
+      }
+    });
+
+    it("accepts an aPNTs purchase", async () => {
+      const svc = makeService();
+      const res = svc.validateAndBuild(await signedBody(buyer, { targetToken: APNTS }));
+      expect(res.ok).toBe(true);
+      if (res.ok) expect(res.matchedRule).toBe("TOKEN_BUY → aPNTs");
+    });
+
+    it("rejects a non-whitelisted payment token", async () => {
+      const svc = makeService();
+      const body = await signedBody(buyer, {
+        paymentToken: ethers.getAddress("0x" + "99".repeat(20)),
+      });
+      expect(svc.validateAndBuild(body)).toMatchObject({ ok: false, code: "NOT_WHITELISTED" });
+    });
+
+    it("rejects a non-whitelisted target token", async () => {
+      const svc = makeService();
+      const body = await signedBody(buyer, {
+        targetToken: ethers.getAddress("0x" + "99".repeat(20)),
+      });
+      expect(svc.validateAndBuild(body)).toMatchObject({ ok: false, code: "NOT_WHITELISTED" });
+    });
+
+    it("rejects an expired deadline", async () => {
+      const svc = makeService();
+      const body = await signedBody(buyer, { deadline: 100 });
+      expect(svc.validateAndBuild(body)).toMatchObject({ ok: false, code: "EXPIRED" });
+    });
+
+    it("rejects a zero payment amount", async () => {
+      const svc = makeService();
+      const body = await signedBody(buyer, { paymentAmount: "0" });
+      expect(svc.validateAndBuild(body)).toMatchObject({ ok: false, code: "INVALID_SHAPE" });
+    });
+
+    it("rejects a payment over the per-tx cap", async () => {
+      const svc = makeService();
+      const body = await signedBody(buyer, { paymentAmount: "864000001" });
+      expect(svc.validateAndBuild(body)).toMatchObject({ ok: false, code: "NOT_WHITELISTED" });
+    });
+
+    it("rejects a signature from a different signer", async () => {
+      const svc = makeService();
+      // stranger signs but intent.buyer stays buyer.address → recovered ≠ buyer.
+      const body = await signedBody(stranger);
+      expect(svc.validateAndBuild(body)).toMatchObject({ ok: false, code: "SIGNATURE_INVALID" });
+    });
+  });
+
+  describe("rate limiting", () => {
+    it("enforces the per-address hourly cap", async () => {
+      const svc = makeService();
+      // Inject a stub wallet so relay() proceeds past INFRA_NOT_READY.
+      (svc as any).wallet = {
+        address: buyer.address,
+        sendTransaction: async () => ({ hash: "0xdead" }),
+      };
+
+      const r1 = await svc.relay(await signedBody());
+      const r2 = await svc.relay(await signedBody());
+      const r3 = await svc.relay(await signedBody());
+      expect(r1.ok).toBe(true);
+      expect(r2.ok).toBe(true);
+      expect(r3).toMatchObject({ ok: false, code: "RATE_LIMITED" });
+    });
+  });
+});

--- a/src/modules/relay/relay.service.ts
+++ b/src/modules/relay/relay.service.ts
@@ -1,0 +1,357 @@
+import { Injectable, Logger, Optional, OnApplicationBootstrap } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { ethers } from "ethers";
+import { CapabilityRegistry } from "../capability/capability-registry.service.js";
+import { RelayV3Dto } from "./dto/relay.dto.js";
+import {
+  BUY_INTENT_DOMAIN_NAME,
+  BUY_INTENT_DOMAIN_VERSION,
+  BUY_INTENT_TYPES,
+  DEFAULT_MAX_PAYMENT_USDC_6DEC,
+  EXECUTE_BUY_FRAGMENT,
+  SEPOLIA_DEFAULTS,
+  type RelayErrorCode,
+  type RelayResult,
+} from "./relay.constants.js";
+
+/**
+ * Gasless purchase relay (#98) — optional, opt-in module.
+ *
+ * Ports the v3 path of the standalone `mycelium/launch → services/relayer`
+ * Cloudflare Worker into the DVT node so the launch token sale (GToken / aPNTs)
+ * no longer depends on a single centralized Worker. dvt1/2/3 can each run it for
+ * redundancy + anti-censorship — every node is an independent relayer; the SDK
+ * picks one and fails over. This is "redundancy decentralization"; the aPoints-
+ * metered economic layer (permissionless, paid relay) is a deferred Phase 2.
+ *
+ * It is ORTHOGONAL to the BLS signing core: the buyer signs with their own EOA
+ * (EIP-3009 + EIP-712 BuyIntent), the node submits with its operator EOA. No
+ * PackedUserOperation, no AAStarValidator, no BLS aggregation is involved — so
+ * this never touches the security-critical 403 owner-auth gate.
+ *
+ * Opt-in (RELAY_ENABLED, default off). Requires a DEDICATED RELAY_OPERATOR_PK —
+ * a funded hot wallet that pays gas. It intentionally does NOT fall back to the
+ * validator-owner ETH_PRIVATE_KEY: the relay operator is a public-facing
+ * gas-paying key and must be isolated from the registration/owner key.
+ *
+ * Off-chain checks here (whitelist, caps, deadline, signature recovery) are a
+ * fast-fail gate to save gas; BuyHelper re-verifies everything on-chain and is
+ * authoritative.
+ */
+@Injectable()
+export class RelayService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(RelayService.name);
+
+  private readonly enabledByConfig: boolean;
+  private readonly operatorPk: string;
+  private readonly rpcUrl: string;
+  private readonly chainId: number;
+  private readonly buyHelper: string;
+  private readonly usdc: string;
+  private readonly gtoken: string;
+  private readonly apnts: string;
+  private readonly maxPaymentAmount: bigint;
+  private readonly maxPerAddressPerHour: number;
+  private readonly maxGlobalPerHour: number;
+  private readonly now: () => number;
+
+  /** Live once bootstrap validates the operator key; null = relay disabled. */
+  private wallet: ethers.Wallet | null = null;
+
+  /** In-memory rate-limit counters, replacing the Worker's Cloudflare KV. */
+  private readonly addrCounts = new Map<string, number>();
+  private readonly globalCounts = new Map<number, number>();
+
+  /** Serializes on-chain submissions so concurrent requests can't reuse a nonce. */
+  private submitChain: Promise<unknown> = Promise.resolve();
+
+  constructor(
+    private readonly config: ConfigService,
+    @Optional() capabilityRegistry?: CapabilityRegistry,
+    /** Test seam: controls `Date.now()` for deadline/rate-limit windows. */
+    @Optional() now?: () => number
+  ) {
+    this.enabledByConfig = config.get<boolean>("relayEnabled") === true;
+    this.operatorPk = config.get<string>("relayOperatorPk") ?? "";
+    this.rpcUrl = config.get<string>("relayRpcUrl") ?? config.get<string>("ethRpcUrl") ?? "";
+    this.chainId = config.get<number>("relayChainId") ?? SEPOLIA_DEFAULTS.chainId;
+    this.buyHelper = config.get<string>("relayBuyHelper") ?? SEPOLIA_DEFAULTS.buyHelper;
+    this.usdc = config.get<string>("relayUsdc") ?? SEPOLIA_DEFAULTS.usdc;
+    this.gtoken = config.get<string>("relayGtoken") ?? SEPOLIA_DEFAULTS.gtoken;
+    this.apnts = config.get<string>("relayApnts") ?? SEPOLIA_DEFAULTS.apnts;
+    this.maxPaymentAmount = BigInt(
+      config.get<string>("relayMaxPaymentAmount") ?? DEFAULT_MAX_PAYMENT_USDC_6DEC
+    );
+    this.maxPerAddressPerHour = config.get<number>("relayRateLimitPerAddressPerHour") ?? 5;
+    this.maxGlobalPerHour = config.get<number>("relayRateLimitGlobalPerHour") ?? 100;
+    this.now = now ?? (() => Date.now());
+
+    capabilityRegistry?.register({
+      name: "relay",
+      class: "infra-app",
+      description: "Gasless GToken/aPNTs purchase relay for the launch sale (#98)",
+      enabled: this.enabledByConfig,
+    });
+  }
+
+  onApplicationBootstrap(): void {
+    if (!this.enabledByConfig) return;
+    if (!/^0x[0-9a-fA-F]{64}$/.test(this.operatorPk)) {
+      this.logger.warn(
+        "Relay: RELAY_ENABLED=true but RELAY_OPERATOR_PK missing/invalid " +
+          "(must be 32-byte 0x hex, dedicated — NOT the validator owner key) — disabled"
+      );
+      return;
+    }
+    if (!this.rpcUrl) {
+      this.logger.warn(
+        "Relay: RELAY_ENABLED=true but no RPC URL (RELAY_RPC_URL/ETH_RPC_URL) — disabled"
+      );
+      return;
+    }
+    const provider = new ethers.JsonRpcProvider(this.rpcUrl, this.chainId);
+    this.wallet = new ethers.Wallet(this.operatorPk, provider);
+    this.logger.log(
+      `Gasless relay ENABLED — operator=${this.wallet.address} chainId=${this.chainId} ` +
+        `buyHelper=${this.buyHelper} caps: ${this.maxPerAddressPerHour}/addr/h ` +
+        `${this.maxGlobalPerHour}/global/h perTx≤${this.maxPaymentAmount}`
+    );
+  }
+
+  /** True once the operator wallet is live (RELAY_ENABLED + valid key + RPC). */
+  isEnabled(): boolean {
+    return this.wallet !== null;
+  }
+
+  /** Operator address for /relay/health, or null when disabled. */
+  operatorAddress(): string | null {
+    return this.wallet?.address ?? null;
+  }
+
+  /**
+   * Full relay attempt: rate limit → validate/build → submit. Never throws;
+   * returns a discriminated RelayResult that the controller maps to HTTP status.
+   */
+  async relay(body: RelayV3Dto): Promise<RelayResult> {
+    if (!this.wallet) {
+      return { ok: false, code: "INFRA_NOT_READY", reason: "relay not enabled on this node" };
+    }
+
+    const buyer = body?.intent?.buyer;
+    if (!buyer || typeof buyer !== "string" || !/^0x[0-9a-fA-F]{40}$/.test(buyer)) {
+      return { ok: false, code: "INVALID_SHAPE", reason: "intent.buyer must be a valid address" };
+    }
+
+    const rl = this.checkRateLimit(buyer);
+    if (!rl.allowed) {
+      return { ok: false, code: "RATE_LIMITED", reason: rl.reason };
+    }
+
+    const built = this.validateAndBuild(body);
+    if (!built.ok) return built;
+
+    return this.submit(built.callData, built.matchedRule);
+  }
+
+  /**
+   * Pure validation + calldata encoding (no network). Verifies whitelist, caps,
+   * deadline and the BuyIntent signature, then ABI-encodes executeBuy. Exposed
+   * for unit testing.
+   */
+  validateAndBuild(
+    body: RelayV3Dto
+  ):
+    | { ok: true; callData: string; matchedRule: string }
+    | { ok: false; code: RelayErrorCode; reason: string } {
+    if (!body?.intent || !body?.buyIntentSig || !body?.transferAuth) {
+      return { ok: false, code: "INVALID_SHAPE", reason: "missing required fields" };
+    }
+    const i = body.intent;
+    if (!i.buyer || !i.paymentToken || !i.targetToken || !i.recipient || !i.nonce) {
+      return { ok: false, code: "INVALID_SHAPE", reason: "missing intent field" };
+    }
+
+    // Whitelist: USDC payment only; GToken or aPNTs target only.
+    if (i.paymentToken.toLowerCase() !== this.usdc.toLowerCase()) {
+      return {
+        ok: false,
+        code: "NOT_WHITELISTED",
+        reason: `paymentToken ${i.paymentToken} not whitelisted`,
+      };
+    }
+    const isGToken = i.targetToken.toLowerCase() === this.gtoken.toLowerCase();
+    const isAPNTs = i.targetToken.toLowerCase() === this.apnts.toLowerCase();
+    if (!isGToken && !isAPNTs) {
+      return {
+        ok: false,
+        code: "NOT_WHITELISTED",
+        reason: `targetToken ${i.targetToken} not whitelisted`,
+      };
+    }
+
+    // Deadline (cheap, before signature work).
+    const nowSec = Math.floor(this.now() / 1000);
+    if (i.deadline < nowSec) {
+      return { ok: false, code: "EXPIRED", reason: `deadline ${i.deadline} < now ${nowSec}` };
+    }
+
+    // Amount caps.
+    let paymentAmount: bigint;
+    let minOut: bigint;
+    try {
+      paymentAmount = BigInt(i.paymentAmount);
+      minOut = BigInt(i.minOut);
+    } catch {
+      return { ok: false, code: "INVALID_SHAPE", reason: "paymentAmount/minOut not integer" };
+    }
+    if (paymentAmount === 0n) {
+      return { ok: false, code: "INVALID_SHAPE", reason: "paymentAmount must be > 0" };
+    }
+    if (paymentAmount > this.maxPaymentAmount) {
+      return {
+        ok: false,
+        code: "NOT_WHITELISTED",
+        reason: `paymentAmount ${paymentAmount} exceeds per-tx cap ${this.maxPaymentAmount}`,
+      };
+    }
+
+    // Off-chain verify BuyIntent (BuyHelper re-checks on-chain).
+    let recovered: string;
+    try {
+      recovered = ethers.verifyTypedData(
+        {
+          name: BUY_INTENT_DOMAIN_NAME,
+          version: BUY_INTENT_DOMAIN_VERSION,
+          chainId: this.chainId,
+          verifyingContract: this.buyHelper,
+        },
+        BUY_INTENT_TYPES as unknown as Record<string, ethers.TypedDataField[]>,
+        {
+          buyer: i.buyer,
+          paymentToken: i.paymentToken,
+          paymentAmount,
+          targetToken: i.targetToken,
+          recipient: i.recipient,
+          minOut,
+          deadline: BigInt(i.deadline),
+          nonce: i.nonce,
+        },
+        body.buyIntentSig
+      );
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { ok: false, code: "SIGNATURE_INVALID", reason: `BuyIntent verify threw: ${msg}` };
+    }
+    if (recovered.toLowerCase() !== i.buyer.toLowerCase()) {
+      return {
+        ok: false,
+        code: "SIGNATURE_INVALID",
+        reason: `BuyIntent signer ${recovered} ≠ buyer ${i.buyer}`,
+      };
+    }
+
+    // Encode executeBuy calldata.
+    let callData: string;
+    try {
+      const iface = new ethers.Interface([EXECUTE_BUY_FRAGMENT]);
+      callData = iface.encodeFunctionData("executeBuy", [
+        [
+          i.buyer,
+          i.paymentToken,
+          paymentAmount,
+          i.targetToken,
+          i.recipient,
+          minOut,
+          BigInt(i.deadline),
+          i.nonce,
+        ],
+        body.buyIntentSig,
+        [
+          BigInt(body.transferAuth.validAfter),
+          body.transferAuth.v,
+          body.transferAuth.r,
+          body.transferAuth.s,
+        ],
+      ]);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { ok: false, code: "INVALID_SHAPE", reason: `encode failed: ${msg}` };
+    }
+
+    return {
+      ok: true,
+      callData,
+      matchedRule: isGToken ? "TOKEN_BUY → GToken" : "TOKEN_BUY → aPNTs",
+    };
+  }
+
+  /** Submit the executeBuy tx, serialized so concurrent calls get distinct nonces. */
+  private submit(callData: string, matchedRule: string): Promise<RelayResult> {
+    const run = this.submitChain.then(
+      () => this.sendTx(callData, matchedRule),
+      () => this.sendTx(callData, matchedRule)
+    );
+    // Keep the chain alive regardless of this submission's outcome.
+    this.submitChain = run.catch(() => {});
+    return run;
+  }
+
+  private async sendTx(callData: string, matchedRule: string): Promise<RelayResult> {
+    try {
+      const tx = await this.wallet!.sendTransaction({
+        to: this.buyHelper,
+        data: callData,
+        value: 0n,
+      });
+      this.logger.log(`Relay submitted ${matchedRule} → ${tx.hash}`);
+      return { ok: true, txHash: tx.hash, matchedRule };
+    } catch (e: unknown) {
+      const msg =
+        (e as { shortMessage?: string })?.shortMessage ??
+        (e instanceof Error ? e.message : String(e));
+      this.logger.error(`Relay submit failed: ${msg}`);
+      return { ok: false, code: "SUBMIT_FAILED", reason: msg };
+    }
+  }
+
+  /**
+   * 1-hour fixed-window rate limit, per-address and global. Mirrors the Worker's
+   * KV limiter with in-memory counters; old windows are pruned on each check.
+   */
+  private checkRateLimit(buyer: string): { allowed: boolean; reason: string } {
+    const epoch = Math.floor(this.now() / 3_600_000);
+    this.pruneWindows(epoch);
+
+    const addrKey = `${buyer.toLowerCase()}:${epoch}`;
+    const addrCount = this.addrCounts.get(addrKey) ?? 0;
+    const globalCount = this.globalCounts.get(epoch) ?? 0;
+
+    if (addrCount >= this.maxPerAddressPerHour) {
+      return {
+        allowed: false,
+        reason: `Address rate limit: ${this.maxPerAddressPerHour}/hour exceeded`,
+      };
+    }
+    if (globalCount >= this.maxGlobalPerHour) {
+      return {
+        allowed: false,
+        reason: `Global rate limit: ${this.maxGlobalPerHour}/hour exceeded`,
+      };
+    }
+
+    this.addrCounts.set(addrKey, addrCount + 1);
+    this.globalCounts.set(epoch, globalCount + 1);
+    return { allowed: true, reason: "" };
+  }
+
+  /** Drop counters from windows older than the current one to bound memory. */
+  private pruneWindows(currentEpoch: number): void {
+    for (const epoch of this.globalCounts.keys()) {
+      if (epoch < currentEpoch) this.globalCounts.delete(epoch);
+    }
+    for (const key of this.addrCounts.keys()) {
+      const epoch = Number(key.slice(key.lastIndexOf(":") + 1));
+      if (epoch < currentEpoch) this.addrCounts.delete(key);
+    }
+  }
+}


### PR DESCRIPTION
Closes part of #98 (conservative Phase 1). Adds an **optional, opt-in** module that ports the launch token-sale relayer (`mycelium/launch → services/relayer`, v3 path) into the DVT node, so the gasless GToken/aPNTs purchase flow no longer depends on a single centralized Cloudflare Worker.

## What & why
- The user chose the **conservative** option from the #98 discussion: each DVT node runs an **independent relayer** (redundancy + anti-censorship), the SDK points `relayerUrl` at any node and fails over. This kills the single point of failure now. The **aPoints-metered, permissionless** economic layer (true decentralization, paid relay) remains a deferred **Phase 2**.
- **Orthogonal to BLS co-signing**: buyer + operator are plain EOAs (EIP-3009 USDC `transferWithAuthorization` + EIP-712 `BuyIntent` → `BuyHelper.executeBuy`). No `PackedUserOperation`, no `AAStarValidator`, no aggregation — so it **never touches the security-critical 403 owner-auth gate**.

## Module (`src/modules/relay/`)
- `RelayService` — off-chain `BuyIntent` verify (ethers `verifyTypedData`), whitelist (USDC payment; GToken/aPNTs target only), per-tx cap, **in-memory hourly rate limit** (per-address + global, replacing the Worker's Cloudflare KV, windows pruned), and **serialized submission** (mutex) so concurrent requests can't reuse a nonce. Off-chain checks are a gas-saving fast-fail gate; `BuyHelper` re-verifies everything on-chain and is authoritative.
- `RelayController` — `POST /v3/relay` (wire-compatible with the old Worker) + `GET /relay/health`.
- Ported with **ethers v6** (already in the repo) — no viem added.
- 12 unit tests (valid GToken/aPNTs, each rejection path, rate limit).

## Security
- **Opt-in** via `RELAY_ENABLED` (default off), mirroring the keeper module.
- Requires a **DEDICATED** `RELAY_OPERATOR_PK` (funded hot wallet) — it does **NOT** fall back to `ETH_PRIVATE_KEY`, isolating the public-facing gas-paying key from the validator-owner key. Hex-validated; warns + stays disabled on missing/invalid key.
- No fund-theft surface: the buyer signs their own intent (recipient is the buyer's choice); the relay only pays gas.

## Deploy
- `.env.testnet.example` documents all `RELAY_*` knobs (addresses default to the Sepolia Path-A sale stack).
- `deploy/README.md` §8 + `dvt-testnet.sh status` shows per-node relay state.
- dvt1/2/3 stay **off** until an operator funds a dedicated key and flips `RELAY_ENABLED` — no on-chain gas is spent silently.

## Known limitation (testnet-acceptable; mainnet follow-up)
A caller can burn operator gas via on-chain reverts (e.g. invalid `transferAuth`). Bounded today by rate limits + caps — same exposure as the original Worker. A pre-submit `eth_call` to reject reverting txs is deferred to Phase 2 hardening.

## Verification
- `npm run type-check` ✅  `npm run lint:check` ✅ (0 errors)  `npm run build` ✅
- `npx jest` ✅ 89/89 (12 new)
- Full app DI boot smoke ✅ — `RelayModule` resolves, `/v3/relay` + `/relay/health` mapped (the `@Optional()` Function-typed seam avoids the prior NestJS DI boot bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
