### PR TITLE
chore(confirm): lowercase account before KMS verify (defense-in-depth)

### DIFF
--- a/src/modules/confirmation/confirmation.service.spec.ts
+++ b/src/modules/confirmation/confirmation.service.spec.ts
@@ -150,6 +150,23 @@ describe("ConfirmationService — out-of-band confirmation (scheme A, #50 ⑤)",
     expect(await svc.gate(executeUserOp(101n), HASH)).toBe("confirmed");
   });
 
+  it("confirmWithPasskey: lowercases the account before the KMS call (defense-in-depth)", async () => {
+    const seen: string[] = [];
+    const svc = makeKms(
+      { confirmEnabled: true, confirmThresholdWei: "100" },
+      notif(true),
+      async (a: string) => {
+        seen.push(a);
+        return true;
+      }
+    );
+    const MIXED = "0xAbCdEf0000000000000000000000000000000011";
+    const hash = "0x" + "ee".repeat(32);
+    await svc.gate({ ...executeUserOp(101n), sender: MIXED }, hash);
+    expect(await svc.confirmWithPasskey(hash, passkeyWithChallenge(challengeOf(hash)))).toBe(true);
+    expect(seen[0]).toBe(MIXED.toLowerCase()); // checksummed sender → lowercased to KMS
+  });
+
   it("confirmWithPasskey: challenge ≠ userOpHash → rejected, KMS NOT called", async () => {
     let called = false;
     const svc = makeKms({ confirmEnabled: true, confirmThresholdWei: "100" }, notif(true), async () => {

--- a/src/modules/confirmation/confirmation.service.ts
+++ b/src/modules/confirmation/confirmation.service.ts
@@ -177,7 +177,11 @@ export class ConfirmationService {
       this.logger.warn(`Passkey confirm ${userOpHash}: clientData challenge ≠ userOpHash — rejected`);
       return false;
     }
-    const verified = await this.kmsVerify(p.account, userOpHash, passkey).catch(e => {
+    // Lowercase the account before the KMS call — defense-in-depth so a checksummed
+    // (EIP-55) userOp.sender always matches KMS's address key. KMS normalizes to
+    // lowercase internally (AirAccount v0.27.2), but we don't depend on that here.
+    const account = (p.account || "").toLowerCase();
+    const verified = await this.kmsVerify(account, userOpHash, passkey).catch(e => {
       this.logger.error(`Passkey confirm ${userOpHash}: KMS verify threw — ${String(e)}`);
       return false; // fail-closed
     });


### PR DESCRIPTION
Belt-and-suspenders for the address-case issue flagged on aastar-sdk#203.

KMS fixed it at the storage layer (AirAccount v0.27.2 lowercases the address key on all 4 paths). On the DVT side, `confirmWithPasskey` now lowercases `p.account` (= `userOp.sender`, typically EIP-55 **checksummed**) before calling `verifyConfirmAssertion`, so the node **never depends on KMS's normalization** — a checksummed sender always matches the KMS key.

- `confirmation.service.ts`: `const account = (p.account || "").toLowerCase()` before the KMS call.
- +1 test: mixed-case sender → lowercased value reaches the KMS verifier.

`type-check` ✅ · `lint` ✅ (0 errors) · `jest` ✅ **105/105**. No behavior change for the happy path (both sides now normalize); pure hardening.

Companion: aastar-sdk#203, AirAccount#129 (v0.27.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
