### PR TITLE
fix(#58 keeper): bind to cachedPrice() (ABI drift) + serve multiple paymasters

### DIFF
--- a/deploy/dvt-testnet.sh
+++ b/deploy/dvt-testnet.sh
@@ -97,6 +97,17 @@ status() {
       *) echo "  node$i relay: ❌ down" ;;
     esac
   done
+  echo "keeper (#58, optional):"
+  for i in 1 2 3; do
+    local port="${PORTS[$((i - 1))]}"
+    local h
+    h="$(curl -s -m 4 "http://localhost:$port/health" 2>/dev/null || true)"
+    case "$h" in
+      *'"name":"keeper","enabled":true'*) echo "  node$i keeper: ✅ enabled" ;;
+      *'"name":"keeper","enabled":false'*) echo "  node$i keeper: ⚪ disabled" ;;
+      *) echo "  node$i keeper: ❌ down" ;;
+    esac
+  done
   echo "public:"
   for h in "${HOSTS[@]}"; do
     if curl -s -m 8 "https://$h.aastar.io/node/info" >/dev/null 2>&1; then echo "  https://$h.aastar.io  ✅"; else echo "  https://$h.aastar.io  ❌"; fi

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -72,10 +72,14 @@ export default () => {
     // backend-independent (algorithm/wire is the fixed kernel — see conformance/).
     signerBackend: process.env.SIGNER_BACKEND || "local",
 
-    // Price Keeper (#58). Opt-in; keeps SuperPaymaster cachedPrice permanently fresh via
+    // Price Keeper (#58). Opt-in; keeps paymaster cachedPrice permanently fresh via
     // on-chain updatePrice() calls when approaching the staleness threshold. Requires
     // ETH_PRIVATE_KEY (or a dedicated KEEPER_PRIVATE_KEY in a future phase). Default off.
     // KEEPER_CHAINLINK_FEED defaults to the canonical Sepolia ETH/USD feed.
+    // KEEPER_PAYMASTER_ADDRESS is comma-separated — keep multiple paymasters fresh with
+    // one keeper (e.g. SuperPaymaster + a community PaymasterV4). The reader binds to
+    // `cachedPrice()` (returns price, updatedAt) which both SuperPaymaster v3 and
+    // PaymasterV4 expose; each paymaster's own priceStalenessThreshold is honored.
     keeperEnabled: process.env.KEEPER_ENABLED === "true",
     keeperIntervalMs: parseInt(process.env.KEEPER_INTERVAL_MS || "60000", 10),
     keeperRefreshBufferS: process.env.KEEPER_REFRESH_BUFFER_S || "300",

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -375,12 +375,19 @@ export class BlockchainService {
    * ABI confirmed against SuperPaymaster v5.4.x `getCachedPriceInfo()` + `priceStalenessThreshold()`.
    */
   async getPriceInfo(paymasterAddress: string): Promise<{ updatedAt: bigint; threshold: bigint }> {
+    // Both SuperPaymaster v3 (PriceCache: int256 price, uint256 updatedAt, uint80
+    // roundId, uint8 decimals) and PaymasterV4 (uint208 price, uint48 updatedAt)
+    // expose `cachedPrice()` — NOT `getCachedPriceInfo()` (which reverts on the
+    // current deployments). ABI encoding pads each field to its own word, so
+    // `updatedAt` is the 2nd return value in BOTH; a single minimal 2-field ABI
+    // reads it correctly for either type. (ABI mirrors @aastar/sdk PaymasterClient;
+    // the node stays standalone — no SDK runtime dep, per the DVT↛SDK contract.)
     const abi = [
-      "function getCachedPriceInfo() view returns (uint256 price, uint256 updatedAt)",
+      "function cachedPrice() view returns (uint256 price, uint256 updatedAt)",
       "function priceStalenessThreshold() view returns (uint256)",
     ];
     const contract = new ethers.Contract(paymasterAddress, abi, this.provider);
-    const [, updatedAt] = await contract.getCachedPriceInfo();
+    const [, updatedAt] = await contract.cachedPrice();
     const threshold = await contract.priceStalenessThreshold();
     return { updatedAt: BigInt(updatedAt), threshold: BigInt(threshold) };
   }

--- a/src/modules/keeper/keeper.service.spec.ts
+++ b/src/modules/keeper/keeper.service.spec.ts
@@ -205,6 +205,49 @@ describe("KeeperService", () => {
     expect(updatePriceCalled).toHaveLength(2);
   });
 
+  it("tick: refreshes every paymaster in a comma-separated list (independent thresholds)", async () => {
+    const updated: string[] = [];
+    const blockchain = makeBlockchain({
+      // both stale at NOW_NEAR_EXPIRY (updatedAt=1000, threshold=3600)
+      getPriceInfo: async () => ({ updatedAt: 1000n, threshold: 3600n }),
+      updatePrice: async (addr?: string) => {
+        updated.push(addr ?? "?");
+        return "0xTX";
+      },
+    } as any);
+    const a = "0x" + "aa".repeat(20);
+    const b = "0x" + "bb".repeat(20);
+    const svc = new KeeperService(
+      blockchain,
+      makeNotify(),
+      makeConfig({ keeperPaymasterAddress: `${a}, ${b}` }),
+      NOW_NEAR_EXPIRY
+    );
+    await svc.tick();
+    expect(updated).toEqual([a, b]);
+  });
+
+  it("tick: shared daily cap stops mid-list", async () => {
+    const updated: string[] = [];
+    const blockchain = makeBlockchain({
+      getPriceInfo: async () => ({ updatedAt: 1000n, threshold: 3600n }),
+      updatePrice: async (addr?: string) => {
+        updated.push(addr ?? "?");
+        return "0xTX";
+      },
+    } as any);
+    const a = "0x" + "aa".repeat(20);
+    const b = "0x" + "bb".repeat(20);
+    const svc = new KeeperService(
+      blockchain,
+      makeNotify(),
+      makeConfig({ keeperPaymasterAddress: `${a},${b}`, keeperMaxUpdatesPerDay: 1 }),
+      NOW_NEAR_EXPIRY
+    );
+    await svc.tick();
+    expect(updated).toEqual([a]); // cap=1 → only the first paymaster updates
+  });
+
   it("onApplicationShutdown clears the startup timer scheduled at bootstrap", () => {
     const svc = new KeeperService(makeBlockchain(), makeNotify(), makeConfig(), clockAt(0));
     svc.onApplicationBootstrap();

--- a/src/modules/keeper/keeper.service.ts
+++ b/src/modules/keeper/keeper.service.ts
@@ -42,7 +42,8 @@ export class KeeperService implements OnApplicationBootstrap, OnApplicationShutd
   private readonly refreshBufferS: bigint;
   private readonly maxUpdatesPerDay: number;
   private readonly maxBaseFeeGwei: bigint;
-  private readonly paymasterAddress: string;
+  /** One or more paymasters to keep fresh (KEEPER_PAYMASTER_ADDRESS, comma-separated). */
+  private readonly paymasterAddresses: string[];
   private readonly chainlinkFeed: string;
   private readonly clock: () => number;
   private readonly random: () => number;
@@ -67,7 +68,10 @@ export class KeeperService implements OnApplicationBootstrap, OnApplicationShutd
     this.refreshBufferS = BigInt(config.get<string>("keeperRefreshBufferS") ?? "300");
     this.maxUpdatesPerDay = config.get<number>("keeperMaxUpdatesPerDay") ?? 48;
     this.maxBaseFeeGwei = BigInt(config.get<string>("keeperMaxBaseFeeGwei") ?? "50");
-    this.paymasterAddress = config.get<string>("keeperPaymasterAddress") ?? "";
+    this.paymasterAddresses = (config.get<string>("keeperPaymasterAddress") ?? "")
+      .split(",")
+      .map(s => s.trim())
+      .filter(s => s.length > 0);
     this.chainlinkFeed = config.get<string>("keeperChainlinkFeed") ?? "";
     this.clock = clock ?? (() => Date.now());
     this.random = random ?? (() => Math.random());
@@ -75,14 +79,15 @@ export class KeeperService implements OnApplicationBootstrap, OnApplicationShutd
     capabilityRegistry?.register({
       name: "keeper",
       class: "infra-app",
-      description: "Chainlink price keeper — keeps SuperPaymaster cachedPrice fresh (#58)",
+      description:
+        "Chainlink price keeper — keeps SuperPaymaster / PaymasterV4 cachedPrice fresh (#58)",
       enabled: this.enabled,
     });
   }
 
   onApplicationBootstrap(): void {
     if (!this.enabled) return;
-    if (!this.paymasterAddress) {
+    if (this.paymasterAddresses.length === 0) {
       this.logger.warn(
         "Keeper: KEEPER_ENABLED=true but KEEPER_PAYMASTER_ADDRESS not set — disabled"
       );
@@ -102,7 +107,7 @@ export class KeeperService implements OnApplicationBootstrap, OnApplicationShutd
     }, jitterMs);
     this.logger.log(
       `Price Keeper ENABLED — interval=${this.intervalMs}ms jitter=${jitterMs}ms ` +
-        `paymaster=${this.paymasterAddress} buffer=${this.refreshBufferS}s ` +
+        `paymasters=[${this.paymasterAddresses.join(", ")}] buffer=${this.refreshBufferS}s ` +
         `cap=${this.maxUpdatesPerDay}/day maxBaseFee=${this.maxBaseFeeGwei}gwei`
     );
   }
@@ -142,17 +147,34 @@ export class KeeperService implements OnApplicationBootstrap, OnApplicationShutd
       return;
     }
 
-    // Read on-chain price freshness.
-    const { updatedAt, threshold } = await this.blockchainService.getPriceInfo(
-      this.paymasterAddress
-    );
-    const nowS = BigInt(Math.floor(this.clock() / 1000));
-    const age = nowS - updatedAt;
-    const timeUntilStale = threshold - age;
+    // Guardrail: skip the whole tick if gas is expensive (one read per tick).
+    const baseFeeGwei = await this.blockchainService.getBaseFeeGwei();
+    if (baseFeeGwei > this.maxBaseFeeGwei) {
+      this.logger.warn(
+        `Keeper: baseFee ${baseFeeGwei} gwei > max ${this.maxBaseFeeGwei} gwei, skipping`
+      );
+      return;
+    }
 
+    const nowS = BigInt(Math.floor(this.clock() / 1000));
+    // Each paymaster is independent (its own staleness threshold). The daily cap
+    // is shared across all of them; stop once it's exhausted this tick.
+    for (const addr of this.paymasterAddresses) {
+      if (this.updatesToday >= this.maxUpdatesPerDay) break;
+      await this.refreshOne(addr, nowS);
+    }
+  }
+
+  /**
+   * Refresh a single paymaster if its cached price is approaching staleness AND
+   * Chainlink has a newer reading. Never throws; logs + notifies on failure.
+   */
+  private async refreshOne(paymaster: string, nowS: bigint): Promise<void> {
+    const { updatedAt, threshold } = await this.blockchainService.getPriceInfo(paymaster);
+    const timeUntilStale = threshold - (nowS - updatedAt);
     if (timeUntilStale > this.refreshBufferS) {
       this.logger.debug(
-        `Keeper: price fresh — stale in ${timeUntilStale}s (buffer=${this.refreshBufferS}s)`
+        `Keeper: ${paymaster} fresh — stale in ${timeUntilStale}s (buffer=${this.refreshBufferS}s)`
       );
       return;
     }
@@ -163,32 +185,24 @@ export class KeeperService implements OnApplicationBootstrap, OnApplicationShutd
     );
     if (chainlinkUpdatedAt <= updatedAt) {
       this.logger.debug(
-        `Keeper: Chainlink not updated since last price (chainlink=${chainlinkUpdatedAt} ≤ price=${updatedAt}), skipping`
-      );
-      return;
-    }
-
-    // Guardrail: skip if gas is expensive.
-    const baseFeeGwei = await this.blockchainService.getBaseFeeGwei();
-    if (baseFeeGwei > this.maxBaseFeeGwei) {
-      this.logger.warn(
-        `Keeper: baseFee ${baseFeeGwei} gwei > max ${this.maxBaseFeeGwei} gwei, skipping`
+        `Keeper: ${paymaster} Chainlink not updated since last price ` +
+          `(chainlink=${chainlinkUpdatedAt} ≤ price=${updatedAt}), skipping`
       );
       return;
     }
 
     try {
-      const txHash = await this.blockchainService.updatePrice(this.paymasterAddress);
+      const txHash = await this.blockchainService.updatePrice(paymaster);
       this.updatesToday++;
       this.logger.log(
-        `Keeper: updatePrice() → ${txHash} (${this.updatesToday}/${this.maxUpdatesPerDay} today)`
+        `Keeper: ${paymaster} updatePrice() → ${txHash} (${this.updatesToday}/${this.maxUpdatesPerDay} today)`
       );
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      this.logger.error(`Keeper: updatePrice() failed — ${msg}`);
+      this.logger.error(`Keeper: ${paymaster} updatePrice() failed — ${msg}`);
       // Fire-and-forget alert (notification failure must never block the keeper loop).
       void this.notificationService
-        .sendToAccount(this.paymasterAddress, `[Keeper] updatePrice failed: ${msg}`)
+        .sendToAccount(paymaster, `[Keeper] updatePrice failed: ${msg}`)
         .catch(() => {});
     }
   }


### PR DESCRIPTION
## Why

While wiring the keeper for the Sepolia testnet I found it was **broken against the current deployments** and couldn't serve the two paymasters we need.

### 1. ABI drift (real bug)
The keeper read `getCachedPriceInfo()` — which **reverts** on the current SuperPaymaster (`0x030025…`, v5.4.0-beta.1) and on the community PaymasterV4 (`0x1f0D4eF1…`). Both expose **`cachedPrice()`** instead:
- SuperPaymaster v3: `(int256 price, uint256 updatedAt, uint80 roundId, uint8 decimals)` — 4 words
- PaymasterV4: `(uint208 price, uint48 updatedAt)` — 2 words

ABI encoding pads each field to its own 32-byte word, so **`updatedAt` is the 2nd return slot in BOTH**. A single minimal ABI `cachedPrice() returns (uint256 price, uint256 updatedAt)` reads it correctly for either type — **verified on-chain** (SP updatedAt=1781615568, V4 updatedAt=1780196820). Mirrors `@aastar/sdk` `PaymasterClient`'s ABI; the node stays **standalone** (no SDK runtime dep — keeps the DVT↛SDK integration contract intact).

### 2. Multiple paymasters
`KEEPER_PAYMASTER_ADDRESS` is now **comma-separated**. `tick()` reads baseFee once, then loops each paymaster via `refreshOne()` — each honoring its **own** `priceStalenessThreshold` (SP=4200s, V4=86400s), sharing the daily cap. One keeper serves **SuperPaymaster + PaymasterV4**; the 3 testnet nodes run keepers redundantly (idempotent + jittered, unchanged).

Both Sepolia paymasters are **currently stale** (SP age ~6d ≫ 4200s; V4 age ~22d ≫ 86400s), so an enabled keeper will refresh them.

## Changes
- `blockchain.service.ts` `getPriceInfo` → `cachedPrice()` (the only consumer is the keeper).
- `keeper.service.ts` → `paymasterAddresses: string[]`, `tick()` loops `refreshOne()`.
- `configuration.ts` + `.env.testnet.example` document `KEEPER_*` + both Sepolia addresses.
- `dvt-testnet.sh` `status` shows per-node keeper state via `/health`.
- +2 keeper unit tests (multi-paymaster fan-out; shared-cap stops mid-list).

## Verification
- `npm run type-check` ✅  `npm run lint:check` ✅ (0 errors)  `npm run build` ✅
- `npx jest` ✅ **91/91** (14 keeper, +2 new)
- On-chain ABI confirmed against both live paymasters via the Sepolia RPC.

## Note
Found while answering "is the keeper working?" — this is exactly the kind of drift the `check-deps` skill guards. Worth a follow-up to add the paymaster `cachedPrice()` ABI to the dependency baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
