### PR TITLE
feat(health): add GET / service index so the bare domain no longer 404s

### DIFF
--- a/src/modules/health/health.controller.ts
+++ b/src/modules/health/health.controller.ts
@@ -3,21 +3,50 @@ import { ApiOperation, ApiTags } from "@nestjs/swagger";
 import { CapabilityRegistry } from "../capability/capability-registry.service.js";
 
 /**
- * Top-level liveness endpoint. Plain `GET /health` is the conventional probe
- * (Docker/Cloudflare/uptime monitors hit it); the node previously only exposed
- * `/node/info` and `/relay/health`, so a bare `/health` 404'd. This always
- * returns 200 while the process is up and lists which optional capabilities are
- * enabled (relay, keeper, policy, …) from the global CapabilityRegistry.
+ * Root + liveness endpoints. Plain `GET /health` is the conventional probe
+ * (Docker/Cloudflare/uptime monitors hit it), and `GET /` is the bare-domain
+ * landing — both previously 404'd. They always return 200 while the process is
+ * up and list which optional capabilities are enabled (relay, keeper, policy, …)
+ * from the global CapabilityRegistry.
  */
 @ApiTags("health")
-@Controller("health")
+@Controller()
 export class HealthController {
   constructor(@Optional() private readonly capabilities?: CapabilityRegistry) {}
 
   @Get()
+  @ApiOperation({ summary: "Service index — identity + enabled capabilities + endpoint map" })
+  root(): {
+    service: string;
+    status: string;
+    capabilities: Array<{ name: string; enabled: boolean }>;
+    endpoints: Record<string, string>;
+  } {
+    return {
+      service: "aastar-dvt-node",
+      status: "ok",
+      capabilities: this.capList(),
+      endpoints: {
+        health: "GET /health",
+        node: "GET /node/info",
+        sign: "POST /signature/sign",
+        aggregate: "POST /signature/aggregate",
+        verify: "POST /signature/verify",
+        relay: "POST /v3/relay",
+        relayHealth: "GET /relay/health",
+        admin: "GET /admin",
+        docs: "GET /api",
+      },
+    };
+  }
+
+  @Get("health")
   @ApiOperation({ summary: "Liveness check + enabled capabilities" })
   health(): { status: string; capabilities: Array<{ name: string; enabled: boolean }> } {
-    const caps = (this.capabilities?.list() ?? []).map(c => ({ name: c.name, enabled: c.enabled }));
-    return { status: "ok", capabilities: caps };
+    return { status: "ok", capabilities: this.capList() };
+  }
+
+  private capList(): Array<{ name: string; enabled: boolean }> {
+    return (this.capabilities?.list() ?? []).map(c => ({ name: c.name, enabled: c.enabled }));
   }
 }


### PR DESCRIPTION
`https://dvtN.aastar.io/` returned **404** — there was no root route (only `/health`, `/node/info`, `/relay/health`, `/admin`, `/api`). Same gap class as the earlier missing `/health`.

Adds **`GET /`** → a small JSON service index:
```json
{ "service":"aastar-dvt-node", "status":"ok",
  "capabilities":[{"name":"relay","enabled":true},{"name":"keeper","enabled":true},…],
  "endpoints":{ "health":"GET /health","node":"GET /node/info","sign":"POST /signature/sign",
                "relay":"POST /v3/relay","admin":"GET /admin","docs":"GET /api", … } }
```
`HealthController` is now `@Controller()` with explicit `@Get("health")` + `@Get()` root — no collision with the relay (`v3/relay`, `relay/health`) or admin routes.

Verified live on dvt1/2/3 (`GET /` and `GET /health` both 200; capabilities show relay+keeper enabled). `npm run type-check` ✅ · `lint` ✅ (0 errors) · `jest` ✅ 91/91.

Deploy/ops only flavor — no behavior change to the signing/relay/keeper paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
