### PR TITLE
feat(#130 x402): operate x402 facilitator as an optional DVT node module

### DIFF
--- a/docs/x402-facilitator.md
+++ b/docs/x402-facilitator.md
@@ -1,0 +1,271 @@
+# x402 Facilitator Module (DVT) — Endpoint & Settlement Spec
+
+Status: implemented, opt-in (`X402_FACILITATOR_ENABLED`, default off). Tracks
+issue
+[#130](https://github.com/AAStarCommunity/YetAnotherAA-Validator/issues/130).
+
+The DVT node operates the **x402 payment facilitator** as an optional module,
+the same shape as `relay` (#98): an opt-in HTTP service that holds a **dedicated
+operator key** and submits an on-chain settlement on the payer's behalf. The
+role was previously homeless — the SDK (`@aastar/x402`) is client-only and the
+in-repo SuperPaymaster reference node (`packages/x402-facilitator-node`) is
+`@deprecated`. A client now just repoints its facilitator `url` at
+`https://<dvt-node>/x402`.
+
+This module is **orthogonal to the BLS signing core**: no `PackedUserOperation`,
+no `AAStarValidator`, no BLS aggregation — it never touches the
+security-critical 403 owner-auth gate. The payer authorizes with their own
+EIP-712 signature; the node submits with its operator EOA.
+
+---
+
+## 1. Endpoints (x402 v2, SDK `FacilitatorClient`-compatible)
+
+Base path `/x402`. Wire-compatible with
+`aastar-sdk/packages/x402/src/facilitator.ts` — the SDK client posts to
+`${url}/verify`, `${url}/settle`, `GET ${url}/supported`.
+
+| Method | Path              | Purpose                                            | Latency |
+| ------ | ----------------- | -------------------------------------------------- | ------- |
+| POST   | `/x402/verify`    | Off-chain signature/expiry/nonce-replay check      | ~100 ms |
+| POST   | `/x402/settle`    | Submit the on-chain `X402Facilitator` settlement   | ~2 s    |
+| GET    | `/x402/supported` | Discovery: settleable kinds, assets, fee, contract | —       |
+
+### Request body (`/verify` and `/settle`)
+
+The standard x402 v2 envelope:
+
+```jsonc
+{
+  "x402Version": 2,
+  "paymentPayload": {
+    "x402Version": 2,
+    "payload": {
+      "signature": "0x…", // payer EIP-712 signature
+      "authorization": {
+        // EIP-3009 authorization fields
+        "from": "0x…", // payer
+        "to": "0x…", // final recipient (== paymentRequirements.payTo)
+        "value": "1000000", // == paymentRequirements.amount
+        "validAfter": "0",
+        "validBefore": "1750000000",
+        "nonce": "0x…32 bytes", // direct path nonce; eip-3009 salt fallback
+      },
+    },
+  },
+  "paymentRequirements": {
+    "scheme": "exact", // x402 PRICING scheme (only "exact" accepted)
+    "network": "eip155:11155111",
+    "asset": "0x…", // xPNTs (direct) or EIP-3009 token (USDC)
+    "amount": "1000000",
+    "payTo": "0x…", // final recipient
+    "maxTimeoutSeconds": 3600,
+    "extra": {
+      /* see §2 */
+    },
+  },
+}
+```
+
+### Response shapes
+
+Both endpoints return **HTTP 200 with a discriminated body for ALL application
+outcomes** (the SDK client throws on non-2xx and only reads JSON on 2xx, so a
+rejection must still be 200). HTTP 503 is reserved for "module disabled on this
+node". The optional HMAC guard (§4) may pre-empt `/settle` with 402/400/403.
+
+```jsonc
+// /verify → VerifyResponse
+{ "isValid": true, "payer": "0x…" }
+{ "isValid": false, "invalidReason": "Nonce already used" }
+
+// /settle → SettleResponse
+{ "success": true, "transaction": "0x…txhash", "network": "eip155:11155111", "payer": "0x…" }
+{ "success": false, "errorReason": "settlement reverted (tx 0x…)" }
+
+// /supported → FacilitatorSupported
+{
+  "kinds": [{
+    "x402Version": 2,
+    "scheme": "exact",
+    "network": "eip155:11155111",
+    "extra": {
+      "settlementSchemes": ["direct", "eip-3009"],
+      "assets": ["0x696a73…", "0xe6579a…"],   // lower-cased xPNTs (direct)
+      "feeBPS": 200,
+      "facilitatorContract": "0xfe1DB01e…",
+      "operator": "0x…"
+    }
+  }],
+  "extensions": []
+}
+```
+
+---
+
+## 2. `paymentRequirements.extra` schema (this module owns it)
+
+The x402 v2 standard `paymentRequirements` carries no SuperPaymaster settlement
+detail. Per #130 (deliverable: "agree the `/supported.extra` schema"), this
+module reads the following OPTIONAL fields from `extra`:
+
+| Field        | Type                       | Default                                                       | Meaning                                 |
+| ------------ | -------------------------- | ------------------------------------------------------------- | --------------------------------------- |
+| `settlement` | `"direct"` \| `"eip-3009"` | auto: `asset ∈ X402_SUPPORTED_ASSETS` ? `direct` : `eip-3009` | which on-chain call                     |
+| `maxFee`     | decimal string             | `amount`                                                      | payer-approved fee cap (M-1)            |
+| `salt`       | `0x`+64 hex                | `authorization.nonce`                                         | EIP-3009 nonce preimage                 |
+| `name`       | string                     | `"USDC"`                                                      | EIP-712 token domain name (eip-3009)    |
+| `version`    | string                     | `"2"`                                                         | EIP-712 token domain version (eip-3009) |
+
+`permit2` is rejected by the **shared scheme guard**
+(`rejectUnsupportedScheme`), which both `/verify` and `/settle` funnel through
+so they can never diverge.
+
+### Nonce derivation (must match the contract byte-for-byte)
+
+- **direct**: on-chain nonce = the raw `authorization.nonce`.
+- **eip-3009**: on-chain nonce = `keccak256(abi.encode(payTo, maxFee, salt))`
+  (`X402Facilitator.settleX402Payment` derives it; the payer's EIP-3009
+  signature and the replay slot are BOTH keyed on this derived value).
+- **replay key**: `keccak256(abi.encode(asset, from, effectiveNonce))`
+  (`x402NonceKey`). `/verify` checks both this triple key and the legacy
+  raw-nonce slot against `x402SettlementNonces`.
+
+---
+
+## 3. On-chain settlement (authoritative ABI)
+
+Settles on the standalone **`X402Facilitator`** contract (v5.4 god-split, NOT
+SuperPaymaster). The ABI is taken from the contract source, NOT the stale
+`@aastar/core` ABI:
+
+```solidity
+// direct (xPNTs): payer signs an X402PaymentAuthorization (EOA or ERC-1271)
+settleX402PaymentDirect(from, to, asset, amount, maxFee, validBefore, nonce, signature)
+
+// eip-3009 (USDC): payer signs a ReceiveWithAuthorization; nonce = keccak256(to, maxFee, salt)
+settleX402Payment(from, to, asset, amount, maxFee, validAfter, validBefore, salt, signature)
+```
+
+EIP-712 domains:
+
+- **direct**:
+  `name="X402Facilitator", version="1", verifyingContract = facilitator`.
+- **eip-3009**: the token's own domain (`name`/`version` from `extra`, default
+  USDC `"USDC"`/`"2"`), `verifyingContract = asset`, recipient `to` = the
+  facilitator contract (`receiveWithAuthorization` forces `msg.sender == to`).
+
+`/verify` recovers EOA signatures off-chain and falls back to an on-chain
+**ERC-1271** `isValidSignature` check for AirAccount passkey / smart accounts,
+matching the contract's `SignatureCheckerLib`.
+
+### ⚠️ SDK-side gap (aastar-sdk#39 — needed for end-to-end)
+
+The current SDK `X402Client.createPayment` produces a payload that the deployed
+contract **cannot yet settle**: it signs a `TransferWithAuthorization` (the
+contract requires `ReceiveWithAuthorization`), omits `maxFee`/`salt`, and the
+`direct` path lacks the `X402PaymentAuthorization` signature. For this module to
+settle real payments, the SDK must, per the schema above:
+
+1. For `eip-3009`: sign **ReceiveWithAuthorization** over the derived nonce
+   `keccak256(payTo, maxFee, salt)`, recipient = the facilitator contract; put
+   `maxFee` + `salt` in `extra`.
+2. For `direct`: sign the **X402PaymentAuthorization** (X402Facilitator domain)
+   and put `maxFee` in `extra`; set `extra.settlement = "direct"`.
+3. Set `extra.settlement` (or rely on asset-based auto-detection) and keep
+   `paymentRequirements.scheme = "exact"`.
+
+The SDK also owns `DEFAULT_X402_FACILITATORS` (mirrors `DEFAULT_DVT_NODES`),
+pointing at `https://dvt{1,2,3}.aastar.io/x402` once these nodes are deployed.
+
+---
+
+## 4. Optional HMAC anti-spam guard (`/x402/settle`)
+
+Opt-in via `ENABLE_HMAC_CHALLENGE=true` + `HMAC_SECRET`. Recommended for PUBLIC
+nodes to blunt replay/bot spam on the gas-spending settle path. **Not a security
+gate** — the on-chain authorization is authoritative.
+
+1. Client calls `/x402/settle` with no HMAC headers → **402** carrying
+   `X-Challenge: <ts>:hmac(secret, "challenge:<ts>")` (self-verifying, 5-min
+   TTL, no server state).
+2. Client recomputes `X-Payment-HMAC = hmac(challenge, rawBody)` and replays
+   with both `X-Challenge` and `X-Payment-HMAC`. HMAC covers the raw request
+   bytes (`main.ts` enables `rawBody: true`).
+
+When disabled (default), the guard is a no-op.
+
+---
+
+## 5. Configuration
+
+```bash
+# x402 Facilitator module (AAStar Sepolia defaults; aPNTs + PNTs settle `direct`)
+X402_FACILITATOR_ENABLED=true
+X402_FACILITATOR_CONTRACT=0xfe1DB01e1d6622e722B92ed5993af61325DB92aF
+X402_SUPPORTED_ASSETS=0x696A73701b104c6cCBbAadDD2216788ea08EaB89,0xE6579A90dc498a710008de12119812D0FB7aA224
+X402_OPERATOR_PK=0x…            # DEDICATED key — NOT ETH_PRIVATE_KEY / RELAY_OPERATOR_PK
+X402_FEE_BPS=200
+X402_CHAIN_ID=11155111
+X402_RPC_URL=https://…          # falls back to ETH_RPC_URL
+# Optional anti-spam
+ENABLE_HMAC_CHALLENGE=true
+HMAC_SECRET=<32-byte random>
+```
+
+| Default asset | Token | Sepolia address                              | Scheme   |
+| ------------- | ----- | -------------------------------------------- | -------- |
+| AAStar        | aPNTs | `0x696A73701b104c6cCBbAadDD2216788ea08EaB89` | `direct` |
+| Mycelium      | PNTs  | `0xE6579A90dc498a710008de12119812D0FB7aA224` | `direct` |
+
+---
+
+## 6. Operator provisioning runbook
+
+The `X402_OPERATOR_PK` EOA must be provisioned by the AAStar deployer before it
+can settle. It must also be funded with ETH for gas.
+
+> ⚠️ Verified against the deployed contract source — the function name and role
+> string below differ from the draft in issue #130. The contract checks
+> `REGISTRY.hasRole(keccak256("PAYMASTER_SUPER"), msg.sender)` (NOT
+> `"ROLE_PAYMASTER_SUPER"`) and the direct gate is `addApprovedFacilitator` on
+> the xPNTs token (NOT `addAutoApprovedSpender` — that is a separate
+> transferFrom firewall). Using the issue's strings produces the wrong role hash
+> / wrong mapping and every settle reverts with `Unauthorized()`.
+
+```bash
+# 1. Set this operator's facilitator fee on X402Facilitator (onlyOwner = AAStar deployer)
+cast send $X402_FACILITATOR "setOperatorFacilitatorFee(address,uint256)" \
+  $OPERATOR_ADDRESS 200 --private-key $DEPLOYER_KEY --rpc-url $RPC_URL
+
+# 2. Approve the operator as a facilitator on each supported xPNTs token.
+#    Caller MUST be the token's communityOwner (a multisig), and OPERATOR != communityOwner.
+cast send $APNTS_TOKEN "addApprovedFacilitator(address)" $OPERATOR_ADDRESS \
+  --private-key $COMMUNITY_OWNER_KEY --rpc-url $RPC_URL
+cast send $PNTS_TOKEN  "addApprovedFacilitator(address)" $OPERATOR_ADDRESS \
+  --private-key $COMMUNITY_OWNER_KEY --rpc-url $RPC_URL
+
+# 3. Grant the PAYMASTER_SUPER role in the Registry (onlyOwner). The role hash is
+#    keccak256("PAYMASTER_SUPER") — note: NO "ROLE_" prefix in the hashed string.
+cast send $REGISTRY "grantRole(bytes32,address)" \
+  $(cast keccak "PAYMASTER_SUPER") $OPERATOR_ADDRESS \
+  --private-key $DEPLOYER_KEY --rpc-url $RPC_URL
+```
+
+The `direct` path requires the operator be in
+`IxPNTsToken(asset).approvedFacilitators(operator)` for each supported token —
+established by step 2's `addApprovedFacilitator` (callable only by the token's
+`communityOwner`; revocable instantly via `removeApprovedFacilitator` for
+incident response). This is distinct from `autoApprovedSpenders` (the
+transferFrom allowance firewall).
+
+---
+
+## 7. Source provenance
+
+- HTTP contract: `aastar-sdk/packages/x402/src/{facilitator,types}.ts`.
+- verify/settle logic ported (viem → ethers v6) from the battle-tested reference
+  node `SuperPaymaster/packages/x402-facilitator-node/src/` (4/4 E2E on Sepolia
+  v5.4.1-rc.1).
+- Authoritative ABI/domains from
+  `SuperPaymaster/contracts/src/paymasters/superpaymaster/v3/X402Facilitator.sol`.

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { AppConfigModule } from "./config/config.module.js";
 import { CapabilityModule } from "./modules/capability/capability.module.js";
 import { KeeperModule } from "./modules/keeper/keeper.module.js";
 import { RelayModule } from "./modules/relay/relay.module.js";
+import { X402FacilitatorModule } from "./modules/x402-facilitator/x402-facilitator.module.js";
 import { HealthModule } from "./modules/health/health.module.js";
 
 @Module({
@@ -23,6 +24,7 @@ import { HealthModule } from "./modules/health/health.module.js";
     DashboardModule,
     KeeperModule,
     RelayModule,
+    X402FacilitatorModule,
     HealthModule,
   ],
 })

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -123,6 +123,26 @@ export default () => {
       10
     ),
 
+    // x402 payment facilitator (#130). Opt-in; operates the x402 facilitator service
+    // (verify off-chain → settle on the standalone X402Facilitator contract) as a DVT
+    // node module, mirroring relay. Default off → behavior unchanged. Requires a
+    // DEDICATED X402_OPERATOR_PK (funded EOA holding ROLE_PAYMASTER_SUPER + listed in
+    // each supported xPNTs token's approvedFacilitators) — it does NOT fall back to
+    // ETH_PRIVATE_KEY or RELAY_OPERATOR_PK, keeping the public settlement key isolated.
+    // X402_SUPPORTED_ASSETS are the xPNTs the operator is approved for (settled `direct`);
+    // anything else settles via EIP-3009. Addresses default to the Sepolia v5.4.1 stack.
+    x402FacilitatorEnabled: process.env.X402_FACILITATOR_ENABLED === "true",
+    x402FacilitatorContract: process.env.X402_FACILITATOR_CONTRACT || undefined,
+    x402SupportedAssets: parseAllowlist(process.env.X402_SUPPORTED_ASSETS || ""),
+    x402OperatorPk: process.env.X402_OPERATOR_PK || undefined,
+    x402FeeBPS: parseInt(process.env.X402_FEE_BPS || "200", 10),
+    x402ChainId: parseInt(process.env.X402_CHAIN_ID || "11155111", 10),
+    x402RpcUrl: process.env.X402_RPC_URL || undefined,
+    // Optional anti-spam HMAC challenge on /x402/settle (public nodes). Honors the
+    // reference node's env names (ENABLE_HMAC_CHALLENGE / HMAC_SECRET).
+    x402HmacEnabled: process.env.ENABLE_HMAC_CHALLENGE === "true",
+    x402HmacSecret: process.env.HMAC_SECRET || undefined,
+
     // Gossip Network
     gossipPublicUrl: process.env.GOSSIP_PUBLIC_URL || `ws://localhost:${port}/ws`,
     gossipBootstrapPeers: parseBootstrapPeers(process.env.GOSSIP_BOOTSTRAP_PEERS || ""),

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,9 @@ import { ConfigService } from "@nestjs/config";
 import { GossipService } from "./modules/gossip/gossip.service.js";
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  // rawBody: true exposes the unparsed request body (req.rawBody) so the optional
+  // x402 HMAC challenge guard can verify HMAC over the exact bytes the client signed.
+  const app = await NestFactory.create(AppModule, { rawBody: true });
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/src/modules/x402-facilitator/__tests__/x402-facilitator.service.spec.ts
+++ b/src/modules/x402-facilitator/__tests__/x402-facilitator.service.spec.ts
@@ -1,0 +1,394 @@
+import { ethers } from "ethers";
+import { X402FacilitatorService } from "../x402-facilitator.service.js";
+import {
+  X402_AUTH_TYPES,
+  RECEIVE_WITH_AUTH_TYPES,
+  getX402FacilitatorDomain,
+  getEip3009TokenDomain,
+  computeEip3009Nonce,
+  rejectUnsupportedScheme,
+} from "../x402-facilitator.constants.js";
+
+const CHAIN_ID = 11155111;
+const FACILITATOR = ethers.getAddress("0x" + "fe".repeat(20));
+const APNTS = ethers.getAddress("0x" + "a1".repeat(20)); // a supported xPNTs (direct)
+const USDC = ethers.getAddress("0x" + "11".repeat(20)); // not supported → eip-3009
+const PAY_TO = ethers.getAddress("0x" + "44".repeat(20));
+const NONCE = "0x" + "55".repeat(32);
+
+const payer = new ethers.Wallet("0x" + "11".repeat(32));
+const stranger = new ethers.Wallet("0x" + "22".repeat(32));
+
+const NOW_MS = 1_000_000_000_000; // nowSec = 1e9
+const NOW_SEC = 1_000_000_000;
+const FUTURE = NOW_SEC + 3600;
+
+const BASE_CONFIG: Record<string, unknown> = {
+  x402FacilitatorEnabled: false, // pure-method tests don't need a live wallet
+  x402ChainId: CHAIN_ID,
+  x402FacilitatorContract: FACILITATOR,
+  x402SupportedAssets: [APNTS.toLowerCase()],
+  x402FeeBPS: 200,
+};
+
+function makeConfig(overrides: Record<string, unknown> = {}) {
+  const cfg = { ...BASE_CONFIG, ...overrides };
+  return { get: (k: string) => cfg[k] } as any;
+}
+
+function makeRegistry() {
+  const registered: Array<{ name: string; enabled: boolean }> = [];
+  return { registered, register: (cap: any) => registered.push(cap) } as any;
+}
+
+function makeService(configOverrides: Record<string, unknown> = {}) {
+  return new X402FacilitatorService(makeConfig(configOverrides), makeRegistry(), () => NOW_MS);
+}
+
+/** Build the SDK x402 v2 envelope for a direct (xPNTs) payment, signed by `signer`. */
+async function directEnvelope(
+  signer: ethers.Wallet = payer,
+  overrides: { amount?: bigint; maxFee?: bigint; nonce?: string; validBefore?: number } = {}
+) {
+  const amount = overrides.amount ?? 1_000_000n;
+  const maxFee = overrides.maxFee ?? amount;
+  const nonce = overrides.nonce ?? NONCE;
+  const validBefore = overrides.validBefore ?? FUTURE;
+  const domain = getX402FacilitatorDomain(CHAIN_ID, FACILITATOR);
+  const message = {
+    from: payer.address,
+    to: PAY_TO,
+    asset: APNTS,
+    amount,
+    maxFee,
+    validBefore: BigInt(validBefore),
+    nonce,
+  };
+  const signature = await signer.signTypedData(domain, X402_AUTH_TYPES as any, message);
+  return {
+    x402Version: 2,
+    paymentPayload: {
+      x402Version: 2,
+      payload: {
+        signature,
+        authorization: {
+          from: payer.address,
+          to: PAY_TO,
+          value: amount.toString(),
+          validAfter: "0",
+          validBefore: validBefore.toString(),
+          nonce,
+        },
+      },
+    },
+    paymentRequirements: {
+      scheme: "exact",
+      network: `eip155:${CHAIN_ID}`,
+      asset: APNTS,
+      amount: amount.toString(),
+      payTo: PAY_TO,
+      maxTimeoutSeconds: 3600,
+      extra: { settlement: "direct", maxFee: maxFee.toString() },
+    },
+  };
+}
+
+/** Build the SDK envelope for an EIP-3009 (USDC) payment, signed over the derived nonce. */
+async function eip3009Envelope(
+  signer: ethers.Wallet = payer,
+  overrides: {
+    amount?: bigint;
+    maxFee?: bigint;
+    salt?: string;
+    validBefore?: number;
+    validAfter?: number;
+  } = {}
+) {
+  const amount = overrides.amount ?? 2_000_000n;
+  const maxFee = overrides.maxFee ?? amount;
+  const salt = overrides.salt ?? NONCE;
+  const validBefore = overrides.validBefore ?? FUTURE;
+  const validAfter = overrides.validAfter ?? 0;
+  const effectiveNonce = computeEip3009Nonce(PAY_TO, maxFee, salt);
+  const domain = getEip3009TokenDomain("USDC", "2", CHAIN_ID, USDC);
+  const message = {
+    from: payer.address,
+    to: FACILITATOR, // EIP-3009 recipient is the facilitator contract
+    value: amount,
+    validAfter: BigInt(validAfter),
+    validBefore: BigInt(validBefore),
+    nonce: effectiveNonce,
+  };
+  const signature = await signer.signTypedData(domain, RECEIVE_WITH_AUTH_TYPES as any, message);
+  return {
+    x402Version: 2,
+    paymentPayload: {
+      x402Version: 2,
+      payload: {
+        signature,
+        authorization: {
+          from: payer.address,
+          to: PAY_TO,
+          value: amount.toString(),
+          validAfter: validAfter.toString(),
+          validBefore: validBefore.toString(),
+          nonce: salt,
+        },
+      },
+    },
+    paymentRequirements: {
+      scheme: "exact",
+      network: `eip155:${CHAIN_ID}`,
+      asset: USDC,
+      amount: amount.toString(),
+      payTo: PAY_TO,
+      maxTimeoutSeconds: 3600,
+      extra: {
+        settlement: "eip-3009",
+        maxFee: maxFee.toString(),
+        salt,
+        name: "USDC",
+        version: "2",
+      },
+    },
+  };
+}
+
+describe("X402FacilitatorService", () => {
+  describe("capability registration", () => {
+    it("registers x402-facilitator reflecting the enabled flag", () => {
+      const reg = makeRegistry();
+      new X402FacilitatorService(makeConfig({ x402FacilitatorEnabled: true }), reg, () => NOW_MS);
+      expect(reg.registered).toHaveLength(1);
+      expect(reg.registered[0]).toMatchObject({ name: "x402-facilitator", enabled: true });
+    });
+  });
+
+  describe("resolveScheme", () => {
+    const svc = makeService();
+    it("settles a provisioned xPNTs asset via direct", () => {
+      expect(svc.resolveScheme(APNTS)).toBe("direct");
+      expect(svc.resolveScheme(APNTS.toLowerCase())).toBe("direct");
+    });
+    it("settles an unknown asset via eip-3009", () => {
+      expect(svc.resolveScheme(USDC)).toBe("eip-3009");
+    });
+    it("honors an explicit extra.settlement override", () => {
+      expect(svc.resolveScheme(USDC, "direct")).toBe("direct");
+    });
+  });
+
+  describe("rejectUnsupportedScheme (shared guard)", () => {
+    it("accepts direct + eip-3009, rejects permit2/unknown", () => {
+      expect(rejectUnsupportedScheme("direct")).toBeNull();
+      expect(rejectUnsupportedScheme("eip-3009")).toBeNull();
+      expect(rejectUnsupportedScheme("permit2")).toMatch(/Unsupported/);
+      expect(rejectUnsupportedScheme("bogus")).toMatch(/Unsupported/);
+    });
+  });
+
+  describe("normalize", () => {
+    const svc = makeService();
+
+    it("normalizes a direct envelope", async () => {
+      const dto = await directEnvelope();
+      const r = svc.normalize(dto as any);
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.payment).toMatchObject({
+        scheme: "direct",
+        from: payer.address,
+        to: PAY_TO,
+        asset: APNTS,
+        amount: 1_000_000n,
+        maxFee: 1_000_000n,
+        nonce: NONCE,
+      });
+    });
+
+    it("auto-detects eip-3009 when extra.settlement is absent (asset not provisioned)", async () => {
+      const dto = await eip3009Envelope();
+      delete (dto.paymentRequirements.extra as any).settlement;
+      const r = svc.normalize(dto as any);
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.payment.scheme).toBe("eip-3009");
+    });
+
+    it("rejects a permit2 settlement via the shared guard", async () => {
+      const dto = await directEnvelope();
+      (dto.paymentRequirements.extra as any).settlement = "permit2";
+      const r = svc.normalize(dto as any);
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.reason).toMatch(/Unsupported settlement scheme/);
+    });
+
+    it("rejects a network mismatch", async () => {
+      const dto = await directEnvelope();
+      dto.paymentRequirements.network = "eip155:1";
+      const r = svc.normalize(dto as any);
+      expect(r.ok).toBe(false);
+    });
+
+    it("rejects a non-exact x402 pricing scheme", async () => {
+      const dto = await directEnvelope();
+      dto.paymentRequirements.scheme = "upto";
+      const r = svc.normalize(dto as any);
+      expect(r.ok).toBe(false);
+    });
+
+    it("rejects a malformed nonce / address / amount", async () => {
+      const bad1 = await directEnvelope();
+      (bad1.paymentPayload.payload.authorization as any).nonce = "0xdeadbeef";
+      expect(svc.normalize(bad1 as any).ok).toBe(false);
+
+      const bad2 = await directEnvelope();
+      bad2.paymentRequirements.asset = "not-an-address";
+      expect(svc.normalize(bad2 as any).ok).toBe(false);
+
+      const bad3 = await directEnvelope();
+      bad3.paymentRequirements.amount = "12.5";
+      expect(svc.normalize(bad3 as any).ok).toBe(false);
+    });
+
+    it("rejects a missing paymentPayload", () => {
+      expect(svc.normalize({ paymentRequirements: {} } as any).ok).toBe(false);
+    });
+
+    it("rejects a non-v2 x402Version (top level or embedded)", async () => {
+      const bad1 = await directEnvelope();
+      bad1.x402Version = 1;
+      expect(svc.normalize(bad1 as any).ok).toBe(false);
+
+      const bad2 = await directEnvelope();
+      (bad2.paymentPayload as any).x402Version = 3;
+      expect(svc.normalize(bad2 as any).ok).toBe(false);
+    });
+
+    it("rejects a present-but-malformed extra.salt instead of silently falling back", async () => {
+      const dto = await eip3009Envelope();
+      (dto.paymentRequirements.extra as any).salt = "0xnothex";
+      const r = svc.normalize(dto as any);
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.reason).toMatch(/salt/);
+    });
+  });
+
+  describe("effectiveNonce", () => {
+    const svc = makeService();
+    it("uses the raw nonce for direct", async () => {
+      const r = svc.normalize((await directEnvelope()) as any);
+      if (!r.ok) throw new Error("normalize failed");
+      expect(svc.effectiveNonce(r.payment)).toBe(NONCE);
+    });
+    it("derives keccak256(to, maxFee, salt) for eip-3009", async () => {
+      const r = svc.normalize((await eip3009Envelope()) as any);
+      if (!r.ok) throw new Error("normalize failed");
+      expect(svc.effectiveNonce(r.payment)).toBe(computeEip3009Nonce(PAY_TO, 2_000_000n, NONCE));
+    });
+  });
+
+  describe("buildSettleCall (on-chain arg order)", () => {
+    const svc = makeService();
+
+    it("direct → settleX402PaymentDirect(from,to,asset,amount,maxFee,validBefore,nonce,sig)", async () => {
+      const r = svc.normalize((await directEnvelope()) as any);
+      if (!r.ok) throw new Error("normalize failed");
+      const call = svc.buildSettleCall(r.payment);
+      expect(call.method).toBe("settleX402PaymentDirect");
+      expect(call.args).toEqual([
+        payer.address,
+        PAY_TO,
+        APNTS,
+        1_000_000n,
+        1_000_000n,
+        BigInt(FUTURE),
+        NONCE,
+        r.payment.signature,
+      ]);
+    });
+
+    it("eip-3009 → settleX402Payment(from,to,asset,amount,maxFee,validAfter,validBefore,salt,sig)", async () => {
+      const r = svc.normalize((await eip3009Envelope()) as any);
+      if (!r.ok) throw new Error("normalize failed");
+      const call = svc.buildSettleCall(r.payment);
+      expect(call.method).toBe("settleX402Payment");
+      expect(call.args).toEqual([
+        payer.address,
+        PAY_TO,
+        USDC,
+        2_000_000n,
+        2_000_000n,
+        0n,
+        BigInt(FUTURE),
+        NONCE, // salt
+        r.payment.signature,
+      ]);
+    });
+  });
+
+  describe("verifySignatureOffChain (EOA recovery)", () => {
+    const svc = makeService();
+
+    it("accepts a valid direct X402PaymentAuthorization signature", async () => {
+      const r = svc.normalize((await directEnvelope()) as any);
+      if (!r.ok) throw new Error("normalize failed");
+      const v = await svc.verifySignatureOffChain(r.payment);
+      expect(v).toEqual({ ok: true, payer: payer.address });
+    });
+
+    it("rejects a direct signature from the wrong signer", async () => {
+      const r = svc.normalize((await directEnvelope(stranger)) as any);
+      if (!r.ok) throw new Error("normalize failed");
+      const v = await svc.verifySignatureOffChain(r.payment);
+      expect(v.ok).toBe(false);
+    });
+
+    it("rejects a direct payment whose amount was tampered after signing", async () => {
+      const dto = await directEnvelope();
+      // Bump amount in BOTH the requirements and authorization so it normalizes,
+      // but the signature was over the original amount → recovery mismatches.
+      dto.paymentRequirements.amount = "999999999";
+      (dto.paymentPayload.payload.authorization as any).value = "999999999";
+      const r = svc.normalize(dto as any);
+      if (!r.ok) throw new Error("normalize failed");
+      const v = await svc.verifySignatureOffChain(r.payment);
+      expect(v.ok).toBe(false);
+    });
+
+    it("rejects an expired direct authorization", async () => {
+      const r = svc.normalize((await directEnvelope(payer, { validBefore: NOW_SEC - 1 })) as any);
+      if (!r.ok) throw new Error("normalize failed");
+      const v = await svc.verifySignatureOffChain(r.payment);
+      expect(v.ok).toBe(false);
+      if (v.ok) return;
+      expect(v.reason).toMatch(/expired/i);
+    });
+
+    it("accepts a valid eip-3009 ReceiveWithAuthorization signature", async () => {
+      const r = svc.normalize((await eip3009Envelope()) as any);
+      if (!r.ok) throw new Error("normalize failed");
+      const v = await svc.verifySignatureOffChain(r.payment);
+      expect(v).toEqual({ ok: true, payer: payer.address });
+    });
+
+    it("rejects an expired eip-3009 payment", async () => {
+      const r = svc.normalize((await eip3009Envelope(payer, { validBefore: NOW_SEC - 1 })) as any);
+      if (!r.ok) throw new Error("normalize failed");
+      const v = await svc.verifySignatureOffChain(r.payment);
+      expect(v.ok).toBe(false);
+    });
+  });
+
+  describe("disabled node", () => {
+    it("verify/settle short-circuit when not enabled", async () => {
+      const svc = makeService();
+      expect(svc.isEnabled()).toBe(false);
+      const dto = await directEnvelope();
+      expect((await svc.verify(dto as any)).ok).toBe(false);
+      expect((await svc.settle(dto as any)).ok).toBe(false);
+    });
+  });
+});

--- a/src/modules/x402-facilitator/dto/facilitator.dto.ts
+++ b/src/modules/x402-facilitator/dto/facilitator.dto.ts
@@ -1,0 +1,46 @@
+import { IsObject, IsOptional, IsInt } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
+
+/**
+ * POST /x402/verify and /x402/settle request body — the x402 v2 facilitator
+ * envelope the SDK's `FacilitatorClient` sends (`{ x402Version, paymentPayload,
+ * paymentRequirements }`). See `aastar-sdk/packages/x402/src/facilitator.ts`.
+ *
+ * Following the project convention (see sign.dto.ts / relay.dto.ts): the nested
+ * objects are NOT field-validated by the DTO — only their top-level presence/type.
+ * All real validation (scheme guard, signature recovery, nonce replay, expiry)
+ * happens inside X402FacilitatorService, which owns rejection and maps to the
+ * correct response. This keeps the global ValidationPipe (whitelist:true,
+ * forbidNonWhitelisted:true) from silently stripping nested fields we forward
+ * verbatim to ethers / the contract.
+ *
+ * `paymentPayload.payload.authorization` carries the EIP-3009 fields
+ * `{ from, to, value, validAfter, validBefore, nonce }` + `payload.signature`.
+ * `paymentRequirements` carries `{ scheme, network, asset, amount, payTo,
+ * maxTimeoutSeconds, extra }`, where `extra` additionally carries the
+ * SuperPaymaster settlement fields (`settlement`, `maxFee`, `salt`, token
+ * `name`/`version`) — schema documented in docs/x402-facilitator.md.
+ */
+export class FacilitatorRequestDto {
+  @ApiProperty({ description: "x402 protocol version (must be 2).", example: 2 })
+  @IsOptional()
+  @IsInt()
+  x402Version?: number;
+
+  @ApiProperty({
+    description:
+      "x402 v2 PaymentPayload: { x402Version, accepted, payload: { signature, " +
+      "authorization: { from, to, value, validAfter, validBefore, nonce } } }.",
+  })
+  @IsObject()
+  paymentPayload: Record<string, unknown>;
+
+  @ApiProperty({
+    description:
+      "x402 v2 PaymentRequirements: { scheme, network, asset, amount, payTo, " +
+      "maxTimeoutSeconds, extra }. `extra` additionally carries SuperPaymaster " +
+      "settlement fields { settlement?: 'direct'|'eip-3009', maxFee?, salt?, name?, version? }.",
+  })
+  @IsObject()
+  paymentRequirements: Record<string, unknown>;
+}

--- a/src/modules/x402-facilitator/hmac-challenge.guard.ts
+++ b/src/modules/x402-facilitator/hmac-challenge.guard.ts
@@ -1,0 +1,122 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+  Injectable,
+  Logger,
+} from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { createHmac, timingSafeEqual } from "crypto";
+import type { Request, Response } from "express";
+
+const CHALLENGE_TTL_MS = 300_000; // 5 minutes
+
+/**
+ * Optional stateless HMAC challenge-response guard for POST /x402/settle (#130),
+ * ported from the reference node's `middleware/hmac-challenge.ts`. Recommended for
+ * PUBLIC facilitator nodes to blunt replay/bot spam on the gas-spending settle path;
+ * it is NOT a security gate (the on-chain X402Facilitator authorization is
+ * authoritative). Opt-in via ENABLE_HMAC_CHALLENGE=true + HMAC_SECRET.
+ *
+ * Handshake (matches the reference flow):
+ *  1. Client calls /settle with no HMAC headers → 402 carrying `X-Challenge`
+ *     (`<ts>:hmac(secret, "challenge:<ts>")`, self-verifying, no server state).
+ *  2. Client recomputes `X-Payment-HMAC = hmac(challenge, rawBody)` and replays
+ *     with both `X-Challenge` and `X-Payment-HMAC`.
+ * The HMAC covers the RAW request bytes, so main.ts enables `rawBody: true`.
+ *
+ * When disabled (default) the guard is a no-op and settle behaves unchanged.
+ */
+@Injectable()
+export class HmacChallengeGuard implements CanActivate {
+  private readonly logger = new Logger(HmacChallengeGuard.name);
+  private readonly enabled: boolean;
+  private readonly secret: string;
+  private readonly now: () => number;
+
+  constructor(config: ConfigService, now?: () => number) {
+    this.enabled = config.get<boolean>("x402HmacEnabled") === true;
+    this.secret = config.get<string>("x402HmacSecret") ?? "";
+    this.now = now ?? (() => Date.now());
+    if (this.enabled && !this.secret) {
+      this.logger.warn(
+        "x402: ENABLE_HMAC_CHALLENGE=true but HMAC_SECRET is empty — settle requests will be rejected"
+      );
+    }
+  }
+
+  canActivate(context: ExecutionContext): boolean {
+    if (!this.enabled) return true;
+
+    const http = context.switchToHttp();
+    const req = http.getRequest<Request & { rawBody?: Buffer }>();
+    if (!this.secret) {
+      throw new HttpException(
+        { success: false, errorReason: "HMAC challenge enabled but server secret unset" },
+        HttpStatus.SERVICE_UNAVAILABLE
+      );
+    }
+
+    const challenge = req.header("X-Challenge");
+    const clientHmac = req.header("X-Payment-HMAC");
+
+    // First contact: issue a challenge so the client can authenticate its retry.
+    if (!challenge || !clientHmac) {
+      const res = http.getResponse<Response>();
+      res.setHeader("X-Challenge", this.generateChallenge());
+      throw new HttpException(
+        { success: false, errorReason: "Payment challenge required (see X-Challenge header)" },
+        HttpStatus.PAYMENT_REQUIRED
+      );
+    }
+
+    if (!this.verifyChallenge(challenge)) {
+      throw new HttpException(
+        { success: false, errorReason: "Invalid or expired challenge" },
+        HttpStatus.BAD_REQUEST
+      );
+    }
+
+    const rawBody = req.rawBody?.toString("utf8") ?? JSON.stringify(req.body ?? {});
+    if (!this.verifyHmac(challenge, rawBody, clientHmac)) {
+      throw new HttpException(
+        { success: false, errorReason: "HMAC verification failed" },
+        HttpStatus.FORBIDDEN
+      );
+    }
+    return true;
+  }
+
+  /** Generate a stateless challenge token: `<ts>:hmac(secret, "challenge:<ts>")`. */
+  generateChallenge(): string {
+    const ts = this.now().toString();
+    return `${ts}:${createHmac("sha256", this.secret).update(`challenge:${ts}`).digest("hex")}`;
+  }
+
+  private verifyChallenge(challenge: string): boolean {
+    const parts = challenge.split(":");
+    if (parts.length !== 2) return false;
+    const [ts, mac] = parts;
+    const tsNum = Number(ts);
+    if (!Number.isFinite(tsNum) || this.now() - tsNum > CHALLENGE_TTL_MS) return false;
+    const expected = createHmac("sha256", this.secret).update(`challenge:${ts}`).digest("hex");
+    return safeEqualHex(expected, mac);
+  }
+
+  /** Client computes HMAC(challenge, rawBody); the challenge string is the HMAC key. */
+  private verifyHmac(challenge: string, body: string, clientHmac: string): boolean {
+    const expected = createHmac("sha256", challenge).update(body).digest("hex");
+    return safeEqualHex(expected, clientHmac);
+  }
+}
+
+/** Constant-time hex comparison; false on any length/format mismatch. */
+function safeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(a, "hex"), Buffer.from(b, "hex"));
+  } catch {
+    return false;
+  }
+}

--- a/src/modules/x402-facilitator/x402-facilitator.constants.ts
+++ b/src/modules/x402-facilitator/x402-facilitator.constants.ts
@@ -1,0 +1,198 @@
+/**
+ * Wire + on-chain constants for the optional x402 payment-facilitator module (#130).
+ *
+ * The DVT node runs the x402 facilitator the same way it runs `relay` (#98): an
+ * opt-in HTTP service that holds a DEDICATED operator key and submits an on-chain
+ * settlement on the payer's behalf. The HTTP envelope is the SDK's x402 v2
+ * `FacilitatorClient` contract (`aastar-sdk/packages/x402/src/facilitator.ts`);
+ * the SuperPaymaster-specific settlement fields (settlement scheme, maxFee, salt)
+ * ride in `paymentRequirements.extra`, whose schema this module owns (see
+ * docs/x402-facilitator.md).
+ *
+ * The verify/settle LOGIC is ported from the battle-tested reference service
+ * `SuperPaymaster/packages/x402-facilitator-node` (4/4 E2E on Sepolia v5.4.1-rc.1),
+ * rewritten from viem to ethers v6 to match this repo. The ABIs below are taken
+ * from the AUTHORITATIVE contract source
+ * `SuperPaymaster/contracts/src/paymasters/superpaymaster/v3/X402Facilitator.sol`
+ * (NOT the stale `@aastar/core` ABI, which still carries the pre-v5.4 8-arg
+ * `settleX402Payment` and an unsigned direct path — see aastar-sdk#39).
+ */
+
+import { ethers } from "ethers";
+
+/**
+ * Settlement schemes this facilitator can actually settle on-chain.
+ *
+ * This is the SuperPaymaster *settlement* axis (which contract call), distinct
+ * from the x402 v2 *pricing* scheme (`exact`/`upto`) the SDK puts in
+ * `paymentRequirements.scheme`. "permit2" was removed in the v5.4 god-split and
+ * is rejected, exactly as the reference node does.
+ */
+export const SUPPORTED_SETTLEMENT_SCHEMES = ["direct", "eip-3009"] as const;
+export type SettlementScheme = (typeof SUPPORTED_SETTLEMENT_SCHEMES)[number];
+
+export function isSupportedSettlementScheme(scheme: string): scheme is SettlementScheme {
+  return (SUPPORTED_SETTLEMENT_SCHEMES as readonly string[]).includes(scheme);
+}
+
+/**
+ * The single shared scheme guard called by BOTH verify and settle so the two
+ * paths can never diverge — the exact invariant Codex stop-review enforced on the
+ * reference node (`lib/scheme.ts`): if verify accepts a scheme settle must too,
+ * and vice-versa. Returns a human-readable rejection reason, or null when settleable.
+ */
+export function rejectUnsupportedScheme(scheme: string): string | null {
+  if (isSupportedSettlementScheme(scheme)) return null;
+  return `Unsupported settlement scheme: ${scheme}. Supported: ${SUPPORTED_SETTLEMENT_SCHEMES.join(", ")}`;
+}
+
+/**
+ * Authoritative X402Facilitator ABI (human-readable, ethers v6). Mirrors the
+ * deployed `X402Facilitator-1.0.0` (Sepolia 0xfe1DB01e…) function signatures:
+ *
+ *   settleX402Payment(from,to,asset,amount,maxFee,validAfter,validBefore,salt,sig)
+ *     — EIP-3009 receiveWithAuthorization path; on-chain nonce = keccak256(to,maxFee,salt)
+ *   settleX402PaymentDirect(from,to,asset,amount,maxFee,validBefore,nonce,sig)
+ *     — xPNTs path; requires payer X402PaymentAuthorization signature (EOA or ERC-1271)
+ *
+ * Arg order is part of the contract signature: a transposed argument reverts (or
+ * mis-settles). It is locked here and asserted in the settle-args unit test.
+ */
+export const X402_FACILITATOR_ABI = [
+  "function settleX402Payment(address from,address to,address asset,uint256 amount,uint256 maxFee,uint256 validAfter,uint256 validBefore,bytes32 salt,bytes signature) returns (bytes32 settlementId)",
+  "function settleX402PaymentDirect(address from,address to,address asset,uint256 amount,uint256 maxFee,uint256 validBefore,bytes32 nonce,bytes signature) returns (bytes32 settlementId)",
+  "function x402SettlementNonces(bytes32) view returns (bool)",
+  "function x402NonceKey(address asset,address from,bytes32 nonce) pure returns (bytes32)",
+  "function facilitatorFeeBPS() view returns (uint256)",
+  "function version() pure returns (string)",
+] as const;
+
+/** Minimal ERC-1271 ABI for the optional on-chain smart-account signature fallback in verify. */
+export const ERC1271_ABI = [
+  "function isValidSignature(bytes32 hash,bytes signature) view returns (bytes4)",
+] as const;
+
+/** EIP-1271 magic value returned by `isValidSignature` for a valid signature. */
+export const ERC1271_MAGIC_VALUE = "0x1626ba7e";
+
+/**
+ * EIP-712 domain for the X402Facilitator contract (direct/xPNTs path).
+ *
+ * v5.4 god-split: the payer's `X402PaymentAuthorization` is recovered by
+ * `X402Facilitator._x402DomainSeparator`, which uses name="X402Facilitator",
+ * version="1", verifyingContract = the facilitator contract address. A wrong name
+ * or verifyingContract makes every recovery yield the wrong signer → settle reverts.
+ */
+export function getX402FacilitatorDomain(
+  chainId: number,
+  facilitatorAddress: string
+): ethers.TypedDataDomain {
+  return { name: "X402Facilitator", version: "1", chainId, verifyingContract: facilitatorAddress };
+}
+
+/**
+ * Matches X402Facilitator.X402_AUTH_TYPEHASH:
+ * "X402PaymentAuthorization(address from,address to,address asset,uint256 amount,uint256 maxFee,uint256 validBefore,bytes32 nonce)"
+ */
+export const X402_AUTH_TYPES = {
+  X402PaymentAuthorization: [
+    { name: "from", type: "address" },
+    { name: "to", type: "address" },
+    { name: "asset", type: "address" },
+    { name: "amount", type: "uint256" },
+    { name: "maxFee", type: "uint256" },
+    { name: "validBefore", type: "uint256" },
+    { name: "nonce", type: "bytes32" },
+  ],
+} as const;
+
+/**
+ * EIP-3009 ReceiveWithAuthorization typed data (EIP-3009 path).
+ *
+ * The contract calls `receiveWithAuthorization` (NOT transfer-): the token forces
+ * msg.sender == to (= the facilitator), closing the front-run nonce-burn grief
+ * vector. The two EIP-3009 variants sign IDENTICAL fields under DIFFERENT typehash
+ * strings, so the payer's signature only recovers `from` against this Receive
+ * typehash; verifying against TransferWithAuthorization would reject every valid sig.
+ */
+export const RECEIVE_WITH_AUTH_TYPES = {
+  ReceiveWithAuthorization: [
+    { name: "from", type: "address" },
+    { name: "to", type: "address" },
+    { name: "value", type: "uint256" },
+    { name: "validAfter", type: "uint256" },
+    { name: "validBefore", type: "uint256" },
+    { name: "nonce", type: "bytes32" },
+  ],
+} as const;
+
+/** EIP-712 domain for an EIP-3009 token (e.g. USDC: name "USDC", version "2"). */
+export function getEip3009TokenDomain(
+  tokenName: string,
+  tokenVersion: string,
+  chainId: number,
+  tokenAddress: string
+): ethers.TypedDataDomain {
+  return { name: tokenName, version: tokenVersion, chainId, verifyingContract: tokenAddress };
+}
+
+/**
+ * Mirror X402Facilitator.x402NonceKey(asset, from, nonce):
+ *   keccak256(abi.encode(address asset, address from, bytes32 nonce))
+ *
+ * The contract records spent settlement nonces at THIS triple key in
+ * `x402SettlementNonces`, NOT at the raw nonce slot (the raw slot is only checked
+ * for legacy pre-v5.4 entries). A replay check on the raw nonce always misses real
+ * replays. Must stay byte-identical to Solidity `abi.encode(address,address,bytes32)`.
+ */
+export function computeX402NonceKey(asset: string, from: string, nonce: string): string {
+  return ethers.keccak256(
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      ["address", "address", "bytes32"],
+      [asset, from, nonce]
+    )
+  );
+}
+
+/**
+ * Mirror X402Facilitator.settleX402Payment's on-chain EIP-3009 nonce derivation:
+ *   nonce = keccak256(abi.encode(address to, uint256 maxFee, bytes32 salt))
+ *
+ * C-03/M-1: the EIP-3009 path binds the FINAL recipient `to` AND the payer-approved
+ * fee cap `maxFee` into the token-level nonce. The contract derives it from the
+ * preimage `salt` and submits it to receiveWithAuthorization, so the payer's
+ * EIP-3009 signature and the replay slot are BOTH keyed on this derived value, not
+ * on the raw `salt`. verify MUST therefore check the signature + replay slot against
+ * this derived nonce, exactly as the contract derives it.
+ */
+export function computeEip3009Nonce(to: string, maxFee: bigint, salt: string): string {
+  return ethers.keccak256(
+    ethers.AbiCoder.defaultAbiCoder().encode(["address", "uint256", "bytes32"], [to, maxFee, salt])
+  );
+}
+
+/**
+ * AAStar Sepolia defaults (v5.4.1-rc.1, per issue #130). All overridable via env so
+ * a community operator can point the module at a different deployment without code
+ * changes. The two default supported assets are xPNTs variants settled via the
+ * `direct` scheme (the xPNTs factory auto-approves the facilitator at deploy).
+ */
+export const SEPOLIA_DEFAULTS = {
+  chainId: 11155111,
+  facilitatorContract: "0xfe1DB01e1d6622e722B92ed5993af61325DB92aF",
+  apnts: "0x696A73701b104c6cCBbAadDD2216788ea08EaB89", // AAStar community
+  pnts: "0xE6579A90dc498a710008de12119812D0FB7aA224", // Mycelium community
+} as const;
+
+/** CAIP-2 network id from a chain id (e.g. 11155111 → "eip155:11155111"). */
+export function toNetworkId(chainId: number): string {
+  return `eip155:${chainId}`;
+}
+
+/** Discriminated result of an off-chain verify. */
+export type VerifyResult = { ok: true; payer: string } | { ok: false; reason: string };
+
+/** Discriminated result of an on-chain settle attempt. */
+export type SettleResult =
+  | { ok: true; txHash: string; payer: string }
+  | { ok: false; reason: string };

--- a/src/modules/x402-facilitator/x402-facilitator.controller.ts
+++ b/src/modules/x402-facilitator/x402-facilitator.controller.ts
@@ -1,0 +1,82 @@
+import { Body, Controller, Get, HttpException, HttpStatus, Post, UseGuards } from "@nestjs/common";
+import { ApiOperation, ApiTags } from "@nestjs/swagger";
+import { X402FacilitatorService } from "./x402-facilitator.service.js";
+import { FacilitatorRequestDto } from "./dto/facilitator.dto.js";
+import { HmacChallengeGuard } from "./hmac-challenge.guard.js";
+
+/**
+ * x402 v2 facilitator endpoints (#130), wire-compatible with the SDK's
+ * `FacilitatorClient` (`aastar-sdk/packages/x402/src/facilitator.ts`) so a client
+ * only repoints its facilitator `url` at `https://<dvt-node>/x402`:
+ *
+ *   POST /x402/verify     — off-chain signature/expiry/replay check (~100ms)
+ *   POST /x402/settle     — submit the on-chain X402Facilitator settlement (~2s)
+ *   GET  /x402/supported  — discovery: settleable kinds, assets, fee, contract
+ *
+ * Response-status contract (matched to the SDK client, which throws on non-2xx and
+ * reads the JSON body only on 2xx):
+ *  - verify/settle return HTTP 200 with the discriminated body for ALL application
+ *    outcomes (isValid:false / success:false carry the reason) so the SDK reads the
+ *    result instead of throwing.
+ *  - HTTP 503 only when the module is disabled/misconfigured on this node.
+ *  - The optional HMAC guard may pre-empt /settle with 402/400/403 (anti-spam handshake).
+ */
+@ApiTags("x402-facilitator")
+@Controller("x402")
+export class X402FacilitatorController {
+  constructor(private readonly service: X402FacilitatorService) {}
+
+  @Post("verify")
+  @ApiOperation({ summary: "x402 verify — off-chain payment signature/expiry/replay check" })
+  async verify(
+    @Body() body: FacilitatorRequestDto
+  ): Promise<{ isValid: boolean; invalidReason?: string; payer?: string }> {
+    this.assertEnabled();
+    const result = await this.service.verify(body);
+    return result.ok
+      ? { isValid: true, payer: result.payer }
+      : { isValid: false, invalidReason: result.reason };
+  }
+
+  @Post("settle")
+  @UseGuards(HmacChallengeGuard)
+  @ApiOperation({ summary: "x402 settle — submit the on-chain X402Facilitator settlement" })
+  async settle(@Body() body: FacilitatorRequestDto): Promise<{
+    success: boolean;
+    transaction?: string;
+    network?: string;
+    payer?: string;
+    errorReason?: string;
+  }> {
+    this.assertEnabled();
+    const result = await this.service.settle(body);
+    return result.ok
+      ? {
+          success: true,
+          transaction: result.txHash,
+          network: this.service.networkId(),
+          payer: result.payer,
+        }
+      : { success: false, errorReason: result.reason };
+  }
+
+  @Get("supported")
+  @ApiOperation({ summary: "x402 supported — settleable kinds, assets, fee, contract (discovery)" })
+  supported(): {
+    kinds: Array<{ x402Version: number; scheme: string; network: string; extra: unknown }>;
+    extensions: string[];
+  } {
+    // Always 200 — discovery is safe even when disabled (advertises this node's config).
+    return this.service.supported();
+  }
+
+  /** 503 when the operator wallet isn't live — a clear misconfiguration signal to clients. */
+  private assertEnabled(): void {
+    if (!this.service.isEnabled()) {
+      throw new HttpException(
+        { success: false, errorReason: "x402 facilitator not enabled on this node" },
+        HttpStatus.SERVICE_UNAVAILABLE
+      );
+    }
+  }
+}

--- a/src/modules/x402-facilitator/x402-facilitator.module.ts
+++ b/src/modules/x402-facilitator/x402-facilitator.module.ts
@@ -1,0 +1,18 @@
+import { Module } from "@nestjs/common";
+import { X402FacilitatorService } from "./x402-facilitator.service.js";
+import { X402FacilitatorController } from "./x402-facilitator.controller.js";
+import { HmacChallengeGuard } from "./hmac-challenge.guard.js";
+
+/**
+ * Optional x402 payment facilitator (#130). Opt-in via X402_FACILITATOR_ENABLED.
+ * The CapabilityRegistry it self-registers into is a @Global singleton, so no
+ * explicit import is needed here. Always loaded; the endpoints return 503 until
+ * X402_FACILITATOR_ENABLED + a valid X402_OPERATOR_PK make the operator wallet live
+ * (mirrors the relay module). The HMAC guard is a provider so it can inject ConfigService.
+ */
+@Module({
+  providers: [X402FacilitatorService, HmacChallengeGuard],
+  controllers: [X402FacilitatorController],
+  exports: [X402FacilitatorService],
+})
+export class X402FacilitatorModule {}

--- a/src/modules/x402-facilitator/x402-facilitator.service.ts
+++ b/src/modules/x402-facilitator/x402-facilitator.service.ts
@@ -1,0 +1,533 @@
+import { Injectable, Logger, Optional, OnApplicationBootstrap } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { ethers } from "ethers";
+import { CapabilityRegistry } from "../capability/capability-registry.service.js";
+import { bumpedFees } from "../../utils/gas.util.js";
+import { FacilitatorRequestDto } from "./dto/facilitator.dto.js";
+import {
+  SEPOLIA_DEFAULTS,
+  X402_FACILITATOR_ABI,
+  ERC1271_ABI,
+  ERC1271_MAGIC_VALUE,
+  X402_AUTH_TYPES,
+  RECEIVE_WITH_AUTH_TYPES,
+  getX402FacilitatorDomain,
+  getEip3009TokenDomain,
+  computeX402NonceKey,
+  computeEip3009Nonce,
+  rejectUnsupportedScheme,
+  toNetworkId,
+  type SettlementScheme,
+  type VerifyResult,
+  type SettleResult,
+} from "./x402-facilitator.constants.js";
+
+/**
+ * Fully-normalized settlement parameters, derived from the SDK's x402 v2 envelope
+ * by {@link X402FacilitatorService.normalize}. Both verify and settle operate on
+ * THIS shape so they can never interpret the same request differently.
+ */
+export interface NormalizedPayment {
+  scheme: SettlementScheme;
+  from: string;
+  to: string; // FINAL recipient (paymentRequirements.payTo)
+  asset: string;
+  amount: bigint;
+  maxFee: bigint;
+  validAfter: bigint;
+  validBefore: bigint;
+  nonce: string; // raw authorization nonce (direct path nonce, eip-3009 salt fallback)
+  salt: string; // eip-3009 preimage; on-chain nonce = keccak256(to, maxFee, salt)
+  signature: string;
+  tokenName: string; // EIP-3009 domain name (e.g. "USDC")
+  tokenVersion: string; // EIP-3009 domain version (e.g. "2")
+}
+
+/**
+ * x402 payment facilitator (#130) — optional, opt-in DVT node module.
+ *
+ * Operates the x402 *facilitator service* the way `relay` (#98) operates the
+ * gasless purchase relay: an HTTP service that holds a DEDICATED operator key and
+ * submits an on-chain settlement on the payer's behalf. The role was previously
+ * homeless — the SDK (`@aastar/x402`) is client-only and the in-repo
+ * SuperPaymaster node is `@deprecated`; this module gives it a home on the DVT
+ * node so the SDK just repoints its facilitator URL.
+ *
+ * It is ORTHOGONAL to the BLS signing core: no PackedUserOperation, no
+ * AAStarValidator, no BLS aggregation — so it never touches the security-critical
+ * 403 owner-auth gate. The payer authorizes via their own EIP-712 signature
+ * (X402PaymentAuthorization for xPNTs `direct`, or EIP-3009 ReceiveWithAuthorization
+ * for USDC `eip-3009`); the node submits with its operator EOA.
+ *
+ * Opt-in (X402_FACILITATOR_ENABLED, default off → behavior unchanged). Requires a
+ * DEDICATED X402_OPERATOR_PK — a funded EOA that (1) holds ROLE_PAYMASTER_SUPER in
+ * the Registry and (2) is in `approvedFacilitators` on each supported xPNTs token.
+ * It intentionally does NOT fall back to ETH_PRIVATE_KEY (validator owner) or
+ * RELAY_OPERATOR_PK — the public-facing settlement key stays isolated.
+ *
+ * Off-chain verify is a fast-fail gate (signature, expiry, nonce replay) that
+ * mirrors what the contract enforces; the X402Facilitator contract re-verifies
+ * everything on-chain and is authoritative.
+ */
+@Injectable()
+export class X402FacilitatorService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(X402FacilitatorService.name);
+
+  private readonly enabledByConfig: boolean;
+  private readonly operatorPk: string;
+  private readonly rpcUrl: string;
+  private readonly chainId: number;
+  private readonly facilitatorContract: string;
+  /** Lower-cased xPNTs assets this operator is provisioned for (settled `direct`). */
+  private readonly supportedAssets: string[];
+  private readonly feeBPS: number;
+  private readonly now: () => number;
+
+  /** Live once bootstrap validates the operator key + RPC; null = disabled. */
+  private wallet: ethers.Wallet | null = null;
+  private contract: ethers.Contract | null = null;
+  private provider: ethers.JsonRpcProvider | null = null;
+
+  /** Serializes on-chain submissions so concurrent requests can't reuse a nonce. */
+  private submitChain: Promise<unknown> = Promise.resolve();
+
+  constructor(
+    private readonly config: ConfigService,
+    @Optional() capabilityRegistry?: CapabilityRegistry,
+    /** Test seam: controls `Date.now()` for expiry windows. */
+    @Optional() now?: () => number
+  ) {
+    this.enabledByConfig = config.get<boolean>("x402FacilitatorEnabled") === true;
+    this.operatorPk = config.get<string>("x402OperatorPk") ?? "";
+    this.rpcUrl = config.get<string>("x402RpcUrl") ?? config.get<string>("ethRpcUrl") ?? "";
+    this.chainId = config.get<number>("x402ChainId") ?? SEPOLIA_DEFAULTS.chainId;
+    this.facilitatorContract =
+      config.get<string>("x402FacilitatorContract") ?? SEPOLIA_DEFAULTS.facilitatorContract;
+    this.supportedAssets = (config.get<string[]>("x402SupportedAssets") ?? []).map(a =>
+      a.toLowerCase()
+    );
+    this.feeBPS = config.get<number>("x402FeeBPS") ?? 200;
+    this.now = now ?? (() => Date.now());
+
+    capabilityRegistry?.register({
+      name: "x402-facilitator",
+      class: "infra-app",
+      description: `x402 payment facilitator (${this.supportedAssets.length} asset(s), feeBPS=${this.feeBPS})`,
+      enabled: this.enabledByConfig,
+    });
+  }
+
+  onApplicationBootstrap(): void {
+    if (!this.enabledByConfig) return;
+    if (!/^0x[0-9a-fA-F]{64}$/.test(this.operatorPk)) {
+      this.logger.warn(
+        "x402: X402_FACILITATOR_ENABLED=true but X402_OPERATOR_PK missing/invalid " +
+          "(must be 32-byte 0x hex, DEDICATED — not the validator owner or relay key) — disabled"
+      );
+      return;
+    }
+    if (!this.rpcUrl) {
+      this.logger.warn(
+        "x402: X402_FACILITATOR_ENABLED=true but no RPC URL (X402_RPC_URL/ETH_RPC_URL) — disabled"
+      );
+      return;
+    }
+    if (!ethers.isAddress(this.facilitatorContract)) {
+      this.logger.warn("x402: X402_FACILITATOR_CONTRACT is not a valid address — disabled");
+      return;
+    }
+    this.provider = new ethers.JsonRpcProvider(this.rpcUrl, this.chainId);
+    this.wallet = new ethers.Wallet(this.operatorPk, this.provider);
+    this.contract = new ethers.Contract(
+      this.facilitatorContract,
+      X402_FACILITATOR_ABI,
+      this.wallet
+    );
+    this.logger.log(
+      `x402 facilitator ENABLED — operator=${this.wallet.address} chainId=${this.chainId} ` +
+        `contract=${this.facilitatorContract} feeBPS=${this.feeBPS} ` +
+        `assets(direct)=[${this.supportedAssets.join(", ")}]`
+    );
+  }
+
+  /** True once the operator wallet + contract are live. */
+  isEnabled(): boolean {
+    return this.wallet !== null && this.contract !== null;
+  }
+
+  /** Operator address for discovery/health, or null when disabled. */
+  operatorAddress(): string | null {
+    return this.wallet?.address ?? null;
+  }
+
+  /** CAIP-2 network id this node settles on (e.g. "eip155:11155111"). */
+  networkId(): string {
+    return toNetworkId(this.chainId);
+  }
+
+  /**
+   * GET /x402/supported — advertise settleable kinds for client/gossip discovery.
+   * Carries the SuperPaymaster-specific bits (supported assets, fee, contract,
+   * settlement schemes) in `extra`, the schema this module owns (docs/x402-facilitator.md).
+   */
+  supported(): {
+    kinds: Array<{ x402Version: number; scheme: string; network: string; extra: unknown }>;
+    extensions: string[];
+  } {
+    return {
+      kinds: [
+        {
+          x402Version: 2,
+          scheme: "exact",
+          network: toNetworkId(this.chainId),
+          extra: {
+            settlementSchemes: ["direct", "eip-3009"],
+            assets: this.supportedAssets,
+            feeBPS: this.feeBPS,
+            facilitatorContract: this.facilitatorContract,
+            operator: this.operatorAddress(),
+          },
+        },
+      ],
+      extensions: [],
+    };
+  }
+
+  /**
+   * Resolve the on-chain settlement scheme. An explicit `extra.settlement` wins
+   * (and is run through the shared guard by the caller); otherwise an asset in the
+   * operator's provisioned xPNTs set settles `direct`, everything else `eip-3009`.
+   */
+  resolveScheme(asset: string, extraSettlement?: unknown): string {
+    if (typeof extraSettlement === "string" && extraSettlement.length > 0) return extraSettlement;
+    return this.supportedAssets.includes(asset.toLowerCase()) ? "direct" : "eip-3009";
+  }
+
+  /**
+   * Parse the SDK x402 v2 envelope into a {@link NormalizedPayment}. Pure (no
+   * network). Returns a `{ reason }` on any structural problem so verify/settle
+   * fail identically. Both endpoints MUST funnel through this — it is the single
+   * source of the values handed to ethers + the contract.
+   */
+  normalize(
+    dto: FacilitatorRequestDto
+  ): { ok: true; payment: NormalizedPayment } | { ok: false; reason: string } {
+    const pp = dto?.paymentPayload as Record<string, unknown> | undefined;
+    const pr = dto?.paymentRequirements as Record<string, unknown> | undefined;
+    if (!pp || !pr) return { ok: false, reason: "missing paymentPayload or paymentRequirements" };
+
+    // Reject non-v2 envelopes explicitly: a different protocol version whose field
+    // shape happens to overlap must not be silently processed as v2. Both the top
+    // level and the embedded paymentPayload carry x402Version per the SDK contract.
+    for (const [v, where] of [
+      [dto.x402Version, "request"],
+      [pp.x402Version, "paymentPayload"],
+    ] as const) {
+      if (v !== undefined && v !== 2) {
+        return {
+          ok: false,
+          reason: `unsupported x402Version in ${where}: ${String(v)} (expected 2)`,
+        };
+      }
+    }
+
+    const inner = pp.payload as Record<string, unknown> | undefined;
+    const auth = inner?.authorization as Record<string, unknown> | undefined;
+    if (!inner || !auth)
+      return { ok: false, reason: "missing paymentPayload.payload.authorization" };
+
+    const extra = (pr.extra as Record<string, unknown> | undefined) ?? {};
+
+    // x402 v2 pricing scheme: the SDK only produces "exact". Reject "upto"/unknown.
+    const pricingScheme = pr.scheme;
+    if (pricingScheme !== undefined && pricingScheme !== "exact") {
+      return {
+        ok: false,
+        reason: `unsupported x402 scheme: ${String(pricingScheme)} (expected "exact")`,
+      };
+    }
+
+    // Network must match this node's chain (when supplied).
+    if (pr.network !== undefined && pr.network !== toNetworkId(this.chainId)) {
+      return { ok: false, reason: `network ${String(pr.network)} != ${toNetworkId(this.chainId)}` };
+    }
+
+    const from = auth.from;
+    const to = pr.payTo ?? auth.to; // final recipient
+    const asset = pr.asset;
+    const amountStr = (pr.amount ?? auth.value) as unknown;
+    const signature = inner.signature;
+    const nonce = auth.nonce;
+    const validAfterStr = (auth.validAfter ?? "0") as unknown;
+    const validBeforeStr = auth.validBefore;
+
+    for (const [v, name] of [
+      [from, "from"],
+      [to, "to"],
+      [asset, "asset"],
+    ] as const) {
+      if (typeof v !== "string" || !ethers.isAddress(v)) {
+        return { ok: false, reason: `invalid ${name}: not an address` };
+      }
+    }
+    if (typeof nonce !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(nonce)) {
+      return { ok: false, reason: "invalid nonce: must be 0x + 64 hex chars" };
+    }
+    if (typeof signature !== "string" || !ethers.isHexString(signature) || signature.length < 4) {
+      return { ok: false, reason: "invalid signature: must be a hex string" };
+    }
+    if (typeof amountStr !== "string" || !/^\d+$/.test(amountStr)) {
+      return { ok: false, reason: "invalid amount: must be a non-negative integer string" };
+    }
+    if (typeof validBeforeStr !== "string" || !/^\d+$/.test(validBeforeStr)) {
+      return { ok: false, reason: "invalid validBefore: must be a non-negative integer string" };
+    }
+    if (typeof validAfterStr !== "string" || !/^\d+$/.test(validAfterStr)) {
+      return { ok: false, reason: "invalid validAfter: must be a non-negative integer string" };
+    }
+
+    const amount = BigInt(amountStr);
+    const maxFeeRaw = extra.maxFee;
+    let maxFee: bigint;
+    try {
+      maxFee = maxFeeRaw === undefined ? amount : BigInt(maxFeeRaw as string | number);
+    } catch {
+      return { ok: false, reason: "invalid extra.maxFee" };
+    }
+
+    // salt is OPTIONAL and falls back to the authorization nonce when ABSENT. But a
+    // PRESENT-yet-malformed salt is a client encoding bug, not a fallback case:
+    // reject it loudly rather than silently settling against a different nonce than
+    // the client believes it signed.
+    const saltRaw = extra.salt;
+    let salt: string;
+    if (saltRaw === undefined) {
+      salt = nonce;
+    } else if (typeof saltRaw === "string" && /^0x[0-9a-fA-F]{64}$/.test(saltRaw)) {
+      salt = saltRaw;
+    } else {
+      return { ok: false, reason: "invalid extra.salt: must be 0x + 64 hex chars" };
+    }
+
+    const scheme = this.resolveScheme(asset as string, extra.settlement);
+    const schemeReason = rejectUnsupportedScheme(scheme);
+    if (schemeReason) return { ok: false, reason: schemeReason };
+
+    return {
+      ok: true,
+      payment: {
+        scheme: scheme as SettlementScheme,
+        from: ethers.getAddress(from as string),
+        to: ethers.getAddress(to as string),
+        asset: ethers.getAddress(asset as string),
+        amount,
+        maxFee,
+        validAfter: BigInt(validAfterStr),
+        validBefore: BigInt(validBeforeStr),
+        nonce,
+        salt,
+        signature,
+        tokenName: typeof extra.name === "string" ? (extra.name as string) : "USDC",
+        tokenVersion: typeof extra.version === "string" ? (extra.version as string) : "2",
+      },
+    };
+  }
+
+  /** On-chain effective nonce, identical to how the contract derives it per scheme. */
+  effectiveNonce(p: NormalizedPayment): string {
+    return p.scheme === "direct" ? p.nonce : computeEip3009Nonce(p.to, p.maxFee, p.salt);
+  }
+
+  /**
+   * Off-chain signature + expiry check (no replay read). Pure w.r.t. the chain
+   * except for the optional ERC-1271 fallback (smart-account / passkey signatures),
+   * which needs a provider — EOA recovery alone is provider-free and unit-tested.
+   */
+  async verifySignatureOffChain(p: NormalizedPayment): Promise<VerifyResult> {
+    const nowSec = BigInt(Math.floor(this.now() / 1000));
+    if (p.amount === 0n) return { ok: false, reason: "Zero amount" };
+
+    if (p.scheme === "direct") {
+      if (nowSec > p.validBefore)
+        return { ok: false, reason: "Authorization expired (validBefore)" };
+      const domain = getX402FacilitatorDomain(this.chainId, this.facilitatorContract);
+      const value = {
+        from: p.from,
+        to: p.to,
+        asset: p.asset,
+        amount: p.amount,
+        maxFee: p.maxFee,
+        validBefore: p.validBefore,
+        nonce: p.nonce,
+      };
+      return this.recoverOrErc1271(domain, X402_AUTH_TYPES, value, p.signature, p.from);
+    }
+
+    // eip-3009: token-domain ReceiveWithAuthorization, recipient = the facilitator
+    // contract (it pulls funds in, then forwards to the final `to`).
+    if (p.validAfter > 0n && nowSec < p.validAfter) {
+      return { ok: false, reason: "Payment not yet valid (validAfter)" };
+    }
+    if (nowSec >= p.validBefore) return { ok: false, reason: "Payment expired (validBefore)" };
+    const domain = getEip3009TokenDomain(p.tokenName, p.tokenVersion, this.chainId, p.asset);
+    const value = {
+      from: p.from,
+      to: this.facilitatorContract,
+      value: p.amount,
+      validAfter: p.validAfter,
+      validBefore: p.validBefore,
+      nonce: this.effectiveNonce(p),
+    };
+    return this.recoverOrErc1271(domain, RECEIVE_WITH_AUTH_TYPES, value, p.signature, p.from);
+  }
+
+  /**
+   * Recover an EIP-712 signature to the expected EOA; on mismatch, fall back to an
+   * on-chain ERC-1271 `isValidSignature` check (AirAccount passkey / smart accounts),
+   * matching the contract's SignatureCheckerLib which accepts both.
+   */
+  private async recoverOrErc1271(
+    domain: ethers.TypedDataDomain,
+    types: Record<string, ReadonlyArray<ethers.TypedDataField>>,
+    value: Record<string, unknown>,
+    signature: string,
+    expected: string
+  ): Promise<VerifyResult> {
+    try {
+      const recovered = ethers.verifyTypedData(
+        domain,
+        types as Record<string, Array<ethers.TypedDataField>>,
+        value,
+        signature
+      );
+      if (recovered.toLowerCase() === expected.toLowerCase()) return { ok: true, payer: expected };
+    } catch {
+      // fall through to ERC-1271
+    }
+
+    if (this.provider) {
+      try {
+        const digest = ethers.TypedDataEncoder.hash(
+          domain,
+          types as Record<string, Array<ethers.TypedDataField>>,
+          value
+        );
+        const account = new ethers.Contract(expected, ERC1271_ABI, this.provider);
+        const magic: string = await account.isValidSignature(digest, signature);
+        if (magic === ERC1271_MAGIC_VALUE) return { ok: true, payer: expected };
+      } catch {
+        // not a smart account / no code / reverted → invalid
+      }
+    }
+    return {
+      ok: false,
+      reason: "Invalid signature (EOA recovery failed; not a valid ERC-1271 signer)",
+    };
+  }
+
+  /**
+   * POST /x402/verify — full off-chain verification: structural normalize → scheme
+   * guard → signature/expiry → on-chain nonce-replay read. Never throws; returns a
+   * discriminated result the controller maps to the SDK VerifyResponse.
+   */
+  async verify(dto: FacilitatorRequestDto): Promise<VerifyResult> {
+    if (!this.isEnabled())
+      return { ok: false, reason: "x402 facilitator not enabled on this node" };
+
+    const norm = this.normalize(dto);
+    if (!norm.ok) return { ok: false, reason: norm.reason };
+    const p = norm.payment;
+
+    // Nonce replay: the contract records the (asset, from, nonce) triple key; the
+    // raw-nonce slot is only the legacy pre-v5.4 path. Mirror BOTH lookups against
+    // the EFFECTIVE nonce so we reject exactly when the contract would revert.
+    const eff = this.effectiveNonce(p);
+    try {
+      const key = computeX402NonceKey(p.asset, p.from, eff);
+      const [keyUsed, legacyUsed] = await Promise.all([
+        this.contract!.x402SettlementNonces(key) as Promise<boolean>,
+        this.contract!.x402SettlementNonces(eff) as Promise<boolean>,
+      ]);
+      if (keyUsed || legacyUsed) return { ok: false, reason: "Nonce already used" };
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { ok: false, reason: `nonce replay check failed: ${msg}` };
+    }
+
+    return this.verifySignatureOffChain(p);
+  }
+
+  /**
+   * Build the ordered contract call for a normalized payment. Pure — the SOLE
+   * source of the on-chain args, so a unit test can lock arg order against the
+   * X402Facilitator ABI without an RPC harness. A transposed arg reverts on-chain.
+   */
+  buildSettleCall(p: NormalizedPayment): { method: string; args: unknown[] } {
+    if (p.scheme === "direct") {
+      // settleX402PaymentDirect(from, to, asset, amount, maxFee, validBefore, nonce, signature)
+      return {
+        method: "settleX402PaymentDirect",
+        args: [p.from, p.to, p.asset, p.amount, p.maxFee, p.validBefore, p.nonce, p.signature],
+      };
+    }
+    // settleX402Payment(from, to, asset, amount, maxFee, validAfter, validBefore, salt, signature)
+    return {
+      method: "settleX402Payment",
+      args: [
+        p.from,
+        p.to,
+        p.asset,
+        p.amount,
+        p.maxFee,
+        p.validAfter,
+        p.validBefore,
+        p.salt,
+        p.signature,
+      ],
+    };
+  }
+
+  /**
+   * POST /x402/settle — submit the on-chain settlement. Re-normalizes (never trusts
+   * a prior verify) and serializes submissions so concurrent requests on the single
+   * operator EOA can't collide on a nonce. Never throws; returns a discriminated result.
+   */
+  async settle(dto: FacilitatorRequestDto): Promise<SettleResult> {
+    if (!this.isEnabled())
+      return { ok: false, reason: "x402 facilitator not enabled on this node" };
+
+    const norm = this.normalize(dto);
+    if (!norm.ok) return { ok: false, reason: norm.reason };
+    const p = norm.payment;
+
+    const run = this.submitChain.then(
+      () => this.sendSettle(p),
+      () => this.sendSettle(p)
+    );
+    this.submitChain = run.catch(() => {});
+    return run;
+  }
+
+  private async sendSettle(p: NormalizedPayment): Promise<SettleResult> {
+    try {
+      const { method, args } = this.buildSettleCall(p);
+      const fees = await bumpedFees(this.wallet!.provider!);
+      const tx: ethers.TransactionResponse = await this.contract!.getFunction(method)(
+        ...args,
+        fees
+      );
+      this.logger.log(`x402 settle (${p.scheme}) submitted ${p.amount} ${p.asset} → ${tx.hash}`);
+      const receipt = await tx.wait(1);
+      if (!receipt || receipt.status !== 1) {
+        return { ok: false, reason: `settlement reverted (tx ${tx.hash})` };
+      }
+      return { ok: true, txHash: tx.hash, payer: p.from };
+    } catch (e: unknown) {
+      const msg =
+        (e as { shortMessage?: string })?.shortMessage ??
+        (e instanceof Error ? e.message : String(e));
+      this.logger.error(`x402 settle failed: ${msg}`);
+      return { ok: false, reason: msg };
+    }
+  }
+}


### PR DESCRIPTION
Closes part of #130 (DVT-side deliverables). Adds an **opt-in** x402 payment-facilitator module to the DVT node, modeled on `relay` (#98): the node holds a **dedicated operator key** and settles x402 payments on the standalone `X402Facilitator` contract. Default off (`X402_FACILITATOR_ENABLED`) → existing behavior unchanged. The SDK just repoints its facilitator `url` at `https://<dvt-node>/x402`.

## What's here
- **Module** `src/modules/x402-facilitator/` — controller (`POST /x402/verify`, `POST /x402/settle`, `GET /x402/supported`), service, DTO, constants, HMAC guard, 25 unit tests.
- **Wire contract** = the SDK's x402 v2 `FacilitatorClient` envelope (`{ x402Version, paymentPayload, paymentRequirements }`). SuperPaymaster-specific settlement fields (`settlement`, `maxFee`, `salt`) ride in `paymentRequirements.extra` — schema in `docs/x402-facilitator.md`.
- **Logic** ported (viem → ethers v6) from the battle-tested reference node `SuperPaymaster/packages/x402-facilitator-node`. ABI + EIP-712 domains taken from the **authoritative** `X402Facilitator.sol`, not the stale `@aastar/core` ABI.
- `direct` (xPNTs) vs `eip-3009` (USDC) auto-detected by `asset ∈ X402_SUPPORTED_ASSETS`, overridable via `extra.settlement`; one **shared scheme guard** keeps verify + settle from diverging (`permit2` rejected).
- On-chain nonce `keccak256(to,maxFee,salt)` + `x402NonceKey` triple-key replay check are byte-identical to the contract; verify adds an **ERC-1271 fallback** so AirAccount passkey / smart-account signatures pass.
- **Key isolation**: `X402_OPERATOR_PK` never falls back to `ETH_PRIVATE_KEY` / `RELAY_OPERATOR_PK`; submissions serialized to avoid operator-EOA nonce collisions.
- Optional **HMAC challenge** guard on `/settle` for public nodes (`ENABLE_HMAC_CHALLENGE`); `main.ts` enables `rawBody`.

## ⚠️ Blocks end-to-end on an SDK change (aastar-sdk#39)
The current SDK `X402Client.createPayment` can't yet drive the deployed contract: it signs `TransferWithAuthorization` (contract needs `ReceiveWithAuthorization`), omits `maxFee`/`salt`, and the `direct` path lacks the `X402PaymentAuthorization` signature. Required SDK changes are documented in `docs/x402-facilitator.md §3`. The SDK also owns `DEFAULT_X402_FACILITATORS`.

## Review
Tier-1 Codex review: **0 critical / 0 high**. Fixed 2 medium **doc** errors — verified against the contract source, the issue #130 runbook itself was wrong: the role hash is `keccak256("PAYMASTER_SUPER")` (not `"ROLE_PAYMASTER_SUPER"`) and the xPNTs gate is `addApprovedFacilitator` by `communityOwner` (not `addAutoApprovedSpender`). Plus 2 low hardenings (reject non-v2 `x402Version`; reject present-but-malformed `extra.salt`).

## Verification
- `npm run type-check` ✓  ·  `npm run lint:check` ✓ (0 errors)  ·  `npm run build` ✓
- `npm test` → **12 suites / 130 tests pass** (25 new), no regressions.