### PR TITLE
fix(node): omit privateKey field from GET /node/info

### DIFF
--- a/src/modules/node/node.controller.ts
+++ b/src/modules/node/node.controller.ts
@@ -7,10 +7,10 @@ import { NodeService } from "./node.service.js";
 export class NodeController {
   constructor(private readonly nodeService: NodeService) {}
 
-  @ApiOperation({ summary: "Get current node information" })
+  @ApiOperation({ summary: "Get current node information (private key never exposed)" })
   @ApiResponse({
     status: 200,
-    description: "Current node information with hidden private key",
+    description: "Current node information — the private key is omitted entirely",
     schema: {
       type: "object",
       properties: {
@@ -20,21 +20,18 @@ export class NodeController {
         },
         nodeName: { type: "string", description: "Name of the node" },
         publicKey: { type: "string", description: "Public key in hex format" },
-        privateKey: {
-          type: "string",
-          description: "Always hidden for security",
-        },
         createdAt: { type: "string", description: "Node creation timestamp" },
       },
     },
   })
   @Get("info")
   getCurrentNodeInfo() {
-    const nodeState = this.nodeService.getCurrentNode();
-    return {
-      ...nodeState,
-      privateKey: "***HIDDEN***",
-    };
+    // Strip the private key OUT of the response (not just mask its value) so the
+    // public endpoint never even names the field. Other callers read the key via
+    // NodeService.getNodeForSigning(), not this DTO.
+    const { privateKey: _omitted, ...safe } = this.nodeService.getCurrentNode();
+    void _omitted;
+    return safe;
   }
 
   @ApiOperation({ summary: "Register current node on-chain" })


### PR DESCRIPTION
During DVT integration the SDK flagged (aastar-sdk#153) that `GET /node/info` returns a `"privateKey":"***HIDDEN***"` field — the **value** is masked but the **field name** is exposed on a public endpoint.

Fix: strip `privateKey` out of the response entirely (destructure-and-omit) instead of spreading the node state and masking the value, and drop it from the Swagger schema. Signing is unaffected — it reads the key via `NodeService.getNodeForSigning()`, not this DTO.

Verified live on dvt1: `/node/info` now returns `nodeId, nodeName, publicKey, createdAt, description` — no `privateKey`.

`type-check` ✅ · `lint` ✅ (0 errors) · `jest` ✅. No behavior change beyond the response shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
