### PR TITLE
chore(release): v1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yetanotheraa-validator",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yetanotheraa-validator",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cli": "^11.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yetanotheraa-validator",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Production-ready BLS signature validation infrastructure for ERC-4337 account abstraction",
   "main": "dist/main.js",
   "type": "module",


### PR DESCRIPTION
Release **v1.6.0** — bundles everything merged since v1.5.0. All on-chain-verified live on dvt1/2/3 (`AAStarBLSAlgorithm.validate === 0`).

## Highlights

### Gasless purchase relay on the DVT node (#98)
- #99 — optional relay module (EIP-3009 + BuyIntent → BuyHelper), kills the centralized Cloudflare Worker single point; per-node independent operator key.
- #104 / #109 — BuyHelper address migrations (onlyRelayer redeploy → audit-fix `receiveWithAuthorization`).

### Keeper hardening (#58)
- #101 — fix ABI drift (`getCachedPriceInfo`→`cachedPrice`) + serve multiple paymasters.
- #105 — stop redundant-keeper nonce jams: fee-bump + pre-submit static-sim + dedicated keeper key.

### Out-of-band confirmation, path-2 (#124)
- #125 — confirmation status + poll API (`GET /signature/confirmation/:userOpHash`).
- #126 — passkey (WebAuthn) approval verified via KMS RP (`POST /signature/confirm {userOpHash, passkey}`); local binding + KMS verify, fail-closed.
- #128 — defensive lowercase of the account before the KMS call.

### Endpoints & hygiene
- #103 — `GET /` service index + `GET /health` (no more bare-domain 404).
- #108 — drop `privateKey` field from `/node/info`.

### Docs
- #107 — production (mainnet) deployment runbook + `.env.mainnet.example`.
- #121 — DVT threat model (`DVT_VALUE.md §8`).
- #123 — aNode incentive & revenue-share model.
- #102 — env-keyed SDK DVT integration config.

### Ops
- #127 — re-pin check-deps baseline (AirAccount v0.26.1 / TA 0.8.0).

## Verification
`npm run test:ci` ✅ 105/105 · `type-check`/`lint` ✅ · build ✅ · live E2E 3-node co-sign → on-chain `validate === 0` ✅.

After merge: tag `v1.6.0` + GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
