### PR TITLE
fix(#140): DVT eth_call isValidOwnerAuth instead of local ECDSA/P256

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -186,6 +186,155 @@ override `RELAY_*` for a different deployment. See
 
 ---
 
+## 9. 运维手册（macOS 本地部署）
+
+### 服务一览
+
+共 2 个进程，6 个逻辑服务：
+
+| 服务 | 端口 | 说明 |
+|------|------|------|
+| DVT node 1 | 4001 | BLS 联合签名节点 |
+| DVT node 2 | 4002 | BLS 联合签名节点 |
+| DVT node 3 | 4003 | BLS 联合签名节点 |
+| cloudflared | — | 将三节点暴露为 dvt1/2/3.aastar.io |
+| relay（内置） | 同节点端口 | Gasless 代币购买中继，`POST /v3/relay` |
+| keeper（内置） | 同节点端口 | 节点签名策略 / 心跳 |
+| x402-facilitator（内置） | 同节点端口 | x402 支付撮合 |
+| **price-keeper** | — | 独立进程，每 3 分钟刷新 SuperPaymaster 价格预言机 |
+
+> relay / keeper / x402-facilitator 是 DVT 节点的内置模块，随节点启停，不需要单独管理。
+> price-keeper 是独立进程，由 LaunchAgent 托管。
+
+---
+
+### 查看所有服务状态
+
+```bash
+cd ~/Dev/aastar/YetAnotherAA-Validator
+./deploy/dvt-testnet.sh status
+```
+
+输出示例：
+```
+local nodes:
+  node1 :4001  ✅ UP
+  node2 :4002  ✅ UP
+  node3 :4003  ✅ UP
+cloudflared:  ✅ running
+relay (#98, optional):
+  node1 relay: ✅ enabled  ...
+keeper (#58, optional):
+  node1 keeper: ✅ enabled  ...
+x402-facilitator (optional):
+  node1 facilitator: ✅ enabled  ...
+price-keeper (standalone):
+  price-keeper: ✅ running
+public:
+  https://dvt1.aastar.io  ✅  ...
+```
+
+---
+
+### 启动
+
+```bash
+cd ~/Dev/aastar/YetAnotherAA-Validator
+
+# 启动 DVT 三节点 + cloudflared（含 relay / keeper / facilitator）
+./deploy/dvt-testnet.sh start
+
+# 启动 price-keeper（通常由 LaunchAgent 自动启动，手动启动用这个）
+cd ~/Dev/aastar/aastar-sdk
+./run-keeper.sh sepolia
+```
+
+### 停止
+
+```bash
+cd ~/Dev/aastar/YetAnotherAA-Validator
+
+# 停止 DVT 三节点 + cloudflared
+./deploy/dvt-testnet.sh stop
+
+# 停止 price-keeper
+pkill -f "keeper.ts.*sepolia"
+```
+
+### 重启
+
+```bash
+cd ~/Dev/aastar/YetAnotherAA-Validator
+
+# 重启 DVT 三节点 + cloudflared
+./deploy/dvt-testnet.sh restart
+
+# 重启 price-keeper（通过 LaunchAgent）
+launchctl kickstart -k gui/$(id -u)/io.aastar.price-keeper
+```
+
+---
+
+### 查看日志
+
+```bash
+cd ~/Dev/aastar/YetAnotherAA-Validator
+
+# DVT 节点日志（1 / 2 / 3 任选）
+./deploy/dvt-testnet.sh logs 1
+./deploy/dvt-testnet.sh logs 2
+./deploy/dvt-testnet.sh logs 3
+
+# cloudflared 隧道日志
+./deploy/dvt-testnet.sh logs cf
+
+# price-keeper 日志
+tail -f ~/Dev/aastar/aastar-sdk/keeper.log
+```
+
+---
+
+### 开机自启（macOS LaunchAgent）
+
+两个 plist 已配置在 `~/Library/LaunchAgents/`，Mac 登录后自动启动，无需手动操作：
+
+| plist 文件 | 管理的服务 | 崩溃自动重启 |
+|-----------|----------|------------|
+| `io.aastar.dvt-testnet.plist` | DVT 三节点 + cloudflared | 否（脚本后台化后退出属正常） |
+| `io.aastar.price-keeper.plist` | price-keeper | 是 |
+
+手动加载 / 卸载（通常不需要）：
+
+```bash
+# 加载（开机自启生效）
+launchctl load ~/Library/LaunchAgents/io.aastar.dvt-testnet.plist
+launchctl load ~/Library/LaunchAgents/io.aastar.price-keeper.plist
+
+# 卸载（取消自启）
+launchctl unload ~/Library/LaunchAgents/io.aastar.dvt-testnet.plist
+launchctl unload ~/Library/LaunchAgents/io.aastar.price-keeper.plist
+```
+
+检查 LaunchAgent 运行状态：
+
+```bash
+launchctl list io.aastar.dvt-testnet
+launchctl list io.aastar.price-keeper
+# PID 有值 = 正在运行；LastExitStatus = 0 = 上次正常退出
+```
+
+---
+
+### ⚠️ price-keeper 为什么不能停
+
+price-keeper 每 3 分钟调用一次 `SuperPaymaster.updatePrice()`。
+一旦停止 → aPNTs 价格过期 → `getRealtimeTokenCost` revert → 用户看到
+`InsufficientBalance`（哪怕账户有 1000 万 aPNTs 也没用）。
+
+签名账户：anni EOA `0xEcAACb915f7D92e9916f449F7ad42BD0408733c9`（持有 `PRICE_UPDATER_ROLE`）。
+
+---
+
 ## Notes
 
 - **Independence is the point** (TESTNET_RELEASE_PLAN §5): real multi-party

--- a/deploy/dvt-testnet.sh
+++ b/deploy/dvt-testnet.sh
@@ -108,6 +108,19 @@ status() {
       *) echo "  node$i keeper: ❌ down" ;;
     esac
   done
+  echo "x402-facilitator (optional):"
+  for i in 1 2 3; do
+    local port="${PORTS[$((i - 1))]}"
+    local h
+    h="$(curl -s -m 4 "http://localhost:$port/health" 2>/dev/null || true)"
+    case "$h" in
+      *'"name":"x402-facilitator","enabled":true'*) echo "  node$i facilitator: ✅ enabled" ;;
+      *'"name":"x402-facilitator","enabled":false'*) echo "  node$i facilitator: ⚪ disabled" ;;
+      *) echo "  node$i facilitator: ❌ down" ;;
+    esac
+  done
+  echo "price-keeper (standalone):"
+  if pgrep -f "keeper.ts.*sepolia" >/dev/null 2>&1; then echo "  price-keeper: ✅ running"; else echo "  price-keeper: ❌ not running (see aastar-sdk/run-keeper.sh)"; fi
   echo "public:"
   for h in "${HOSTS[@]}"; do
     if curl -s -m 8 "https://$h.aastar.io/node/info" >/dev/null 2>&1; then echo "  https://$h.aastar.io  ✅"; else echo "  https://$h.aastar.io  ❌"; fi

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,7 @@ export default {
   testMatch: ["**/__tests__/**/*.ts", "**/?(*.)+(spec|test).ts"],
   testPathIgnorePatterns: [
     "/node_modules/",
+    "/dist/",
     "/contracts/lib/",
     "/contracts/out/",
     "/contracts/cache/",

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -451,8 +451,8 @@ export class BlockchainService {
       throw new Error("Blockchain provider not configured");
     }
 
-    // ERC-1271 magic value for isValidSignature / isValidOwnerAuth
-    const MAGIC_VALUE = "0x1626ba7e";
+    // AAStarAirAccount custom magic value for isValidOwnerAuth (not standard ERC-1271)
+    const MAGIC_VALUE = "0xa0cf00cf";
 
     const abi = [
       "function isValidOwnerAuth(bytes32 userOpHash, bytes calldata ownerAuth) view returns (bytes4)",

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -431,6 +431,46 @@ export class BlockchainService {
   }
 
   /**
+   * Validate owner authorization via ERC-1271 style view: eth_call the account's
+   * `isValidOwnerAuth(userOpHash, ownerAuth)` and verify it returns the magic value.
+   *
+   * This replaces local ECDSA/P256 verification, ensuring DVT never drifts from the
+   * contract's actual validation logic. The account is the single source of truth.
+   *
+   * @param account The account address to call
+   * @param userOpHash The derived userOpHash to validate against
+   * @param ownerAuth The owner authorization (ECDSA signature or WebAuthn blob)
+   * @returns true if the account returns the magic value; false otherwise (fail-closed)
+   */
+  async isValidOwnerAuth(
+    account: string,
+    userOpHash: string,
+    ownerAuth: string
+  ): Promise<boolean> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+
+    // ERC-1271 magic value for isValidSignature / isValidOwnerAuth
+    const MAGIC_VALUE = "0x1626ba7e";
+
+    const abi = [
+      "function isValidOwnerAuth(bytes32 userOpHash, bytes calldata ownerAuth) view returns (bytes4)",
+    ];
+    const contract = new ethers.Contract(account, abi, this.provider);
+
+    try {
+      const result = await contract.isValidOwnerAuth(userOpHash, ownerAuth);
+      return result === MAGIC_VALUE;
+    } catch (error: any) {
+      this.logger.warn(
+        `isValidOwnerAuth eth_call failed for account ${account}: ${error.message}`
+      );
+      return false;
+    }
+  }
+
+  /**
    * Static-simulate updatePrice() WITHOUT sending a tx. Returns true if it would
    * succeed, false if it would revert (e.g. SuperPaymaster's OracleError when the
    * cached price is already as fresh as Chainlink). The keeper calls this right

--- a/src/modules/bls/bls.service.spec.ts
+++ b/src/modules/bls/bls.service.spec.ts
@@ -77,6 +77,7 @@ describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
   let service: InstanceType<typeof BlsService>;
   let getAccountOwner: jest.Mock<(account: string) => Promise<string>>;
   let getUserOpHash: jest.Mock<(userOp: PackedUserOp) => Promise<string>>;
+  let isValidOwnerAuth: jest.Mock<(account: string, userOpHash: string, ownerAuth: string) => Promise<boolean>>;
 
   // Sign a hash exactly the way the account owner signs the UserOperation:
   // EIP-191 prefix over the raw 32-byte hash.
@@ -87,9 +88,11 @@ describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
   beforeEach(() => {
     getAccountOwner = jest.fn<(account: string) => Promise<string>>();
     getUserOpHash = jest.fn<(userOp: PackedUserOp) => Promise<string>>();
+    isValidOwnerAuth = jest.fn<(account: string, userOpHash: string, ownerAuth: string) => Promise<boolean>>();
     const blockchain = {
       getAccountOwner,
       getUserOpHash,
+      isValidOwnerAuth,
     } as unknown as InstanceType<typeof BlockchainService>;
     // Default local-key signer (byte-identical to the pre-port signing path).
     const signer = {
@@ -101,13 +104,14 @@ describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
   it("signs and returns a signature when ownerAuth recovers to the derived-hash owner", async () => {
     getUserOpHash.mockResolvedValue(derivedHash);
     getAccountOwner.mockResolvedValue(ownerWallet.address);
+    isValidOwnerAuth.mockResolvedValue(true);
     const ownerAuth = await signEip191(ownerWallet, derivedHash);
 
     const result = await service.signMessage(makeUserOp(victimAccount), ownerAuth, node);
 
     // account must be derived from userOp.sender, not caller-claimed.
-    expect(getAccountOwner).toHaveBeenCalledWith(victimAccount);
     expect(getUserOpHash).toHaveBeenCalledTimes(1);
+    expect(isValidOwnerAuth).toHaveBeenCalledWith(victimAccount, derivedHash, ownerAuth);
     expect(result.nodeId).toBe(node.nodeId);
     expect(result.signature).toMatch(/^0x[0-9a-f]+$/);
     expect(result.signatureCompact).toBeTruthy();
@@ -120,16 +124,16 @@ describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
   // victim account B by supplying B's userOp + A-owner's signature. Because:
   //   - account = userOp.sender = B  (derived, attacker cannot lie)
   //   - userOpHash is derived from B's userOp via EntryPoint
-  //   - the gate requires B's on-chain owner to have signed that hash
-  // The attacker's signature recovers to A's owner != B's owner → 403.
+  //   - the contract validates against B's authorization logic
+  // The attacker's signature (or WebAuthn) doesn't validate against B → eth_call returns false → 403.
   it("CRITICAL: rejects (403) cross-account oracle — attacker owns a different account", async () => {
     const attackerWallet = ethers.Wallet.createRandom();
     // The node always derives the hash from the submitted userOp (the victim's).
     getUserOpHash.mockResolvedValue(derivedHash);
-    // The submitted userOp is the VICTIM's account; its on-chain owner is ownerWallet.
-    getAccountOwner.mockResolvedValue(ownerWallet.address);
-    // Attacker signs the (derived) victim hash with their OWN key — they own a
-    // different account, not the victim's.
+    // The submitted userOp is the VICTIM's account; contract validation returns false.
+    isValidOwnerAuth.mockResolvedValue(false);
+    // Attacker signs the (derived) victim hash with their OWN key — the contract
+    // (authorizing against victim's owner/keys) rejects it.
     const ownerAuth = await signEip191(attackerWallet as unknown as ethers.Wallet, derivedHash);
 
     await expect(
@@ -137,9 +141,9 @@ describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
     ).rejects.toBeInstanceOf(ForbiddenException);
   });
 
-  it("rejects (403) when userOp.sender's owner != ownerAuth signer", async () => {
+  it("rejects (403) when ownerAuth is invalid (isValidOwnerAuth returns false)", async () => {
     getUserOpHash.mockResolvedValue(derivedHash);
-    getAccountOwner.mockResolvedValue(ownerWallet.address);
+    isValidOwnerAuth.mockResolvedValue(false);
     const wrongSigner = ethers.Wallet.createRandom();
     const ownerAuth = await signEip191(wrongSigner as unknown as ethers.Wallet, derivedHash);
 
@@ -150,9 +154,9 @@ describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
 
   it("attacker cannot substitute a different hash — only the EntryPoint-derived hash is signed", async () => {
     // Owner signs SOME OTHER hash; the node only ever derives & checks against the
-    // EntryPoint hash, so a sig over an unrelated hash never authorizes.
+    // EntryPoint hash, so the contract validation against that other hash fails.
     getUserOpHash.mockResolvedValue(derivedHash);
-    getAccountOwner.mockResolvedValue(ownerWallet.address);
+    isValidOwnerAuth.mockResolvedValue(false);
     const otherHash = "0x" + "11".repeat(32);
     const ownerAuth = await signEip191(ownerWallet, otherHash);
 
@@ -163,7 +167,6 @@ describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
 
   it("rejects (403) when EntryPoint.getUserOpHash reverts", async () => {
     getUserOpHash.mockRejectedValue(new Error("execution reverted"));
-    getAccountOwner.mockResolvedValue(ownerWallet.address);
     const ownerAuth = await signEip191(ownerWallet, derivedHash);
 
     await expect(
@@ -173,7 +176,7 @@ describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
 
   it("rejects (403, not 400) when ownerAuth is malformed", async () => {
     getUserOpHash.mockResolvedValue(derivedHash);
-    getAccountOwner.mockResolvedValue(ownerWallet.address);
+    isValidOwnerAuth.mockResolvedValue(false);
 
     await expect(
       service.signMessage(makeUserOp(victimAccount), "0xdeadbeef", node)
@@ -182,7 +185,7 @@ describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
 
   it("rejects (403, not 400) when ownerAuth is missing/undefined", async () => {
     getUserOpHash.mockResolvedValue(derivedHash);
-    getAccountOwner.mockResolvedValue(ownerWallet.address);
+    isValidOwnerAuth.mockResolvedValue(false);
 
     await expect(
       service.signMessage(makeUserOp(victimAccount), undefined, node)
@@ -191,7 +194,7 @@ describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
 
   it("rejects (403, not 400) when userOp.sender is not a valid address", async () => {
     getUserOpHash.mockResolvedValue(derivedHash);
-    getAccountOwner.mockResolvedValue(ownerWallet.address);
+    isValidOwnerAuth.mockResolvedValue(true);
     const ownerAuth = await signEip191(ownerWallet, derivedHash);
     const bad = { ...makeUserOp(victimAccount), sender: "not-an-address" };
 
@@ -200,12 +203,12 @@ describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
     );
     // Shape rejected before any chain read.
     expect(getUserOpHash).not.toHaveBeenCalled();
-    expect(getAccountOwner).not.toHaveBeenCalled();
+    expect(isValidOwnerAuth).not.toHaveBeenCalled();
   });
 
   it("rejects (403, not 400) when a required userOp field is missing", async () => {
     getUserOpHash.mockResolvedValue(derivedHash);
-    getAccountOwner.mockResolvedValue(ownerWallet.address);
+    isValidOwnerAuth.mockResolvedValue(true);
     const ownerAuth = await signEip191(ownerWallet, derivedHash);
     const bad = { ...makeUserOp(victimAccount) } as Partial<PackedUserOp>;
     delete bad.callData;
@@ -214,12 +217,13 @@ describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
       ForbiddenException
     );
     expect(getUserOpHash).not.toHaveBeenCalled();
-    expect(getAccountOwner).not.toHaveBeenCalled();
+    expect(isValidOwnerAuth).not.toHaveBeenCalled();
   });
 
-  it("rejects (403) fail-closed for a P256/passkey-only account (owner == zero address)", async () => {
+  it("rejects (403) fail-closed when isValidOwnerAuth eth_call fails (e.g. P256 passkey validation rejection)", async () => {
     getUserOpHash.mockResolvedValue(derivedHash);
-    getAccountOwner.mockResolvedValue(ethers.ZeroAddress);
+    isValidOwnerAuth.mockResolvedValue(false);
+    // Attempt with a WebAuthn blob (or any ownerAuth); contract validation fails.
     const ownerAuth = await signEip191(ownerWallet, derivedHash);
 
     await expect(
@@ -227,9 +231,9 @@ describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
     ).rejects.toBeInstanceOf(ForbiddenException);
   });
 
-  it("rejects (403) fail-closed when the on-chain owner read fails", async () => {
+  it("rejects (403) fail-closed when isValidOwnerAuth eth_call throws (rpc failure)", async () => {
     getUserOpHash.mockResolvedValue(derivedHash);
-    getAccountOwner.mockRejectedValue(new Error("rpc down"));
+    isValidOwnerAuth.mockRejectedValue(new Error("rpc down"));
     const ownerAuth = await signEip191(ownerWallet, derivedHash);
 
     await expect(
@@ -237,12 +241,14 @@ describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
     ).rejects.toBeInstanceOf(ForbiddenException);
   });
 
-  it("matches owner regardless of address checksum casing", async () => {
+  it("signs when isValidOwnerAuth returns true regardless of address checksum casing", async () => {
     getUserOpHash.mockResolvedValue(derivedHash);
-    getAccountOwner.mockResolvedValue(ethers.getAddress(ownerWallet.address));
+    isValidOwnerAuth.mockResolvedValue(true);
     const ownerAuth = await signEip191(ownerWallet, derivedHash);
 
     const result = await service.signMessage(makeUserOp(victimAccount), ownerAuth, node);
     expect(result.nodeId).toBe(node.nodeId);
+    // eth_call was made with the checksum-normalized account address.
+    expect(isValidOwnerAuth).toHaveBeenCalledWith(victimAccount, derivedHash, ownerAuth);
   });
 });

--- a/src/modules/bls/bls.service.ts
+++ b/src/modules/bls/bls.service.ts
@@ -16,34 +16,31 @@ export class BlsService {
   ) {}
 
   /**
-   * Fix 2 Stage 1 — owner-authorization gate.
+   * Fix 2 Stage 1 & 2 — owner-authorization gate (ERC-1271 style view).
    *
-   * The node co-signs ONLY when the request carries a valid account-owner ECDSA
-   * signature over the AUTHORITATIVE userOpHash, which is DERIVED from the full
-   * UserOperation (never trusted from the caller). The flow:
+   * The node co-signs ONLY when the account validates the ownerAuth over the
+   * AUTHORITATIVE userOpHash (which is DERIVED from the full UserOperation, never
+   * trusted from the caller). The flow:
    *
    *   account     = userOp.sender                                 (derived, not claimed)
    *   userOpHash  = EntryPoint.getUserOpHash(userOp)              (binds hash↔sender/chain)
-   *   owner       = account.owner()
-   *   require verifyMessage(getBytes(userOpHash), ownerAuth) == owner
+   *   isValid     = account.isValidOwnerAuth(userOpHash, ownerAuth) [eth_call view]
+   *   require isValid returns magic value 0x1626ba7e
    *   then BLS-sign hashToCurve(userOpHash)  — the SAME derived hash (no TOCTOU)
    *
    * Deriving the hash on-chain is what closes the cross-account oracle hole: an
    * attacker who owns account A cannot get the node to sign account B's userOpHash,
    * because the hash is computed from `userOp.sender` (= B) and getUserOpHash binds
-   * it to B, chainId, and the EntryPoint. The owner check then requires B's owner.
+   * it to B, chainId, and the EntryPoint.
    *
-   * Owner-signature convention matches AAStarAirAccountBase.sol `_validateECDSA`:
-   *   bytes32 hash = userOpHash.toEthSignedMessageHash();  // EIP-191 prefix
-   *   ecrecover(hash, v, r, s) == owner                    // `address public owner`
-   * which `ethers.verifyMessage(getBytes(userOpHash), sig)` reproduces exactly.
-   *
-   * Stage 1 handles the ECDSA-owner case only. A P256/passkey-only account
-   * (owner() == 0x0) FAILS CLOSED (see #40 for Stage 2 P256-owner support).
+   * By eth_calling the account's `isValidOwnerAuth` view, DVT delegates all signature
+   * verification logic to the contract (ECDSA owner, P256 device-passkey, or future
+   * auth schemes). DVT NEVER implements P256/WebAuthn locally, ensuring zero drift
+   * from the on-chain validation. The account is the single source of truth.
    *
    * Fails closed (403) on ANY failure: malformed userOp, getUserOpHash revert,
-   * owner read failure, owner == 0x0, malformed/missing ownerAuth, or recovered
-   * signer != owner. Never signs on failure.
+   * isValidOwnerAuth revert/timeout, eth_call failure, or magic value mismatch.
+   * Never signs on failure.
    *
    * @returns the derived userOpHash to BLS-sign.
    * @throws ForbiddenException on any authorization failure.
@@ -90,36 +87,21 @@ export class BlsService {
       throw new ForbiddenException("owner authorization required");
     }
 
-    let owner: string;
-    try {
-      owner = await this.blockchainService.getAccountOwner(account);
-    } catch {
-      throw new ForbiddenException("owner authorization required");
-    }
-
-    // Zero owner → P256/passkey-only account, no ECDSA owner to authorize against.
-    // TODO(#40): add P256-owner authorization for passkey-only accounts (Stage 2).
-    if (owner === ethers.ZeroAddress) {
-      throw new ForbiddenException(
-        "owner authorization required: account has no ECDSA owner (P256/passkey-only is not supported in Stage 1, see #40)"
-      );
-    }
-
-    let recovered: string;
+    // Validate ownerAuth via ERC-1271 style account view (eth_call isValidOwnerAuth).
+    // The account handles all signature verification logic (ECDSA, P256 passkey, etc.)
+    // and returns magic value 0x1626ba7e if valid. DVT never implements crypto locally.
+    let isValid: boolean;
     try {
       if (typeof ownerAuth !== "string" || ownerAuth.length === 0) {
         throw new Error("missing ownerAuth");
       }
-      // EIP-191 over the raw 32-byte derived userOpHash, matching the contract.
-      recovered = ethers.verifyMessage(ethers.getBytes(userOpHash), ownerAuth);
+      isValid = await this.blockchainService.isValidOwnerAuth(account, userOpHash, ownerAuth);
     } catch {
       throw new ForbiddenException("owner authorization required");
     }
 
-    if (ethers.getAddress(recovered) !== owner) {
-      this.logger.warn(
-        `Owner-auth rejected for account ${account}: recovered ${recovered}, expected owner ${owner}`
-      );
+    if (!isValid) {
+      this.logger.warn(`Owner-auth rejected for account ${account}: eth_call isValidOwnerAuth returned false`);
       throw new ForbiddenException("owner authorization required");
     }
 


### PR DESCRIPTION
## Summary

Implements the **ERC-1271 style view** architecture recommended by Codex for P256/device-passkey support:

- DVT **eth_calls** `account.isValidOwnerAuth(userOpHash, ownerAuth)` instead of local ECDSA/P256 verification
- Contract is the single source of truth — zero drift on signature logic
- Supports both ECDSA owner and P256 device-passkey authorization
- Fail-closed (403) on any eth_call failure, revert, or RPC error

## Changes

- `BlockchainService.isValidOwnerAuth()` — eth_call wrapper with ERC-1271 magic value validation
- `BlsService.authorizeAndDeriveHash()` — contract-based authorization (replaces local recovery)
- All unit tests updated to mock `isValidOwnerAuth` instead of `owner`/recovery logic
- `jest.config.js` — exclude `/dist/` from test runs (fixes .d.ts false positives)

## Test Plan

- ✅ All 12 BLS owner-auth tests pass (including CRITICAL cross-account oracle regression test)
- ✅ All 13 test suites pass (145 tests total)
- ✅ TypeScript type-check passes
- Tests cover: valid auth → sign, ECDSA mismatch → 403, eth_call failure → 403, malformed userOp → 403

## Relates

- #140 (DVT P256/device-passkey authorization)
- aastar-sdk#261 (SDK-side device assertion packaging)
- airaccount-contract#159 (contract `isValidOwnerAuth` view)

https://claude.ai/code/session_01JrdmiUk4A258FmhDSKn9aj