### PR TITLE
feat: expose package version in /health and Swagger

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,14 @@
 import "reflect-metadata";
+import { createRequire } from "module";
 import { NestFactory } from "@nestjs/core";
 import { AppModule } from "./app.module.js";
 import { ValidationPipe } from "@nestjs/common";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { ConfigService } from "@nestjs/config";
 import { GossipService } from "./modules/gossip/gossip.service.js";
+
+const require = createRequire(import.meta.url);
+const { version: APP_VERSION } = require("../package.json") as { version: string };
 
 async function bootstrap() {
   // rawBody: true exposes the unparsed request body (req.rawBody) so the optional
@@ -25,7 +29,7 @@ async function bootstrap() {
   const config = new DocumentBuilder()
     .setTitle("BLS Signer Service API")
     .setDescription("API documentation for ERC4337 BLS signature aggregation service")
-    .setVersion("1.0")
+    .setVersion(APP_VERSION)
     .addTag("signature", "Signature operations")
     .addTag("node", "Node management")
     .addTag("admin", "Admin panel for node management")

--- a/src/modules/health/health.controller.ts
+++ b/src/modules/health/health.controller.ts
@@ -1,6 +1,10 @@
+import { createRequire } from "module";
 import { Controller, Get, Optional } from "@nestjs/common";
 import { ApiOperation, ApiTags } from "@nestjs/swagger";
 import { CapabilityRegistry } from "../capability/capability-registry.service.js";
+
+const require = createRequire(import.meta.url);
+const { version: APP_VERSION } = require("../../../package.json") as { version: string };
 
 /**
  * Root + liveness endpoints. Plain `GET /health` is the conventional probe
@@ -42,8 +46,8 @@ export class HealthController {
 
   @Get("health")
   @ApiOperation({ summary: "Liveness check + enabled capabilities" })
-  health(): { status: string; capabilities: Array<{ name: string; enabled: boolean }> } {
-    return { status: "ok", capabilities: this.capList() };
+  health(): { status: string; version: string; capabilities: Array<{ name: string; enabled: boolean }> } {
+    return { status: "ok", version: APP_VERSION, capabilities: this.capList() };
   }
 
   private capList(): Array<{ name: string; enabled: boolean }> {


### PR DESCRIPTION
## Summary
- `GET /health` now returns `"version":"1.7.0"` alongside status + capabilities
- Swagger UI (`/api`) version header reads from `package.json` instead of hardcoded `"1.0"`
- Uses `createRequire(import.meta.url)` for ESM-safe `package.json` load

## Test
```
curl https://dvt1.aastar.io/health
# {"status":"ok","version":"1.7.0","capabilities":[...]}
```