### PR TITLE
chore(check-deps): re-pin AirAccount(KMS) baseline → v0.26.1 / TA 0.8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ deploy/.run/
 
 # Per-node env overrides (independent keys: relay operator, keeper)
 deploy/node*/.env
+
+# test coverage report
+coverage/

--- a/scripts/check-deps.mjs
+++ b/scripts/check-deps.mjs
@@ -86,14 +86,19 @@ const DEPS = [
     repo: "AAStarCommunity/AirAccount",
     relationship:
       "UPSTREAM — KMS produces account owner secp256k1 sig (ownerAuth) Stage-1 verifies; C1 binding",
-    version: "v0.23.0",
+    version: "v0.26.1",
     configPath: null,
     configKey: null,
     addressLabel: null, // KMS/TA — no on-chain contract this node binds to
     address: null,
     // The signing scheme lives in the TEE Trusted App, NOT the host. ownerAuth verification
     // only breaks if the TA signing changes — so guard the TA (and proto) version.
-    deep: { versionGuard: { label: "TA", pinned: "0.5.0" } },
+    // Re-pinned v0.23.0→v0.26.1 / TA 0.5.0→0.8.0 (2026-06-27): reviewed every TA bump
+    // 0.6/0.7/0.8 — all in WebAuthn rpId / P256 session-key / agent-key paths, NONE touch
+    // the secp256k1 ownerAuth-over-userOpHash scheme this node's Stage-1 gate verifies.
+    // KMS verifyConfirmAssertion/getContact (path-2, #124/#126) are now address-keyed
+    // (userOp.sender), matching our impl. v0.27.0 was host-only (TA unchanged at 0.8.0).
+    deep: { versionGuard: { label: "TA", pinned: "0.8.0" } },
   },
 ];
 


### PR DESCRIPTION
The KMS dependency baseline in `scripts/check-deps.mjs` was stale (v0.23.0 / TA 0.5.0) and kept emitting **REAL DRIFT** on every `check-deps` run — alert fatigue that masks future genuine drift.

### Assessment (why this is safe — no DVT code change)
Reviewed every TA bump between the pin and latest:
| TA | release | change | touches secp256k1 ownerAuth? |
|---|---|---|---|
| 0.6 | v0.24 | WebAuthn rpId validation | ❌ |
| 0.7 | v0.25 | P256 session-key user-presence + proto wire | ❌ |
| 0.8 | v0.26 | agent/P256 key mint-challenge label binding | ❌ |

All changes are in the **WebAuthn / P256 / agent-key** paths. **None** touch the `secp256k1` `ownerAuth`-over-`userOpHash` scheme our Stage-1 gate verifies (`ethers.verifyMessage`). KMS `verifyConfirmAssertion`/`getContact` (path-2, #124/#126) are now **address-keyed** (`userOp.sender`) — matching our impl. KMS v0.27.0 was **host-only** (TA stayed 0.8.0).

### Change
Re-pin `AirAccount`: `version v0.23.0 → v0.26.1`, TA guard `0.5.0 → 0.8.0`. After: `npm run check-deps` → **exit 0, all aligned**.

Baseline hygiene only — no `src/` change, no node re-registration. (Per the check-deps skill: re-pin handed off for independent review, not self-merged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
