### PR TITLE
feat(#124): out-of-band confirmation status + poll API (for SDK #176 Phase 4)

### DIFF
--- a/src/modules/confirmation/confirmation.service.spec.ts
+++ b/src/modules/confirmation/confirmation.service.spec.ts
@@ -95,6 +95,30 @@ describe("ConfirmationService — out-of-band confirmation (scheme A, #50 ⑤)",
     expect(await svc.gate(executeUserOp(101n), HASH)).toBe("pending");
   });
 
+  it("getStatus: not_found before any gate, pending after, approved after confirm (read-only)", async () => {
+    const n = notif(true);
+    const svc = make({ confirmEnabled: true, confirmThresholdWei: "100" }, n);
+    expect(svc.getStatus(HASH)).toEqual({ status: "not_found", expiresAt: null });
+
+    await svc.gate(executeUserOp(101n), HASH);
+    const pend = svc.getStatus(HASH);
+    expect(pend.status).toBe("pending");
+    expect(typeof pend.expiresAt).toBe("number");
+
+    const token = n.sent[0].match(/Confirm token: (0x[0-9a-f]+)/)![1];
+    svc.confirm(HASH, token);
+    expect(svc.getStatus(HASH).status).toBe("approved");
+    // read-only: polling didn't consume it — the gate still releases it
+    expect(await svc.gate(executeUserOp(101n), HASH)).toBe("confirmed");
+  });
+
+  it("getStatus: expired once TTL elapsed (ttl=0)", async () => {
+    const n = notif(true);
+    const svc = make({ confirmEnabled: true, confirmThresholdWei: "100", confirmTtlMs: 0 }, n);
+    await svc.gate(executeUserOp(101n), HASH);
+    expect(svc.getStatus(HASH).status).toBe("expired");
+  });
+
   it("expires a pending confirmation (ttl=0)", async () => {
     const n = notif(true);
     const svc = make({ confirmEnabled: true, confirmThresholdWei: "100", confirmTtlMs: 0 }, n);

--- a/src/modules/confirmation/confirmation.service.ts
+++ b/src/modules/confirmation/confirmation.service.ts
@@ -9,6 +9,9 @@ import { CapabilityRegistry } from "../capability/capability-registry.service.js
 /** Result of the confirmation gate for a co-sign request. */
 export type GateResult = "not_required" | "confirmed" | "pending" | "undeliverable";
 
+/** Read-only poll status of a pending confirmation (for SDK/UI; see getStatus). */
+export type ConfirmationStatus = "pending" | "approved" | "expired" | "not_found";
+
 interface Pending {
   token: string;
   confirmed: boolean;
@@ -103,6 +106,23 @@ export class ConfirmationService {
       return "undeliverable";
     }
     return "pending";
+  }
+
+  /**
+   * Read-only status of a pending confirmation — does NOT consume it (for SDK/UI
+   * polling, #124). The single-use consumption happens in gate() when the sign is
+   * re-submitted after approval.
+   *   not_found = never created, or already consumed by a successful sign
+   *   pending   = awaiting out-of-band approval
+   *   approved  = approved; re-submit the sign to release the signature
+   *   expired   = TTL elapsed without approval (the implicit "rejected"; explicit
+   *               reject isn't modeled — letting it expire is how a user declines)
+   */
+  getStatus(userOpHash: string): { status: ConfirmationStatus; expiresAt: number | null } {
+    const p = this.pending.get(userOpHash);
+    if (!p) return { status: "not_found", expiresAt: null };
+    if (p.expiry <= Date.now()) return { status: "expired", expiresAt: p.expiry };
+    return { status: p.confirmed ? "approved" : "pending", expiresAt: p.expiry };
   }
 
   /** Approve a pending op by its userOpHash + the out-of-band token. Single-use. */

--- a/src/modules/signature/signature.controller.ts
+++ b/src/modules/signature/signature.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, ValidationPipe, Logger, UseGuards } from "@nestjs/common";
+import { Controller, Post, Get, Param, Body, ValidationPipe, Logger, UseGuards } from "@nestjs/common";
 import { ThrottleGuard } from "../../common/throttle.guard.js";
 import { ApiTags, ApiOperation, ApiResponse, ApiBody } from "@nestjs/swagger";
 import { SignatureService } from "./signature.service.js";
@@ -119,6 +119,21 @@ export class SignatureController {
       this.logger.error(`❌ Sign Failed: ${error.message}`);
       throw error;
     }
+  }
+
+  @ApiOperation({ summary: "Poll out-of-band confirmation status (#124, for SDK/UI)" })
+  @ApiResponse({
+    status: 200,
+    description:
+      "{ userOpHash, status: pending|approved|expired|not_found, expiresAt }. " +
+      "approved → re-submit POST /signature/sign to release the signature; " +
+      "not_found → never created or already consumed by a successful sign; " +
+      "expired → TTL elapsed (re-submitting sign re-arms a new confirmation).",
+  })
+  @Get("confirmation/:userOpHash")
+  getConfirmationStatus(@Param("userOpHash") userOpHash: string) {
+    const s = this.signatureService.getConfirmationStatus(userOpHash);
+    return { userOpHash, ...s };
   }
 
   @ApiOperation({ summary: "Approve a high-value op pending out-of-band confirmation" })

--- a/src/modules/signature/signature.service.ts
+++ b/src/modules/signature/signature.service.ts
@@ -12,7 +12,10 @@ import { PackedUserOp } from "../blockchain/blockchain.service.js";
 /** Returned (instead of a signature) when a high-value op awaits out-of-band confirmation. */
 export interface PendingConfirmation {
   status: "pending_confirmation";
+  /** Pollable id — feed to GET /signature/confirmation/:userOpHash. */
   userOpHash: string;
+  /** Unix-ms expiry; after this the op must be re-submitted (it re-arms). null if unknown. */
+  expiresAt: number | null;
   message: string;
 }
 
@@ -62,9 +65,11 @@ export class SignatureService {
     }
     if (gate === "pending") {
       this.logger.log(`Awaiting out-of-band confirmation for ${userOpHash}`);
+      const { expiresAt } = this.confirmationService.getStatus(userOpHash);
       return {
         status: "pending_confirmation",
         userOpHash,
+        expiresAt,
         message: "high-value operation pending out-of-band confirmation; approve via your channel",
       };
     }
@@ -81,6 +86,11 @@ export class SignatureService {
   /** Approve a pending high-value op (out-of-band confirmation, #50 ⑤). */
   confirm(userOpHash: string, token: string): boolean {
     return this.confirmationService.confirm(userOpHash, token);
+  }
+
+  /** Read-only poll of a pending confirmation's status (#124, for SDK/UI). */
+  getConfirmationStatus(userOpHash: string) {
+    return this.confirmationService.getStatus(userOpHash);
   }
 
   async aggregateExternalSignatures(signatureStrings: string[]): Promise<AggregateSignatureResult> {


### PR DESCRIPTION
Closes the DVT-side boundary for SDK #176 Phase 4 (out-of-band confirmation UI).

The signer already withholds high-value ops behind out-of-band confirmation (`CONFIRM_ENABLED` + `CONFIRM_THRESHOLD_WEI`) and returns `pending_confirmation`, but the SDK had **no way to poll the outcome**. This adds the missing read API.

### Added
- **`GET /signature/confirmation/:userOpHash`** → `{ userOpHash, status, expiresAt }` where `status ∈ pending | approved | expired | not_found`.
- **`ConfirmationService.getStatus()`** — **read-only** (does NOT consume the pending entry; single-use consumption stays in `gate()` on sign re-submit).
- **`expiresAt`** (unix-ms TTL) now included in the `pending_confirmation` sign response, alongside the pollable `userOpHash` id.

### SDK flow (#176 Phase 4)
1. `POST /signature/sign` → `{ status: "pending_confirmation", userOpHash, expiresAt }`
2. poll `GET /signature/confirmation/:userOpHash` until `approved` (or `expired`)
3. on `approved` → re-`POST /signature/sign` to release the signature

### Semantics (documented in code + Swagger)
- `not_found` = never created **or** already consumed by a successful sign.
- `expired` = TTL elapsed (re-submitting sign re-arms a fresh confirmation). **`rejected` isn't modeled** — letting it expire is how a user declines.
- Approval channel: the existing one-time token over the user's independent channel → `POST /signature/confirm {userOpHash, token}`.

### Verified
`type-check` ✅ · `lint` ✅ (0 errors) · `jest` ✅ **99/99** (+4). Live: `GET /signature/confirmation/:hash` returns `{status:"not_found",expiresAt:null}` for an unknown hash on dvt1 (local + public).

Companion: AAStarCommunity/aastar-sdk#176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
