### PR TITLE
deploy(#130 x402): enable x402 on testnet DVT nodes + provisioning script + SDK config

### DIFF
--- a/deploy/.env.testnet.example
+++ b/deploy/.env.testnet.example
@@ -65,6 +65,27 @@ RELAY_ENABLED=false
 # RELAY_RATE_LIMIT_PER_ADDRESS_PER_HOUR=5
 # RELAY_RATE_LIMIT_GLOBAL_PER_HOUR=100
 
+# --- x402 payment facilitator (#130, optional; default OFF) ---
+# Runs the x402 facilitator as a DVT node module: POST /x402/verify (off-chain),
+# POST /x402/settle (on-chain X402Facilitator), GET /x402/supported (discovery).
+# Mirrors relay — each node holds a DEDICATED operator key and submits settlements.
+# verify/supported go live immediately; settle additionally needs the operator
+# PROVISIONED on-chain (ROLE PAYMASTER_SUPER + each xPNTs addApprovedFacilitator by
+# its communityOwner) + funded with Sepolia gas (see docs/x402-facilitator.md §6).
+# X402_OPERATOR_PK MUST be dedicated (NOT ETH_PRIVATE_KEY / RELAY_OPERATOR_PK) — set
+# it per-node in deploy/node{1,2,3}/.env. Spec: docs/x402-facilitator.md.
+X402_FACILITATOR_ENABLED=false
+# X402_FACILITATOR_CONTRACT=0xfe1DB01e1d6622e722B92ed5993af61325DB92aF
+# X402_SUPPORTED_ASSETS=0x696A73701b104c6cCBbAadDD2216788ea08EaB89,0xE6579A90dc498a710008de12119812D0FB7aA224
+# X402_CHAIN_ID=11155111
+# X402_FEE_BPS=200
+# X402_RPC_URL=                 # defaults to ETH_RPC_URL
+# X402_OPERATOR_PK=0x<dedicated funded+provisioned key, per node>   # put in deploy/node$i/.env
+# Optional stateless-HMAC auth on /settle (maps to the SDK createAuthHeaders):
+# X402_AUTH_ENABLED=false
+# X402_AUTH_SECRET=<32-byte random>
+# X402_AUTH_TTL_MS=300000
+
 # --- Cloudflare named tunnel (required for the public endpoint) ---
 # Create a tunnel in the Cloudflare dashboard (Zero Trust → Networks → Tunnels → Cloudflared),
 # copy its token here. Then add 3 Public Hostnames pointing at http://dvt-node-1:3001 etc.

--- a/deploy/.env.testnet.example
+++ b/deploy/.env.testnet.example
@@ -81,6 +81,8 @@ X402_FACILITATOR_ENABLED=false
 # X402_FEE_BPS=200
 # X402_RPC_URL=                 # defaults to ETH_RPC_URL
 # X402_OPERATOR_PK=0x<dedicated funded+provisioned key, per node>   # put in deploy/node$i/.env
+# X402_OPERATOR_ADDRESS=0x<derived>   # auto-written beside the PK; the provision/register
+#                                     # scripts read THIS (never the key → nothing on `ps`)
 # Optional stateless-HMAC auth on /settle (maps to the SDK createAuthHeaders):
 # X402_AUTH_ENABLED=false
 # X402_AUTH_SECRET=<32-byte random>

--- a/deploy/sdk-dvt-config.testnet.json
+++ b/deploy/sdk-dvt-config.testnet.json
@@ -57,7 +57,11 @@
             "targetToken_apnts": "0x9e66B457E0ABb1F139FD8A596d00f784eBA2873b",
             "buyHelper": "0x8d08fBD8297355BC93397820AE1CfFD884BEaA00"
           },
-          "caps": { "perTxMaxUsdc6dec": "864000000", "perAddressPerHour": 5, "globalPerHour": 100 },
+          "caps": {
+            "perTxMaxUsdc6dec": "864000000",
+            "perAddressPerHour": 5,
+            "globalPerHour": 100
+          },
           "failover": "3 independent relayers — pick any node, retry next on 5xx/timeout"
         },
         "keeper": {
@@ -67,7 +71,40 @@
             "paymasterV4_community": "0x957852251f44570dc2B60Dde0954f191FF3372eE"
           }
         },
-        "health": "GET {url}/health -> {status:'ok', capabilities:[{name,enabled}]}"
+        "health": "GET {url}/health -> {status:'ok', capabilities:[{name,enabled}]}",
+        "x402": {
+          "_status": "endpoints LIVE (verify/supported); settle PENDING operator on-chain provisioning + gas (see docs/x402-facilitator.md §6)",
+          "endpoints": {
+            "verify": "POST {url}/x402/verify  body: {x402Version:2, paymentPayload, paymentRequirements} -> {isValid, invalidReason?, payer?}",
+            "settle": "POST {url}/x402/settle  -> {success, transaction?, network?, payer?, errorReason?}",
+            "supported": "GET {url}/x402/supported -> {kinds:[{x402Version,scheme,network,extra:{settlementSchemes,assets,feeBPS,facilitatorContract,operator}}], extensions}"
+          },
+          "facilitatorContract": "0xfe1DB01e1d6622e722B92ed5993af61325DB92aF",
+          "supportedAssets": {
+            "apnts_aastar": "0x696A73701b104c6cCBbAadDD2216788ea08EaB89",
+            "pnts_mycelium": "0xE6579A90dc498a710008de12119812D0FB7aA224"
+          },
+          "feeBPS": 200,
+          "extraSchema": "paymentRequirements.extra: { settlement?:\"direct\"|\"eip-3009\", maxFee?, salt?, name?, version? } — see docs/x402-facilitator.md §2",
+          "authHeaders": "optional stateless HMAC on /settle (X-X402-Timestamp + X-X402-Auth=HMAC-SHA256(secret, `${ts}.${rawBody}`)); off unless X402_AUTH_ENABLED",
+          "facilitators": [
+            {
+              "url": "https://dvt1.aastar.io/x402",
+              "operator": "0xF92DC383c74eA30d7791b929d5872daD18679516",
+              "supportedAssets": ["apnts_aastar", "pnts_mycelium"]
+            },
+            {
+              "url": "https://dvt2.aastar.io/x402",
+              "operator": "0x2e72A258FD9e1C69B2B2bB6ED8bC7E94773f7b00",
+              "supportedAssets": ["apnts_aastar", "pnts_mycelium"]
+            },
+            {
+              "url": "https://dvt3.aastar.io/x402",
+              "operator": "0x368f8Cb8cCA42174B03156cEa761BaE31cEE5C94",
+              "supportedAssets": ["apnts_aastar", "pnts_mycelium"]
+            }
+          ]
+        }
       }
     },
     "mainnet": {

--- a/deploy/x402-provision.sh
+++ b/deploy/x402-provision.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Provision the 3 testnet DVT x402 facilitator operators on-chain (#130 §6).
+#
+# The node services are already LIVE (/x402/verify + /x402/supported work). This
+# script does the remaining ON-CHAIN, OWNER-KEY steps that let /x402/settle succeed.
+# It needs PRIVILEGED keys that do NOT live in this repo:
+#
+#   AASTAR_OWNER_KEY   controls X402Facilitator + aPNTs + Registry  (owner 0xb5600060e6de5E11D3636731964218E53caadf0E)
+#   MYCELIUM_OWNER_KEY controls PNTs                                (owner 0xEcAACb915f7D92e9916f449F7ad42BD0408733c9)  [optional — only for PNTs settlement]
+#   FUNDER_KEY         any funded Sepolia EOA, to gas the 3 operators            [optional — skip if you fund them another way]
+#
+# Per-operator, this grants the two MANDATORY gates the contract checks:
+#   1. Registry.grantRole(keccak256("PAYMASTER_SUPER"), operator)   — both settle paths
+#   2. aPNTs.addApprovedFacilitator(operator)                       — direct (xPNTs) path
+#      PNTs.addApprovedFacilitator(operator)                        — direct path (Mycelium key)
+#   3. X402Facilitator.setOperatorFacilitatorFee(operator, 200)     — optional fee override
+#   4. fund operator with FUND_ETH Sepolia ETH                      — gas to submit settlements
+#
+# Usage:
+#   RPC_URL=https://… AASTAR_OWNER_KEY=0x… [MYCELIUM_OWNER_KEY=0x…] [FUNDER_KEY=0x…] \
+#     ./deploy/x402-provision.sh
+#
+# Idempotent: skips a step if the operator already has the role / approval. Needs foundry (cast).
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+: "${RPC_URL:?set RPC_URL (Sepolia)}"
+: "${AASTAR_OWNER_KEY:?set AASTAR_OWNER_KEY (owns X402Facilitator + aPNTs + Registry)}"
+FUND_ETH="${FUND_ETH:-0.05}"
+
+X402_FACILITATOR=0xfe1DB01e1d6622e722B92ed5993af61325DB92aF
+REGISTRY=0xf5Bf37ca83AfdAab73691bA7eCcDfA69b8708E71
+APNTS=0x696A73701b104c6cCBbAadDD2216788ea08EaB89
+PNTS=0xE6579A90dc498a710008de12119812D0FB7aA224
+ROLE_PAYMASTER_SUPER="$(cast keccak 'PAYMASTER_SUPER')" # 0x2024516755f4…
+
+# Derive the 3 operator addresses from the per-node env (the keys never leave the host).
+ops=()
+for i in 1 2 3; do
+  pk="$(grep -E '^X402_OPERATOR_PK=' "$REPO/deploy/node$i/.env" | cut -d= -f2)"
+  [ -n "$pk" ] || { echo "node$i: no X402_OPERATOR_PK in deploy/node$i/.env"; exit 1; }
+  ops+=("$(cast wallet address --private-key "$pk")")
+done
+echo "operators: dvt1=${ops[0]} dvt2=${ops[1]} dvt3=${ops[2]}"
+
+send() { echo "  + $1"; cast send "$2" "$3" "${@:4}" --rpc-url "$RPC_URL" >/dev/null; }
+
+for idx in 0 1 2; do
+  OP="${ops[$idx]}"; n=$((idx + 1))
+  echo "== dvt$n operator $OP =="
+
+  # 1. PAYMASTER_SUPER role (mandatory, both paths)
+  if [ "$(cast call "$REGISTRY" 'hasRole(bytes32,address)(bool)' "$ROLE_PAYMASTER_SUPER" "$OP" --rpc-url "$RPC_URL")" = "true" ]; then
+    echo "  = already has PAYMASTER_SUPER"
+  else
+    send "grant PAYMASTER_SUPER" "$REGISTRY" 'grantRole(bytes32,address)' "$ROLE_PAYMASTER_SUPER" "$OP" --private-key "$AASTAR_OWNER_KEY"
+  fi
+
+  # 2. aPNTs approved facilitator (direct path)
+  if [ "$(cast call "$APNTS" 'approvedFacilitators(address)(bool)' "$OP" --rpc-url "$RPC_URL")" = "true" ]; then
+    echo "  = already approved on aPNTs"
+  else
+    send "aPNTs addApprovedFacilitator" "$APNTS" 'addApprovedFacilitator(address)' "$OP" --private-key "$AASTAR_OWNER_KEY"
+  fi
+
+  # 2b. PNTs approved facilitator (needs the Mycelium owner key; optional)
+  if [ -n "${MYCELIUM_OWNER_KEY:-}" ]; then
+    if [ "$(cast call "$PNTS" 'approvedFacilitators(address)(bool)' "$OP" --rpc-url "$RPC_URL")" = "true" ]; then
+      echo "  = already approved on PNTs"
+    else
+      send "PNTs addApprovedFacilitator" "$PNTS" 'addApprovedFacilitator(address)' "$OP" --private-key "$MYCELIUM_OWNER_KEY"
+    fi
+  else
+    echo "  ~ skipping PNTs (set MYCELIUM_OWNER_KEY to enable PNTs settlement)"
+  fi
+
+  # 3. operator fee override (optional)
+  send "setOperatorFacilitatorFee 200" "$X402_FACILITATOR" 'setOperatorFacilitatorFee(address,uint256)' "$OP" 200 --private-key "$AASTAR_OWNER_KEY"
+
+  # 4. gas funding (optional)
+  if [ -n "${FUNDER_KEY:-}" ]; then
+    bal="$(cast balance "$OP" --rpc-url "$RPC_URL")"
+    if [ "$bal" = "0" ]; then
+      echo "  + fund $FUND_ETH ETH"; cast send "$OP" --value "${FUND_ETH}ether" --private-key "$FUNDER_KEY" --rpc-url "$RPC_URL" >/dev/null
+    else
+      echo "  = already funded ($bal wei)"
+    fi
+  else
+    echo "  ~ skipping funding (set FUNDER_KEY, or fund $OP with ~$FUND_ETH Sepolia ETH manually)"
+  fi
+done
+
+echo "done. Verify: curl -s https://dvt1.aastar.io/x402/supported | jq, then a live settle round-trip per docs §7."

--- a/deploy/x402-provision.sh
+++ b/deploy/x402-provision.sh
@@ -9,8 +9,10 @@
 #   MYCELIUM_OWNER_KEY controls PNTs                                (owner 0xEcAACb915f7D92e9916f449F7ad42BD0408733c9)  [optional — only for PNTs settlement]
 #   FUNDER_KEY         any funded Sepolia EOA, to gas the 3 operators            [optional — skip if you fund them another way]
 #
-# Per-operator, this grants the two MANDATORY gates the contract checks:
-#   1. Registry.grantRole(keccak256("PAYMASTER_SUPER"), operator)   — both settle paths
+# Per-operator this does the steps an owner key CAN do:
+#   1. PAYMASTER_SUPER role — DETECT ONLY. The Registry is staking-based (registerRole,
+#      msg.sender==user, needs ROLE_COMMUNITY + ~50 GToken stake); an owner CANNOT grant
+#      it. Settle reverts without it — the script flags this; resolve per docs §6.
 #   2. aPNTs.addApprovedFacilitator(operator)                       — direct (xPNTs) path
 #      PNTs.addApprovedFacilitator(operator)                        — direct path (Mycelium key)
 #   3. X402Facilitator.setOperatorFacilitatorFee(operator, 200)     — optional fee override
@@ -59,15 +61,25 @@ FUNDER_AUTH=();   while IFS= read -r l; do FUNDER_AUTH+=("$l");     done < <(fun
 
 send() { echo "  + $1"; cast send "$2" "$3" "${@:4}" --rpc-url "$RPC_URL" >/dev/null; }
 
+ROLE_BLOCKED=0
 for idx in 0 1 2; do
   OP="${ops[$idx]}"; n=$((idx + 1))
   echo "== dvt$n operator $OP =="
 
-  # 1. PAYMASTER_SUPER role (mandatory, both paths)
+  # 1. PAYMASTER_SUPER role (MANDATORY for both settle paths) — DETECT ONLY.
+  #    Registry (contracts/src/core/Registry.sol) is NOT OZ AccessControl: there is no
+  #    owner `grantRole`. The role is acquired ONLY by the OPERATOR ITSELF calling
+  #    Registry.registerRole(ROLE_PAYMASTER_SUPER, op, data) (msg.sender == user), which
+  #    requires (a) the operator already holds ROLE_COMMUNITY, and (b) staking minStake
+  #    GToken (50e18) + ticketPrice via GTOKEN_STAKING + an SBT mint. That is a
+  #    community-onboarding + staking flow an owner key CANNOT perform on the operator's
+  #    behalf — so this script does NOT attempt it. See docs/x402-facilitator.md §6.
   if [ "$(cast call "$REGISTRY" 'hasRole(bytes32,address)(bool)' "$ROLE_PAYMASTER_SUPER" "$OP" --rpc-url "$RPC_URL")" = "true" ]; then
-    echo "  = already has PAYMASTER_SUPER"
+    echo "  = has PAYMASTER_SUPER"
   else
-    send "grant PAYMASTER_SUPER" "$REGISTRY" 'grantRole(bytes32,address)' "$ROLE_PAYMASTER_SUPER" "$OP" "${AASTAR_AUTH[@]}"
+    echo "  ✗ MISSING PAYMASTER_SUPER → settle WILL revert. The operator must self-register"
+    echo "    (Registry.registerRole: needs ROLE_COMMUNITY + ~50 GToken stake + ticket). docs §6."
+    ROLE_BLOCKED=1
   fi
 
   # 2. aPNTs approved facilitator (direct path)
@@ -110,4 +122,10 @@ for idx in 0 1 2; do
   fi
 done
 
+if [ "$ROLE_BLOCKED" = "1" ]; then
+  echo
+  echo "⚠ One or more operators lack PAYMASTER_SUPER — /x402/settle stays BLOCKED until they"
+  echo "  are registered via the Registry staking flow (NOT this script). approvedFacilitators"
+  echo "  + funding above are correct prep, but settle reverts without the role. See docs §6."
+fi
 echo "done. Verify: curl -s https://dvt1.aastar.io/x402/supported | jq, then a live settle round-trip per docs §7."

--- a/deploy/x402-provision.sh
+++ b/deploy/x402-provision.sh
@@ -20,7 +20,9 @@
 #   RPC_URL=https://… AASTAR_OWNER_KEY=0x… [MYCELIUM_OWNER_KEY=0x…] [FUNDER_KEY=0x…] \
 #     ./deploy/x402-provision.sh
 #
-# Idempotent: skips a step if the operator already has the role / approval. Needs foundry (cast).
+# Idempotent: skips every step the chain already reflects (role granted, facilitator
+# approved, fee already 200, operator already funded) — safe to re-run with no extra txs.
+# Keys are read from env (or a keystore account, *_ACCOUNT, to keep them off `ps`). Needs foundry (cast).
 set -euo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
@@ -43,6 +45,18 @@ for i in 1 2 3; do
 done
 echo "operators: dvt1=${ops[0]} dvt2=${ops[1]} dvt3=${ops[2]}"
 
+# Auth flags: PREFER a foundry keystore account (the key never appears on the cast
+# CLI, so it is not visible in `ps aux`). Set AASTAR_ACCOUNT / MYCELIUM_ACCOUNT /
+# FUNDER_ACCOUNT to a `cast wallet import`-ed account name; otherwise fall back to the
+# raw env key via --private-key (fine on a single-user host, but the expanded value
+# is briefly visible in `ps` — use the keystore mode on shared/CI hosts).
+aastar_auth()   { if [ -n "${AASTAR_ACCOUNT:-}" ];   then printf '%s\n%s\n' --account "$AASTAR_ACCOUNT";   else printf '%s\n%s\n' --private-key "$AASTAR_OWNER_KEY"; fi; }
+mycelium_auth() { if [ -n "${MYCELIUM_ACCOUNT:-}" ]; then printf '%s\n%s\n' --account "$MYCELIUM_ACCOUNT"; else printf '%s\n%s\n' --private-key "${MYCELIUM_OWNER_KEY:-}"; fi; }
+funder_auth()   { if [ -n "${FUNDER_ACCOUNT:-}" ];   then printf '%s\n%s\n' --account "$FUNDER_ACCOUNT";   else printf '%s\n%s\n' --private-key "${FUNDER_KEY:-}"; fi; }
+AASTAR_AUTH=();   while IFS= read -r l; do AASTAR_AUTH+=("$l");     done < <(aastar_auth)
+MYCELIUM_AUTH=(); while IFS= read -r l; do MYCELIUM_AUTH+=("$l"); done < <(mycelium_auth)
+FUNDER_AUTH=();   while IFS= read -r l; do FUNDER_AUTH+=("$l");     done < <(funder_auth)
+
 send() { echo "  + $1"; cast send "$2" "$3" "${@:4}" --rpc-url "$RPC_URL" >/dev/null; }
 
 for idx in 0 1 2; do
@@ -53,40 +67,46 @@ for idx in 0 1 2; do
   if [ "$(cast call "$REGISTRY" 'hasRole(bytes32,address)(bool)' "$ROLE_PAYMASTER_SUPER" "$OP" --rpc-url "$RPC_URL")" = "true" ]; then
     echo "  = already has PAYMASTER_SUPER"
   else
-    send "grant PAYMASTER_SUPER" "$REGISTRY" 'grantRole(bytes32,address)' "$ROLE_PAYMASTER_SUPER" "$OP" --private-key "$AASTAR_OWNER_KEY"
+    send "grant PAYMASTER_SUPER" "$REGISTRY" 'grantRole(bytes32,address)' "$ROLE_PAYMASTER_SUPER" "$OP" "${AASTAR_AUTH[@]}"
   fi
 
   # 2. aPNTs approved facilitator (direct path)
   if [ "$(cast call "$APNTS" 'approvedFacilitators(address)(bool)' "$OP" --rpc-url "$RPC_URL")" = "true" ]; then
     echo "  = already approved on aPNTs"
   else
-    send "aPNTs addApprovedFacilitator" "$APNTS" 'addApprovedFacilitator(address)' "$OP" --private-key "$AASTAR_OWNER_KEY"
+    send "aPNTs addApprovedFacilitator" "$APNTS" 'addApprovedFacilitator(address)' "$OP" "${AASTAR_AUTH[@]}"
   fi
 
-  # 2b. PNTs approved facilitator (needs the Mycelium owner key; optional)
-  if [ -n "${MYCELIUM_OWNER_KEY:-}" ]; then
+  # 2b. PNTs approved facilitator (needs the Mycelium owner key/account; optional)
+  if [ -n "${MYCELIUM_OWNER_KEY:-}" ] || [ -n "${MYCELIUM_ACCOUNT:-}" ]; then
     if [ "$(cast call "$PNTS" 'approvedFacilitators(address)(bool)' "$OP" --rpc-url "$RPC_URL")" = "true" ]; then
       echo "  = already approved on PNTs"
     else
-      send "PNTs addApprovedFacilitator" "$PNTS" 'addApprovedFacilitator(address)' "$OP" --private-key "$MYCELIUM_OWNER_KEY"
+      send "PNTs addApprovedFacilitator" "$PNTS" 'addApprovedFacilitator(address)' "$OP" "${MYCELIUM_AUTH[@]}"
     fi
   else
-    echo "  ~ skipping PNTs (set MYCELIUM_OWNER_KEY to enable PNTs settlement)"
+    echo "  ~ skipping PNTs (set MYCELIUM_OWNER_KEY/MYCELIUM_ACCOUNT to enable PNTs settlement)"
   fi
 
-  # 3. operator fee override (optional)
-  send "setOperatorFacilitatorFee 200" "$X402_FACILITATOR" 'setOperatorFacilitatorFee(address,uint256)' "$OP" 200 --private-key "$AASTAR_OWNER_KEY"
+  # 3. operator fee override (optional) — idempotent: skip when already 200, so a
+  #    re-run doesn't burn 3 redundant on-chain txs.
+  curfee="$(cast call "$X402_FACILITATOR" 'operatorFacilitatorFees(address)(uint256)' "$OP" --rpc-url "$RPC_URL" | awk '{print $1}')"
+  if [ "$curfee" = "200" ]; then
+    echo "  = operator fee already 200"
+  else
+    send "setOperatorFacilitatorFee 200" "$X402_FACILITATOR" 'setOperatorFacilitatorFee(address,uint256)' "$OP" 200 "${AASTAR_AUTH[@]}"
+  fi
 
   # 4. gas funding (optional)
-  if [ -n "${FUNDER_KEY:-}" ]; then
+  if [ -n "${FUNDER_KEY:-}" ] || [ -n "${FUNDER_ACCOUNT:-}" ]; then
     bal="$(cast balance "$OP" --rpc-url "$RPC_URL")"
     if [ "$bal" = "0" ]; then
-      echo "  + fund $FUND_ETH ETH"; cast send "$OP" --value "${FUND_ETH}ether" --private-key "$FUNDER_KEY" --rpc-url "$RPC_URL" >/dev/null
+      echo "  + fund $FUND_ETH ETH"; cast send "$OP" --value "${FUND_ETH}ether" "${FUNDER_AUTH[@]}" --rpc-url "$RPC_URL" >/dev/null
     else
       echo "  = already funded ($bal wei)"
     fi
   else
-    echo "  ~ skipping funding (set FUNDER_KEY, or fund $OP with ~$FUND_ETH Sepolia ETH manually)"
+    echo "  ~ skipping funding (set FUNDER_KEY/FUNDER_ACCOUNT, or fund $OP with ~$FUND_ETH Sepolia ETH manually)"
   fi
 done
 

--- a/deploy/x402-provision.sh
+++ b/deploy/x402-provision.sh
@@ -38,12 +38,14 @@ APNTS=0x696A73701b104c6cCBbAadDD2216788ea08EaB89
 PNTS=0xE6579A90dc498a710008de12119812D0FB7aA224
 ROLE_PAYMASTER_SUPER="$(cast keccak 'PAYMASTER_SUPER')" # 0x2024516755f4…
 
-# Derive the 3 operator addresses from the per-node env (the keys never leave the host).
+# Read the 3 operator ADDRESSES from the per-node env (never the keys — so no operator
+# private key reaches a cast CLI / `ps`). X402_OPERATOR_ADDRESS is written alongside
+# X402_OPERATOR_PK when the keys are generated.
 ops=()
 for i in 1 2 3; do
-  pk="$(grep -E '^X402_OPERATOR_PK=' "$REPO/deploy/node$i/.env" | cut -d= -f2)"
-  [ -n "$pk" ] || { echo "node$i: no X402_OPERATOR_PK in deploy/node$i/.env"; exit 1; }
-  ops+=("$(cast wallet address --private-key "$pk")")
+  addr="$(grep -E '^X402_OPERATOR_ADDRESS=' "$REPO/deploy/node$i/.env" | cut -d= -f2)"
+  [ -n "$addr" ] || { echo "node$i: no X402_OPERATOR_ADDRESS in deploy/node$i/.env"; exit 1; }
+  ops+=("$addr")
 done
 echo "operators: dvt1=${ops[0]} dvt2=${ops[1]} dvt3=${ops[2]}"
 

--- a/deploy/x402-register-operators.sh
+++ b/deploy/x402-register-operators.sh
@@ -31,10 +31,38 @@ AUTH=(--private-key "$AASTAR_OWNER_KEY")
 has() { [ "$(cast call "$REGISTRY" 'hasRole(bytes32,address)(bool)' "$1" "$2" --rpc-url "$RPC_URL")" = "true" ]; }
 approve() { cast send "$GTOKEN" 'approve(address,uint256)' "$STAKING" "$1" "${AUTH[@]}" --rpc-url "$RPC_URL" >/dev/null; }
 mint() { echo "  + safeMintForRole $3"; cast send "$REGISTRY" 'safeMintForRole(bytes32,address,bytes)' "$1" "$2" "$4" "${AUTH[@]}" --rpc-url "$RPC_URL" >/dev/null; }
+# Read operator ADDRESSES (never the keys) so no operator private key reaches a cast CLI / `ps`.
+op_addr() { grep -E '^X402_OPERATOR_ADDRESS=' "$REPO/deploy/node$1/.env" | cut -d= -f2; }
+
+# Sponsor address (for the pre-flight) without exposing the key: prefer the keystore
+# account; else derive from the env key (already used by the --private-key sends below).
+if [ -n "${AASTAR_ACCOUNT:-}" ]; then
+  SPONSOR="$(cast wallet address --account "$AASTAR_ACCOUNT")"
+else
+  SPONSOR="$(cast wallet address --private-key "$AASTAR_OWNER_KEY")"
+fi
+
+# Pre-flight: the sponsor must hold ROLE_COMMUNITY (safeMintForRole gates on it) and
+# enough GToken to cover every operator still needing registration (~85 GToken each:
+# 30 community ticket + 50 stake + 5 super ticket). Fail BEFORE any tx so we never
+# stop mid-loop in a half-registered state under `set -e`.
+has "$ROLE_COMMUNITY" "$SPONSOR" || { echo "sponsor $SPONSOR lacks ROLE_COMMUNITY — safeMintForRole would revert"; exit 1; }
+need=0
+for i in 1 2 3; do
+  OP="$(op_addr "$i")"
+  [ -n "$OP" ] || { echo "node$i: no X402_OPERATOR_ADDRESS in deploy/node$i/.env"; exit 1; }
+  has "$ROLE_COMMUNITY" "$OP" || need=$((need + 35))
+  has "$ROLE_SUPER" "$OP" || need=$((need + 55))
+done
+if [ "$need" -gt 0 ]; then
+  bal_wei="$(cast call "$GTOKEN" 'balanceOf(address)(uint256)' "$SPONSOR" --rpc-url "$RPC_URL" | awk '{print $1}')"
+  bal_gt="$(cast --to-unit "$bal_wei" ether)"
+  echo "sponsor $SPONSOR GToken=$bal_gt, need ≈ $need for unregistered operators"
+  awk -v b="$bal_gt" -v n="$need" 'BEGIN{ if (b+0 < n+0) exit 1 }' || { echo "INSUFFICIENT GToken (have $bal_gt, need ~$need)"; exit 1; }
+fi
 
 for i in 1 2 3; do
-  pk="$(grep -E '^X402_OPERATOR_PK=' "$REPO/deploy/node$i/.env" | cut -d= -f2)"
-  OP="$(cast wallet address --private-key "$pk")"
+  OP="$(op_addr "$i")"
   echo "== dvt$i operator $OP =="
 
   if has "$ROLE_COMMUNITY" "$OP"; then

--- a/deploy/x402-register-operators.sh
+++ b/deploy/x402-register-operators.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Register the 3 DVT x402 operators as staked community paymasters (#130 §6).
+#
+# This is the REAL way to give an operator ROLE_PAYMASTER_SUPER (the Registry is
+# staking-based, NOT owner grantRole). It uses Registry.safeMintForRole, which lets a
+# caller that ALREADY holds ROLE_COMMUNITY register roles FOR another address and pay
+# the stake/ticket from the caller's own GToken. AAStar's owner (0xb560) holds
+# ROLE_COMMUNITY + GToken, so it sponsors all three operators — no operator self-sign.
+#
+# Per operator (idempotent; skips a role already held):
+#   1. ROLE_COMMUNITY      : ticket 30 GToken (no stake). Unique community `name`,
+#      empty ensName. Required first — PAYMASTER_SUPER gates on the operator's COMMUNITY.
+#   2. ROLE_PAYMASTER_SUPER : stake 50 GToken (recoverable on exit) + ticket 5 GToken.
+#   ⇒ ~85 GToken/operator from the sponsor (≈255 total; 150 recoverable stake).
+#
+# Usage:  RPC_URL=… AASTAR_OWNER_KEY=0x<0xb560 key> ./deploy/x402-register-operators.sh
+# Needs foundry (cast). The sponsor (AASTAR_OWNER_KEY) must hold ROLE_COMMUNITY + ≥255 GToken.
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+: "${RPC_URL:?set RPC_URL (Sepolia)}"
+: "${AASTAR_OWNER_KEY:?set AASTAR_OWNER_KEY (0xb560 — holds ROLE_COMMUNITY + GToken)}"
+
+REGISTRY=0xf5Bf37ca83AfdAab73691bA7eCcDfA69b8708E71
+STAKING=0x472297B557c1d0F030f281a5Bb8A535f6c5AB65e
+GTOKEN=0x4c09aE57503Aa1E2A43b05621A38DbdD43b0Aa08
+ROLE_COMMUNITY="$(cast keccak 'COMMUNITY')"
+ROLE_SUPER="$(cast keccak 'PAYMASTER_SUPER')"
+AUTH=(--private-key "$AASTAR_OWNER_KEY")
+[ -n "${AASTAR_ACCOUNT:-}" ] && AUTH=(--account "$AASTAR_ACCOUNT")
+
+has() { [ "$(cast call "$REGISTRY" 'hasRole(bytes32,address)(bool)' "$1" "$2" --rpc-url "$RPC_URL")" = "true" ]; }
+approve() { cast send "$GTOKEN" 'approve(address,uint256)' "$STAKING" "$1" "${AUTH[@]}" --rpc-url "$RPC_URL" >/dev/null; }
+mint() { echo "  + safeMintForRole $3"; cast send "$REGISTRY" 'safeMintForRole(bytes32,address,bytes)' "$1" "$2" "$4" "${AUTH[@]}" --rpc-url "$RPC_URL" >/dev/null; }
+
+for i in 1 2 3; do
+  pk="$(grep -E '^X402_OPERATOR_PK=' "$REPO/deploy/node$i/.env" | cut -d= -f2)"
+  OP="$(cast wallet address --private-key "$pk")"
+  echo "== dvt$i operator $OP =="
+
+  if has "$ROLE_COMMUNITY" "$OP"; then
+    echo "  = already ROLE_COMMUNITY"
+  else
+    DATA="$(cast abi-encode 'f((string,string,uint256))' "(\"AAStar DVT$i x402\",\"dvt$i-x402.aastar.eth\",30000000000000000000)")"
+    approve 35000000000000000000   # 35 GToken (ticket 30 + buffer)
+    mint "$ROLE_COMMUNITY" "$OP" "ROLE_COMMUNITY (AAStar DVT$i x402)" "$DATA"
+  fi
+
+  if has "$ROLE_SUPER" "$OP"; then
+    echo "  = already ROLE_PAYMASTER_SUPER"
+  else
+    approve 60000000000000000000   # 60 GToken (stake 50 + ticket 5 + buffer)
+    mint "$ROLE_SUPER" "$OP" "ROLE_PAYMASTER_SUPER" "0x"
+  fi
+done
+echo "done — operators are staked PAYMASTER_SUPER. Next: approvedFacilitators + funding (x402-provision.sh), then a live settle."

--- a/docs/x402-facilitator.md
+++ b/docs/x402-facilitator.md
@@ -266,14 +266,29 @@ cast send $APNTS_TOKEN "addApprovedFacilitator(address)" $OPERATOR_ADDRESS \
 cast send $PNTS_TOKEN  "addApprovedFacilitator(address)" $OPERATOR_ADDRESS \
   --private-key $COMMUNITY_OWNER_KEY --rpc-url $RPC_URL
 
-# 3. Grant the PAYMASTER_SUPER role in the Registry (onlyOwner). The role hash is
-#    keccak256("PAYMASTER_SUPER") — note: NO "ROLE_" prefix in the hashed string.
-cast send $REGISTRY "grantRole(bytes32,address)" \
-  $(cast keccak "PAYMASTER_SUPER") $OPERATOR_ADDRESS \
-  --private-key $DEPLOYER_KEY --rpc-url $RPC_URL
+# 3. PAYMASTER_SUPER role — NOT an owner grantRole. ⚠️ The Registry
+#    (SuperPaymaster contracts/src/core/Registry.sol) is NOT OpenZeppelin
+#    AccessControl. There is no admin grantRole; on-chain checks confirm getRoleAdmin
+#    reverts and the deployer lacks DEFAULT_ADMIN_ROLE. The role is acquired ONLY by
+#    the OPERATOR ITSELF:
+#      Registry.registerRole(keccak256("PAYMASTER_SUPER"), operator, roleData)   // msg.sender == operator
+#    and it requires, FIRST, that the operator already holds ROLE_COMMUNITY, then a
+#    STAKE of minStake GToken (config = 50e18) + ticketPrice via GTOKEN_STAKING, plus an
+#    SBT mint. So each facilitator operator must be onboarded as a staked community
+#    paymaster — a governance/economic step, not a deployer one-liner.
 ```
 
-The `direct` path requires the operator be in
+> ⚠️ **Registry role-grant correction (verified on-chain 2026-06-28).** The
+> issue #130 runbook's `Registry.grantRole(...)` is wrong (third runbook error):
+> the Registry is staking-based, so `grantRole` reverts. Granting
+> PAYMASTER_SUPER to a DVT x402 operator means registering that operator as a
+> **staked community paymaster** (`registerRole` self-call + ROLE_COMMUNITY +
+> ~50 GToken). This is an open AAStar/SuperPaymaster decision: (a) onboard+stake
+> each operator, (b) add a lighter facilitator-only gate to `X402Facilitator`,
+> or (c) another approach. `deploy/x402-provision.sh` detects-and-reports this
+> rather than attempting it.
+
+The `direct` path also requires the operator be in
 `IxPNTsToken(asset).approvedFacilitators(operator)` for each supported token —
 established by step 2's `addApprovedFacilitator` (callable only by the token's
 `communityOwner`; revocable instantly via `removeApprovedFacilitator` for

--- a/docs/x402-facilitator.md
+++ b/docs/x402-facilitator.md
@@ -299,6 +299,16 @@ transferFrom allowance firewall).
 
 ## 7. Conformance fixtures & live round-trip
 
+> ✅ **Testnet LIVE (2026-06-28).** All 3 operators were registered as staked
+> community paymasters via `deploy/x402-register-operators.sh` (ROLE_COMMUNITY +
+> PAYMASTER_SUPER, ~85 GToken each, sponsored by 0xb560), then
+> `deploy/x402-provision.sh` set aPNTs/PNTs `approvedFacilitator` + fee + gas. A
+> real **direct settle** went through dvt1: 1 aPNTs from the payer → 0.98 to the
+> recipient + 0.02 (2% fee) retained, tx
+> `0xc5bad0afadb8a78639fc0614a6fbd38a5160f3730ffef2b8f77eaf8fb8725a87` (status
+> 1). So `/x402/{verify,settle,supported}` are fully operational on
+> dvt{1,2,3}.aastar.io.
+
 `conformance/x402/fixtures.json` holds the **golden wire vectors** — the exact
 `/x402/{verify,settle}` request bodies a conformant SDK emits (one `direct`, one
 `eip-3009`, signed by a fixed key), plus the values the DVT derives (effective


### PR DESCRIPTION
Brings the x402 facilitator **live on the 3 testnet DVT nodes**. `/x402/verify` + `/x402/supported` are serving on `dvt1/2/3.aastar.io` now (verified against the real `X402Facilitator` 0xfe1DB01e). Tracked changes only — the actual enable flags + per-node operator keys live in git-ignored `deploy/.env.testnet` / `deploy/node{1,2,3}/.env`.

## Live now
```
GET https://dvt{1,2,3}.aastar.io/x402/supported → 200
  {kinds:[{…, extra:{settlementSchemes:[direct,eip-3009], assets:[aPNTs,PNTs], feeBPS:200,
           facilitatorContract:0xfe1DB01e…, operator:<per-node>}}]}
POST .../x402/verify → runs the full pipeline incl. the on-chain nonce read against the real contract.
```
Operators (dedicated keys, one per node): dvt1 `0xF92DC383…`, dvt2 `0x2e72A258…`, dvt3 `0x368f8Cb8…`.

## In this PR
- `.env.testnet.example` — documents the x402 vars (default off).
- `sdk-dvt-config.testnet.json` — `capabilities.x402` (endpoints, contract, assets, feeBPS, `extra` schema, auth headers) + `facilitators[]` `{url:/x402, operator}` so the SDK can fill `DEFAULT_X402_FACILITATORS`.
- `deploy/x402-provision.sh` — idempotent on-chain provisioning for the 3 operators.

## ⛔ `/x402/settle` is gated on provisioning I can't do (needs owner keys + gas)
The contract requires each operator to (1) hold `PAYMASTER_SUPER` in the Registry and (2) be in each xPNTs `approvedFacilitators`, plus gas. Those are owner/governance calls:
- `0xb5600060…` (AAStar) owns X402Facilitator + aPNTs + Registry — **not in this repo**.
- `0xEcAACb91…` (Mycelium) owns PNTs — **different owner**.
- The 3 operators have 0 ETH.

Run `RPC_URL=… AASTAR_OWNER_KEY=… [MYCELIUM_OWNER_KEY=…] [FUNDER_KEY=…] ./deploy/x402-provision.sh` with those keys, then a live settle round-trip (docs §7) closes it out.