### PR TITLE
fix(#58/#98): stop redundant-keeper nonce jams — preflight + fee-bump + dedicated keeper key

### DIFF
--- a/deploy/.env.testnet.example
+++ b/deploy/.env.testnet.example
@@ -13,12 +13,17 @@ POLICY_ENABLED=false
 
 # --- Price Keeper (#58, optional; default OFF) ---
 # Keeps paymaster cachedPrice fresh by calling updatePrice() before it goes stale.
-# Needs ETH_PRIVATE_KEY (funded — pays the updatePrice gas). KEEPER_PAYMASTER_ADDRESS
-# is comma-separated → one keeper can serve several paymasters. 3 nodes run keepers
-# redundantly (idempotent + jittered). Sepolia defaults below: SuperPaymaster + the
-# community PaymasterV4. Chainlink feed defaults to Sepolia ETH/USD.
+# KEEPER_PAYMASTER_ADDRESS is comma-separated → one keeper can serve several
+# paymasters. 3 nodes run keepers redundantly (idempotent + jittered). Before each
+# submit the keeper STATIC-SIMULATES updatePrice() and skips if it would revert
+# (another keeper already refreshed it), so redundant keepers don't jam each other.
+# Fees are auto-bumped (estimate +15%, priority floor) for prompt inclusion.
+# Use a DEDICATED KEEPER_PRIVATE_KEY (funded) — keep it SEPARATE from
+# RELAY_OPERATOR_PK so keeper and relay don't share a nonce queue. Falls back to
+# ETH_PRIVATE_KEY only if unset. Sepolia defaults: SuperPaymaster + community
+# PaymasterV4. Chainlink feed defaults to Sepolia ETH/USD.
 KEEPER_ENABLED=false
-# ETH_PRIVATE_KEY=0x<funded key that pays updatePrice gas>
+# KEEPER_PRIVATE_KEY=0x<dedicated funded key for updatePrice gas — NOT the relay key>
 # KEEPER_PAYMASTER_ADDRESS=0x030025f40d509b1a99547bAEb3795bD27F7182b7,0x957852251f44570dc2B60Dde0954f191FF3372eE
 # KEEPER_INTERVAL_MS=60000
 # KEEPER_REFRESH_BUFFER_S=300

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -86,6 +86,10 @@ export default () => {
     keeperMaxUpdatesPerDay: parseInt(process.env.KEEPER_MAX_UPDATES_PER_DAY || "48", 10),
     keeperMaxBaseFeeGwei: process.env.KEEPER_MAX_BASE_FEE_GWEI || "50",
     keeperPaymasterAddress: process.env.KEEPER_PAYMASTER_ADDRESS || "",
+    // Dedicated keeper signer — keep it SEPARATE from RELAY_OPERATOR_PK so the
+    // keeper's updatePrice() nonce queue can't contend with relay submissions on
+    // one EOA. Falls back to ETH_PRIVATE_KEY only when unset.
+    keeperPrivateKey: process.env.KEEPER_PRIVATE_KEY || undefined,
     keeperChainlinkFeed:
       process.env.KEEPER_CHAINLINK_FEED || "0x694AA1769357215DE4FAC081bf1f309aDC325306",
 

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { ethers } from "ethers";
+import { bumpedFees } from "../../utils/gas.util.js";
 
 /** ERC-4337 v0.7 PackedUserOperation (the exact tuple EntryPoint.getUserOpHash takes). */
 export interface PackedUserOp {
@@ -20,6 +21,11 @@ export class BlockchainService {
   private readonly logger = new Logger(BlockchainService.name);
   private provider: ethers.Provider;
   private wallet: ethers.Wallet;
+  /** Dedicated keeper signer (KEEPER_PRIVATE_KEY) — kept SEPARATE from the relay
+   *  operator key and the admin/registration key so the keeper's updatePrice()
+   *  nonce queue can't contend with relay submissions on the same EOA. Falls back
+   *  to `wallet` (ETH_PRIVATE_KEY) only when KEEPER_PRIVATE_KEY is unset. */
+  private keeperWallet?: ethers.Wallet;
 
   constructor(private configService: ConfigService) {
     this.initializeProvider();
@@ -35,16 +41,31 @@ export class BlockchainService {
       this.logger.warn(
         "ETH_PRIVATE_KEY not set or using placeholder, blockchain operations will be disabled"
       );
-      return;
+    } else {
+      try {
+        this.wallet = new ethers.Wallet(privateKey, this.provider);
+        this.logger.log(`Blockchain service initialized with wallet: ${this.wallet.address}`);
+      } catch (error: any) {
+        this.logger.error(`Invalid private key provided: ${error.message}`);
+        this.logger.warn("Blockchain write operations will be disabled");
+      }
     }
 
-    try {
-      this.wallet = new ethers.Wallet(privateKey, this.provider);
-      this.logger.log(`Blockchain service initialized with wallet: ${this.wallet.address}`);
-    } catch (error: any) {
-      this.logger.error(`Invalid private key provided: ${error.message}`);
-      this.logger.warn("Blockchain write operations will be disabled");
+    // Dedicated keeper signer (optional). Unset → keeper reuses `wallet`.
+    const keeperKey = this.configService.get<string>("keeperPrivateKey");
+    if (keeperKey && /^0x[0-9a-fA-F]{64}$/.test(keeperKey)) {
+      try {
+        this.keeperWallet = new ethers.Wallet(keeperKey, this.provider);
+        this.logger.log(`Keeper signer (dedicated): ${this.keeperWallet.address}`);
+      } catch (error: any) {
+        this.logger.error(`Invalid KEEPER_PRIVATE_KEY: ${error.message}`);
+      }
     }
+  }
+
+  /** Signer the keeper uses for updatePrice() — dedicated key if set, else the admin wallet. */
+  private get keeperSigner(): ethers.Wallet | undefined {
+    return this.keeperWallet ?? this.wallet;
   }
 
   async registerNodeOnChain(
@@ -410,17 +431,40 @@ export class BlockchainService {
   }
 
   /**
-   * Call SuperPaymaster.updatePrice() — pushes a fresh Chainlink price on-chain.
-   * Requires a wallet (ETH_PRIVATE_KEY or KEEPER_PRIVATE_KEY).
-   * Returns the transaction hash.
+   * Static-simulate updatePrice() WITHOUT sending a tx. Returns true if it would
+   * succeed, false if it would revert (e.g. SuperPaymaster's OracleError when the
+   * cached price is already as fresh as Chainlink). The keeper calls this right
+   * before submitting so that, when several redundant keepers tick close together,
+   * only the first actually spends gas — the rest see the just-updated price and
+   * skip instead of broadcasting a doomed (revert) tx. Cheap eth_call, no nonce.
+   */
+  async canUpdatePrice(paymasterAddress: string): Promise<boolean> {
+    const signer = this.keeperSigner;
+    const abi = ["function updatePrice() external"];
+    const contract = new ethers.Contract(paymasterAddress, abi, signer ?? this.provider);
+    try {
+      await contract.updatePrice.staticCall();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Call SuperPaymaster/PaymasterV4 updatePrice() — pushes a fresh Chainlink price
+   * on-chain. Uses the dedicated keeper signer (KEEPER_PRIVATE_KEY) when set, and
+   * bumps the EIP-1559 fees (estimate +15%, priority floor) so the tx mines
+   * promptly instead of sitting underpriced. Returns the transaction hash.
    */
   async updatePrice(paymasterAddress: string): Promise<string> {
-    if (!this.wallet) {
-      throw new Error("Keeper: no wallet configured — set ETH_PRIVATE_KEY or KEEPER_PRIVATE_KEY");
+    const signer = this.keeperSigner;
+    if (!signer) {
+      throw new Error("Keeper: no wallet configured — set KEEPER_PRIVATE_KEY or ETH_PRIVATE_KEY");
     }
     const abi = ["function updatePrice() external"];
-    const contract = new ethers.Contract(paymasterAddress, abi, this.wallet);
-    const tx: ethers.TransactionResponse = await contract.updatePrice();
+    const contract = new ethers.Contract(paymasterAddress, abi, signer);
+    const fees = await bumpedFees(this.provider);
+    const tx: ethers.TransactionResponse = await contract.updatePrice(fees);
     return tx.hash;
   }
 }

--- a/src/modules/keeper/keeper.service.spec.ts
+++ b/src/modules/keeper/keeper.service.spec.ts
@@ -25,6 +25,7 @@ function makeBlockchain(
     getChainlinkUpdatedAt: () => Promise<bigint>;
     getBaseFeeGwei: () => Promise<bigint>;
     updatePrice: () => Promise<string>;
+    canUpdatePrice: () => Promise<boolean>;
   }> = {}
 ): any {
   return {
@@ -32,6 +33,8 @@ function makeBlockchain(
     getChainlinkUpdatedAt: overrides.getChainlinkUpdatedAt ?? (async () => 2000n),
     getBaseFeeGwei: overrides.getBaseFeeGwei ?? (async () => 10n),
     updatePrice: overrides.updatePrice ?? (async () => "0xabc"),
+    // Default: the on-chain static-sim says the update would succeed.
+    canUpdatePrice: overrides.canUpdatePrice ?? (async () => true),
   };
 }
 
@@ -140,6 +143,22 @@ describe("KeeperService", () => {
     const svc = new KeeperService(blockchain, makeNotify(), makeConfig(), NOW_NEAR_EXPIRY);
     await svc.tick();
     expect(updatePriceCalled).toHaveLength(1);
+  });
+
+  it("tick: skips submit when static-sim says updatePrice would revert (another keeper won)", async () => {
+    const updatePriceCalled: boolean[] = [];
+    const blockchain = makeBlockchain({
+      // stale + chainlink newer (would normally submit), but the pre-submit
+      // static-sim reverts → another keeper already refreshed it → skip.
+      canUpdatePrice: async () => false,
+      updatePrice: async () => {
+        updatePriceCalled.push(true);
+        return "0x";
+      },
+    });
+    const svc = new KeeperService(blockchain, makeNotify(), makeConfig(), NOW_NEAR_EXPIRY);
+    await svc.tick();
+    expect(updatePriceCalled).toHaveLength(0);
   });
 
   it("tick: skips when daily cap reached", async () => {

--- a/src/modules/keeper/keeper.service.ts
+++ b/src/modules/keeper/keeper.service.ts
@@ -191,6 +191,18 @@ export class KeeperService implements OnApplicationBootstrap, OnApplicationShutd
       return;
     }
 
+    // Final guard against redundant keepers: the staleness read above is from the
+    // start of the tick; another keeper may have updated the price since. Static-
+    // simulate updatePrice() right before submitting — if it would revert (price
+    // already fresh / not ready), skip instead of broadcasting a doomed tx that
+    // burns gas and jams the operator's nonce queue.
+    if (!(await this.blockchainService.canUpdatePrice(paymaster))) {
+      this.logger.debug(
+        `Keeper: ${paymaster} updatePrice would revert (already fresh / not ready), skipping`
+      );
+      return;
+    }
+
     try {
       const txHash = await this.blockchainService.updatePrice(paymaster);
       this.updatesToday++;

--- a/src/modules/relay/relay.service.spec.ts
+++ b/src/modules/relay/relay.service.spec.ts
@@ -171,9 +171,16 @@ describe("RelayService", () => {
   describe("rate limiting", () => {
     it("enforces the per-address hourly cap", async () => {
       const svc = makeService();
-      // Inject a stub wallet so relay() proceeds past INFRA_NOT_READY.
+      // Inject a stub wallet (with a provider for the fee-bump) so relay()
+      // proceeds past INFRA_NOT_READY.
       (svc as any).wallet = {
         address: buyer.address,
+        provider: {
+          getFeeData: async () => ({
+            maxFeePerGas: 3_000_000_000n,
+            maxPriorityFeePerGas: 2_000_000_000n,
+          }),
+        },
         sendTransaction: async () => ({ hash: "0xdead" }),
       };
 

--- a/src/modules/relay/relay.service.ts
+++ b/src/modules/relay/relay.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, Optional, OnApplicationBootstrap } from "@nestjs/co
 import { ConfigService } from "@nestjs/config";
 import { ethers } from "ethers";
 import { CapabilityRegistry } from "../capability/capability-registry.service.js";
+import { bumpedFees } from "../../utils/gas.util.js";
 import { RelayV3Dto } from "./dto/relay.dto.js";
 import {
   BUY_INTENT_DOMAIN_NAME,
@@ -298,10 +299,15 @@ export class RelayService implements OnApplicationBootstrap {
 
   private async sendTx(callData: string, matchedRule: string): Promise<RelayResult> {
     try {
+      // Bump fees (estimate +15%, priority floor) so the tx mines promptly — a
+      // BuyIntent carries a deadline, and an underpriced tx that mines late
+      // reverts on-chain with Expired (still burning the operator's gas).
+      const fees = await bumpedFees(this.wallet!.provider!);
       const tx = await this.wallet!.sendTransaction({
         to: this.buyHelper,
         data: callData,
         value: 0n,
+        ...fees,
       });
       this.logger.log(`Relay submitted ${matchedRule} → ${tx.hash}`);
       return { ok: true, txHash: tx.hash, matchedRule };

--- a/src/utils/gas.util.spec.ts
+++ b/src/utils/gas.util.spec.ts
@@ -1,0 +1,41 @@
+import { bumpedFees } from "./gas.util.js";
+
+function provider(fd: { maxFeePerGas: bigint | null; maxPriorityFeePerGas: bigint | null }) {
+  return { getFeeData: async () => fd } as any;
+}
+
+const GWEI = 1_000_000_000n;
+const FLOOR = 1_500_000_000n; // default priority floor = 1.5 gwei
+
+describe("bumpedFees", () => {
+  it("bumps the estimate by 15% by default", async () => {
+    const r = await bumpedFees(provider({ maxFeePerGas: 4n * GWEI, maxPriorityFeePerGas: 2n * GWEI }));
+    expect(r.maxPriorityFeePerGas).toBe((2n * GWEI * 115n) / 100n); // 2.3 gwei
+    expect(r.maxFeePerGas).toBe((4n * GWEI * 115n) / 100n); // 4.6 gwei
+  });
+
+  it("honors a custom bump percent", async () => {
+    const r = await bumpedFees(provider({ maxFeePerGas: 10n * GWEI, maxPriorityFeePerGas: 10n * GWEI }), 50);
+    expect(r.maxPriorityFeePerGas).toBe(15n * GWEI);
+    expect(r.maxFeePerGas).toBe(15n * GWEI);
+  });
+
+  it("raises priority to the floor when the estimate is below it", async () => {
+    const r = await bumpedFees(provider({ maxFeePerGas: 4n * GWEI, maxPriorityFeePerGas: 0n }));
+    expect(r.maxPriorityFeePerGas).toBe(FLOOR);
+    expect(r.maxFeePerGas).toBe((4n * GWEI * 115n) / 100n); // unchanged, still ≥ priority
+  });
+
+  it("derives maxFee from priority when the provider returns null fees", async () => {
+    const r = await bumpedFees(provider({ maxFeePerGas: null, maxPriorityFeePerGas: null }));
+    expect(r.maxPriorityFeePerGas).toBe(FLOOR);
+    expect(r.maxFeePerGas).toBe(FLOOR * 2n);
+  });
+
+  it("lifts maxFee above priority if the estimate inverts them", async () => {
+    // bumped priority (2.3 gwei) would exceed a tiny maxFee → maxFee = priority*2
+    const r = await bumpedFees(provider({ maxFeePerGas: 1n, maxPriorityFeePerGas: 2n * GWEI }));
+    expect(r.maxFeePerGas).toBe(r.maxPriorityFeePerGas * 2n);
+    expect(r.maxFeePerGas).toBeGreaterThan(r.maxPriorityFeePerGas);
+  });
+});

--- a/src/utils/gas.util.ts
+++ b/src/utils/gas.util.ts
@@ -1,0 +1,35 @@
+import { ethers } from "ethers";
+
+/**
+ * EIP-1559 fee override: take the provider's estimate and bump it, with a
+ * priority-fee floor. Underpriced txs sit in the mempool — and for time-bound
+ * txs (relay BuyIntents have a deadline, keeper updates chase a staleness
+ * window) a tx that mines late is worse than useless (it reverts and still
+ * burns gas). A modest bump buys timely inclusion.
+ *
+ * @param provider          ethers provider to read getFeeData() from
+ * @param bumpPct           percent to add on top of the estimate (default 15)
+ * @param priorityFloorWei  minimum maxPriorityFeePerGas (default 1.5 gwei) — RPC
+ *                          estimates often suggest ~0 priority on quiet testnets,
+ *                          which validators skip
+ */
+export async function bumpedFees(
+  provider: ethers.Provider,
+  bumpPct = 15,
+  priorityFloorWei = 1_500_000_000n
+): Promise<{ maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }> {
+  const fd = await provider.getFeeData();
+  const bump = (x: bigint | null): bigint | null =>
+    x == null ? null : (x * BigInt(100 + bumpPct)) / 100n;
+
+  let maxPriorityFeePerGas = bump(fd.maxPriorityFeePerGas) ?? priorityFloorWei;
+  if (maxPriorityFeePerGas < priorityFloorWei) maxPriorityFeePerGas = priorityFloorWei;
+
+  let maxFeePerGas = bump(fd.maxFeePerGas);
+  // If the provider gave no maxFeePerGas, or it's below the (bumped) priority,
+  // derive a safe ceiling: priority covers the tip, ×2 leaves room for baseFee.
+  if (maxFeePerGas == null || maxFeePerGas < maxPriorityFeePerGas) {
+    maxFeePerGas = maxPriorityFeePerGas * 2n;
+  }
+  return { maxFeePerGas, maxPriorityFeePerGas };
+}


### PR DESCRIPTION
## The bug (from on-chain investigation)

A relay tx "stuck >90s" turned out to be **mined-but-reverted** `BuyHelper.Expired(deadline, now)` — it sat in the mempool **~10 hours** (deadline was 30 min) before mining. Digging in:

- The submitting operator's txs were **underpriced** and, through a flaky RPC, sat / got dropped. Cross-checking 3 RPCs showed the "6 stuck pending" were a **stale mempool view** on the bad RPC; the network had dropped them. (RPC already switched to a healthy endpoint out-of-band.)
- Compounding it: **3 nodes race to `updatePrice()` the same paymasters**. The losers broadcast txs that revert `OracleError` (price already fresh) and, underpriced, **jammed the operator's nonce queue** (dvt3 had 6 stuck).
- Keeper and relay also **shared one EOA per node** (keeper reused `RELAY_OPERATOR_PK`), so their nonces contended.

## The fix (4 parts)

1. **Fee bump** — `utils/gas.util.ts` `bumpedFees()`: provider estimate +15%, priority-fee floor 1.5 gwei. Applied to **both** relay submit and keeper `updatePrice()` → prompt inclusion, no deadline-expiry reverts. *(+5 unit tests)*
2. **Keeper pre-submit static-sim** — `BlockchainService.canUpdatePrice()` eth_calls `updatePrice()`; the keeper **skips** when it would revert (another keeper just refreshed it). Shrinks the redundant-submit window from a full tick interval to ~1 block. *(+1 unit test)*
3. **Dedicated keeper signer** — `KEEPER_PRIVATE_KEY` (`keeperWallet`), kept **separate** from `RELAY_OPERATOR_PK` so keeper and relay can't contend on one nonce queue. Falls back to `ETH_PRIVATE_KEY` when unset.
4. (ops, already done) nodes moved off the flaky RPC.

## Live validation (Sepolia, 3 dedicated funded keeper keys)

Across a real staleness-window race:
- **node3 keeper submitted 0 txs** — preflight saw the price already fresh and skipped ✅
- all submitted txs **mined fast** (fee-bumped, e.g. 2.14 gwei, status=1) ✅
- **no keeper account had a nonce backlog** (`latest == pending` on all 3) — the prior jam is gone ✅

**Residual (documented, not a jam):** two keepers ticking within ~1 block can still both submit; the loser reverts `OracleError` but mines fast and clears. Zero-redundancy would need leader-election / deterministic paymaster→node assignment — deferred as a separate enhancement; happy to add if wanted.

## Tests
`type-check` ✅ · `lint` ✅ (0 errors) · `jest` ✅ **97/97** (+6).

Live nodes are already running this branch's build with 3 dedicated keeper keys for the validation above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
