### PR TITLE
feat(#124): passkey out-of-band confirmation via KMS RP verify (path-2)

### DIFF
--- a/deploy/.env.testnet.example
+++ b/deploy/.env.testnet.example
@@ -11,6 +11,17 @@ ENTRY_POINT_ADDRESS=0x0000000071727De22E5E9d8BAf0edAc6f37da032
 POLICY_ENABLED=false
 # POLICY_REGISTRY_ADDRESS=0x8c2488d46d5447418558c38AA6441720df656094
 
+
+# --- Out-of-band confirmation path-2 (KMS, #124/#193; optional) ---
+# When CONFIRM_ENABLED=true, high-value ops are withheld until the user approves
+# via a passkey (WebAuthn) assertion verified by KMS (the RP). The node delegates
+# crypto verification to KMS POST /verify-confirm-assertion and resolves contacts
+# via GET /contact/{account}. Use a DEDICATED per-node, revocable API key (PII).
+# CONFIRM_ENABLED=false
+# CONFIRM_THRESHOLD_WEI=500000000000000000   # 0.5 ETH
+# KMS_BASE_URL=https://kms.aastar.io
+# KMS_API_KEY=<dedicated per-node revocable key>
+
 # --- Price Keeper (#58, optional; default OFF) ---
 # Keeps paymaster cachedPrice fresh by calling updatePrice() before it goes stale.
 # KEEPER_PAYMASTER_ADDRESS is comma-separated → one keeper can serve several

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -60,6 +60,12 @@ export default () => {
     confirmEnabled: process.env.CONFIRM_ENABLED === "true",
     confirmThresholdWei: process.env.CONFIRM_THRESHOLD_WEI || "0",
     confirmTtlMs: parseInt(process.env.CONFIRM_TTL_MS || "600000", 10),
+    // KMS endpoint for passkey out-of-band confirmation (path-2, #124/#193): the node
+    // delegates WebAuthn RP verification to KMS (POST /verify-confirm-assertion) and
+    // resolves verified contacts (GET /contact/{account}). Use a DEDICATED per-node,
+    // revocable API key (it reads PII). Unset → passkey confirm fail-closed.
+    kmsBaseUrl: process.env.KMS_BASE_URL || undefined,
+    kmsApiKey: process.env.KMS_API_KEY || undefined,
 
     // Per-IP rate limiting on signature endpoints (#50 hardening ⑦). Opt-in;
     // bounds pre-auth on-chain RPC amplification. Default off = behavior unchanged.

--- a/src/modules/confirmation/confirmation.service.spec.ts
+++ b/src/modules/confirmation/confirmation.service.spec.ts
@@ -42,7 +42,29 @@ function make(config: Record<string, unknown>, n: any): ConfirmationService {
   return new ConfirmationService({ get: (k: string) => config[k] } as any, n);
 }
 
+/** Build a service with an injected KMS verifier (path-2 test seam). */
+function makeKms(config: Record<string, unknown>, n: any, kmsVerify: any): ConfirmationService {
+  return new ConfirmationService({ get: (k: string) => config[k] } as any, n, undefined, kmsVerify);
+}
+
 const HASH = "0x" + "cd".repeat(32);
+
+/** base64url of a hex string's bytes. */
+function challengeOf(hash: string): string {
+  return Buffer.from(hash.replace(/^0x/, ""), "hex").toString("base64url");
+}
+/** A raw AuthenticationResponseJSON whose clientDataJSON binds `challengeB64`. */
+function passkeyWithChallenge(challengeB64: string): unknown {
+  const clientDataJSON = Buffer.from(
+    JSON.stringify({ type: "webauthn.get", challenge: challengeB64, origin: "https://kms.aastar.io" })
+  ).toString("base64url");
+  return {
+    id: "cred",
+    rawId: "cred",
+    type: "public-key",
+    response: { authenticatorData: "AAAA", clientDataJSON, signature: "BBBB" },
+  };
+}
 
 describe("ConfirmationService — out-of-band confirmation (scheme A, #50 ⑤)", () => {
   it("not_required when disabled", async () => {
@@ -110,6 +132,59 @@ describe("ConfirmationService — out-of-band confirmation (scheme A, #50 ⑤)",
     expect(svc.getStatus(HASH).status).toBe("approved");
     // read-only: polling didn't consume it — the gate still releases it
     expect(await svc.gate(executeUserOp(101n), HASH)).toBe("confirmed");
+  });
+
+  it("confirmWithPasskey: valid binding + KMS verified → confirmed, account passed, gate releases", async () => {
+    const calls: Array<{ a: string; u: string }> = [];
+    const svc = makeKms(
+      { confirmEnabled: true, confirmThresholdWei: "100" },
+      notif(true),
+      async (a: string, u: string) => {
+        calls.push({ a, u });
+        return true;
+      }
+    );
+    await svc.gate(executeUserOp(101n), HASH);
+    expect(await svc.confirmWithPasskey(HASH, passkeyWithChallenge(challengeOf(HASH)))).toBe(true);
+    expect(calls[0]).toEqual({ a: ACCOUNT, u: HASH }); // account (userOp.sender) forwarded to KMS
+    expect(await svc.gate(executeUserOp(101n), HASH)).toBe("confirmed");
+  });
+
+  it("confirmWithPasskey: challenge ≠ userOpHash → rejected, KMS NOT called", async () => {
+    let called = false;
+    const svc = makeKms({ confirmEnabled: true, confirmThresholdWei: "100" }, notif(true), async () => {
+      called = true;
+      return true;
+    });
+    await svc.gate(executeUserOp(101n), HASH);
+    // assertion bound to a different hash → local binding check fails first
+    expect(
+      await svc.confirmWithPasskey(HASH, passkeyWithChallenge(challengeOf("0x" + "00".repeat(32))))
+    ).toBe(false);
+    expect(called).toBe(false);
+  });
+
+  it("confirmWithPasskey: binding ok but KMS verified:false → rejected (fail-closed)", async () => {
+    const svc = makeKms(
+      { confirmEnabled: true, confirmThresholdWei: "100" },
+      notif(true),
+      async () => false
+    );
+    await svc.gate(executeUserOp(101n), HASH);
+    expect(await svc.confirmWithPasskey(HASH, passkeyWithChallenge(challengeOf(HASH)))).toBe(false);
+  });
+
+  it("confirmWithPasskey: KMS throws → rejected (fail-closed)", async () => {
+    const svc = makeKms({ confirmEnabled: true, confirmThresholdWei: "100" }, notif(true), async () => {
+      throw new Error("kms down");
+    });
+    await svc.gate(executeUserOp(101n), HASH);
+    expect(await svc.confirmWithPasskey(HASH, passkeyWithChallenge(challengeOf(HASH)))).toBe(false);
+  });
+
+  it("confirmWithPasskey: no pending entry → false", async () => {
+    const svc = makeKms({ confirmEnabled: true, confirmThresholdWei: "100" }, notif(true), async () => true);
+    expect(await svc.confirmWithPasskey(HASH, passkeyWithChallenge(challengeOf(HASH)))).toBe(false);
   });
 
   it("getStatus: expired once TTL elapsed (ttl=0)", async () => {

--- a/src/modules/confirmation/confirmation.service.ts
+++ b/src/modules/confirmation/confirmation.service.ts
@@ -2,9 +2,17 @@ import { Injectable, Logger, Optional } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { ethers } from "ethers";
 import { randomBytes } from "crypto";
+import axios from "axios";
 import { PackedUserOp } from "../blockchain/blockchain.service.js";
 import { NotificationService } from "../notification/notification.service.js";
 import { CapabilityRegistry } from "../capability/capability-registry.service.js";
+
+/** Out-of-band approval factor injected for testing the KMS RP verification. */
+export type KmsVerifyFn = (
+  account: string,
+  userOpHash: string,
+  passkey: unknown
+) => Promise<boolean>;
 
 /** Result of the confirmation gate for a co-sign request. */
 export type GateResult = "not_required" | "confirmed" | "pending" | "undeliverable";
@@ -16,6 +24,8 @@ interface Pending {
   token: string;
   confirmed: boolean;
   expiry: number;
+  /** Account (userOp.sender) — passed to KMS for passkey RP verification (path-2). */
+  account: string;
 }
 
 const EXECUTE_SELECTOR = ethers.id("execute(address,uint256,bytes)").slice(0, 10);
@@ -48,16 +58,25 @@ export class ConfirmationService {
   private readonly enabled: boolean;
   private readonly thresholdWei: bigint;
   private readonly ttlMs: number;
+  private readonly kmsBaseUrl: string;
+  private readonly kmsApiKey: string;
+  /** KMS RP verification (test seam — defaults to the real HTTP call). */
+  private readonly kmsVerify: KmsVerifyFn;
   private readonly pending = new Map<string, Pending>();
 
   constructor(
     configService: ConfigService,
     private readonly notificationService: NotificationService,
-    @Optional() capabilityRegistry?: CapabilityRegistry
+    @Optional() capabilityRegistry?: CapabilityRegistry,
+    /** Test seam: inject a fake KMS verifier. Production uses the real HTTP call. */
+    @Optional() kmsVerify?: KmsVerifyFn
   ) {
     this.enabled = configService.get<boolean>("confirmEnabled") === true;
     this.thresholdWei = BigInt(configService.get<string>("confirmThresholdWei") ?? "0");
     this.ttlMs = configService.get<number>("confirmTtlMs") ?? 600_000; // 10 min default
+    this.kmsBaseUrl = (configService.get<string>("kmsBaseUrl") ?? "").replace(/\/$/, "");
+    this.kmsApiKey = configService.get<string>("kmsApiKey") ?? "";
+    this.kmsVerify = kmsVerify ?? ((a, u, p) => this.realKmsVerify(a, u, p));
     capabilityRegistry?.register({
       name: "confirm",
       class: "infra-app",
@@ -96,7 +115,12 @@ export class ConfirmationService {
     // New high-value op → require out-of-band approval.
     if (!this.notificationService.hasContact(userOp.sender)) return "undeliverable";
     const token = "0x" + randomBytes(16).toString("hex");
-    this.pending.set(userOpHash, { token, confirmed: false, expiry: now + this.ttlMs });
+    this.pending.set(userOpHash, {
+      token,
+      confirmed: false,
+      expiry: now + this.ttlMs,
+      account: userOp.sender ?? "",
+    });
     const msg =
       `🔐 DVT confirmation required for ${userOp.sender}.\n` +
       `Op ${userOpHash}\nApprove only if you initiated it. Confirm token: ${token}`;
@@ -131,6 +155,69 @@ export class ConfirmationService {
     if (!p || p.expiry <= Date.now() || p.token !== token) return false;
     p.confirmed = true;
     return true;
+  }
+
+  /**
+   * Approve a pending op via a passkey (WebAuthn) assertion — path-2 (#124, #193).
+   * The passkey is a factor INDEPENDENT of the owner key, so this approval survives
+   * owner-key compromise (a stolen secp256k1 owner key alone cannot produce it).
+   *
+   * Two checks, both must pass (fail-closed):
+   *   1. local binding: clientDataJSON.type == "webauthn.get" AND challenge == base64url(userOpHash)
+   *      — the assertion is bound to THIS op (the node enforces this itself).
+   *   2. KMS RP verify: the WebAuthn assertion is cryptographically valid for the
+   *      account's registered passkey (the RP lives in KMS, not the node).
+   * `passkey` is the raw `navigator.credentials.get()` AuthenticationResponseJSON.
+   */
+  async confirmWithPasskey(userOpHash: string, passkey: unknown): Promise<boolean> {
+    const p = this.pending.get(userOpHash);
+    if (!p || p.expiry <= Date.now()) return false;
+
+    if (!this.assertionBindsTo(passkey, userOpHash)) {
+      this.logger.warn(`Passkey confirm ${userOpHash}: clientData challenge ≠ userOpHash — rejected`);
+      return false;
+    }
+    const verified = await this.kmsVerify(p.account, userOpHash, passkey).catch(e => {
+      this.logger.error(`Passkey confirm ${userOpHash}: KMS verify threw — ${String(e)}`);
+      return false; // fail-closed
+    });
+    if (!verified) return false;
+
+    p.confirmed = true;
+    return true;
+  }
+
+  /** clientDataJSON.type == "webauthn.get" AND its challenge == base64url(userOpHash). */
+  private assertionBindsTo(passkey: unknown, userOpHash: string): boolean {
+    try {
+      const cdjB64 = (passkey as { response?: { clientDataJSON?: unknown } })?.response
+        ?.clientDataJSON;
+      if (typeof cdjB64 !== "string") return false;
+      const cdj = JSON.parse(Buffer.from(cdjB64, "base64url").toString("utf8"));
+      if (cdj?.type !== "webauthn.get") return false;
+      const expected = Buffer.from(userOpHash.replace(/^0x/, ""), "hex").toString("base64url");
+      return cdj?.challenge === expected;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Real KMS RP verification — POST /verify-confirm-assertion (per-node x-api-key). Fail-closed. */
+  private async realKmsVerify(
+    account: string,
+    userOpHash: string,
+    passkey: unknown
+  ): Promise<boolean> {
+    if (!this.kmsBaseUrl) {
+      this.logger.error("Passkey confirm: KMS_BASE_URL not set — fail-closed");
+      return false;
+    }
+    const res = await axios.post(
+      `${this.kmsBaseUrl}/verify-confirm-assertion`,
+      { account, userOpHash, passkey },
+      { headers: { "x-api-key": this.kmsApiKey }, timeout: 8000 }
+    );
+    return res.data?.verified === true;
   }
 
   private nativeValue(userOp: PackedUserOp): bigint {

--- a/src/modules/signature/signature.controller.ts
+++ b/src/modules/signature/signature.controller.ts
@@ -136,16 +136,31 @@ export class SignatureController {
     return { userOpHash, ...s };
   }
 
-  @ApiOperation({ summary: "Approve a high-value op pending out-of-band confirmation" })
-  @ApiResponse({ status: 200, description: "Confirmation result { confirmed: boolean }" })
+  @ApiOperation({
+    summary: "Approve a high-value op pending out-of-band confirmation (passkey path-2 or legacy token)",
+  })
+  @ApiResponse({
+    status: 200,
+    description:
+      "{ status: 'confirmed'|'rejected', confirmed: boolean }. Pass `passkey` " +
+      "(raw AuthenticationResponseJSON, #124 path-2 — KMS RP verifies) or legacy `token`.",
+  })
   @Post("confirm")
-  confirm(@Body() body: { userOpHash?: string; token?: string }) {
-    const ok =
-      typeof body?.userOpHash === "string" &&
-      typeof body?.token === "string" &&
-      this.signatureService.confirm(body.userOpHash, body.token);
-    this.logger.log(`Confirm ${body?.userOpHash}: ${ok ? "accepted" : "rejected"}`);
-    return { confirmed: ok };
+  async confirm(
+    @Body() body: { userOpHash?: string; token?: string; passkey?: unknown }
+  ): Promise<{ status: "confirmed" | "rejected"; confirmed: boolean }> {
+    let ok = false;
+    if (typeof body?.userOpHash === "string") {
+      if (body.passkey) {
+        ok = await this.signatureService.confirmWithPasskey(body.userOpHash, body.passkey);
+      } else if (typeof body.token === "string") {
+        ok = this.signatureService.confirm(body.userOpHash, body.token);
+      }
+    }
+    this.logger.log(
+      `Confirm ${body?.userOpHash} (${body?.passkey ? "passkey" : "token"}): ${ok ? "accepted" : "rejected"}`
+    );
+    return { status: ok ? "confirmed" : "rejected", confirmed: ok };
   }
 
   @ApiOperation({ summary: "Aggregate multiple BLS signatures" })

--- a/src/modules/signature/signature.service.ts
+++ b/src/modules/signature/signature.service.ts
@@ -88,6 +88,11 @@ export class SignatureService {
     return this.confirmationService.confirm(userOpHash, token);
   }
 
+  /** Approve via a passkey (WebAuthn) assertion — path-2, KMS RP verify (#124/#193). */
+  confirmWithPasskey(userOpHash: string, passkey: unknown): Promise<boolean> {
+    return this.confirmationService.confirmWithPasskey(userOpHash, passkey);
+  }
+
   /** Read-only poll of a pending confirmation's status (#124, for SDK/UI). */
   getConfirmationStatus(userOpHash: string) {
     return this.confirmationService.getStatus(userOpHash);


### PR DESCRIPTION
Implements the locked **path-2** out-of-band confirmation now that KMS `verify-confirm-assertion` is live (kms.aastar.io v0.27.0). A high-value op is approved by a **passkey (WebAuthn) assertion** — a factor **independent of the owner key**, so it survives owner-key compromise (a stolen secp256k1 key alone can't produce it; the bot/token can't be replayed).

### DVT changes
- **`POST /signature/confirm`** accepts `{ userOpHash, passkey }` (raw `AuthenticationResponseJSON`, exactly what `navigator.credentials.get()` returns) **alongside** the legacy `{ userOpHash, token }`. Returns `{ status:'confirmed'|'rejected', confirmed }`.
- **`ConfirmationService.confirmWithPasskey`** — two checks, both must pass (fail-closed):
  1. **local binding** (node does it itself): `clientDataJSON.type=="webauthn.get"` AND `challenge == base64url(userOpHash)` → the assertion is bound to *this* op.
  2. **KMS RP verify** (the WebAuthn RP lives in KMS, not aNode): `POST {KMS}/verify-confirm-assertion { account, userOpHash, passkey }` with a **per-node `x-api-key`** → `{verified}`.
- `gate()` records `account` (userOp.sender) on the pending entry for the KMS call.
- Config `KMS_BASE_URL` / `KMS_API_KEY` (dedicated, per-node, revocable — it reads PII). **Fail-closed**: KMS unreachable / `verified:false` / bad binding → not approved.

### Why this is the secure design
The local binding stops a valid-but-unrelated assertion being replayed; KMS proves the passkey is the account's. Because approval needs a fresh passkey (not the owner key, not a bot-visible token), a thief with the owner key — or a compromised notify-bot — **cannot approve**. Matches the threat model in `docs/DVT_VALUE.md §8`.

### Tests / verify
`type-check` ✅ · `lint` ✅ (0 errors) · `jest` ✅ **104/104** (+5: binding pass/fail, KMS true/false/throws, no-pending). DI boot verified (the `@Optional()` KMS-verify seam avoids the boot bug; `/signature/confirm` mapped). KMS verify is a `@Optional()` test seam.

### Out of scope (follow-up)
NotificationService reading KMS `GET /contact/{account}` for *delivery* (the notify-bot side, gated on its design). This PR is the **verify** half (the SDK/YAA blocker).

Companion: AAStarCommunity/AirAccount#129, aastar-sdk#193, airaccount-contract#133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
