### PR TITLE
chore(format): prettier-fix 4 files merged unformatted (#141/#142)

### DIFF
--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -442,11 +442,7 @@ export class BlockchainService {
    * @param ownerAuth The owner authorization (ECDSA signature or WebAuthn blob)
    * @returns true if the account returns the magic value; false otherwise (fail-closed)
    */
-  async isValidOwnerAuth(
-    account: string,
-    userOpHash: string,
-    ownerAuth: string
-  ): Promise<boolean> {
+  async isValidOwnerAuth(account: string, userOpHash: string, ownerAuth: string): Promise<boolean> {
     if (!this.provider) {
       throw new Error("Blockchain provider not configured");
     }
@@ -463,9 +459,7 @@ export class BlockchainService {
       const result = await contract.isValidOwnerAuth(userOpHash, ownerAuth);
       return result === MAGIC_VALUE;
     } catch (error: any) {
-      this.logger.warn(
-        `isValidOwnerAuth eth_call failed for account ${account}: ${error.message}`
-      );
+      this.logger.warn(`isValidOwnerAuth eth_call failed for account ${account}: ${error.message}`);
       return false;
     }
   }

--- a/src/modules/bls/bls.service.spec.ts
+++ b/src/modules/bls/bls.service.spec.ts
@@ -77,7 +77,9 @@ describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
   let service: InstanceType<typeof BlsService>;
   let getAccountOwner: jest.Mock<(account: string) => Promise<string>>;
   let getUserOpHash: jest.Mock<(userOp: PackedUserOp) => Promise<string>>;
-  let isValidOwnerAuth: jest.Mock<(account: string, userOpHash: string, ownerAuth: string) => Promise<boolean>>;
+  let isValidOwnerAuth: jest.Mock<
+    (account: string, userOpHash: string, ownerAuth: string) => Promise<boolean>
+  >;
 
   // Sign a hash exactly the way the account owner signs the UserOperation:
   // EIP-191 prefix over the raw 32-byte hash.
@@ -88,7 +90,8 @@ describe("BlsService — owner-authorization gate (Fix 2 Stage 1)", () => {
   beforeEach(() => {
     getAccountOwner = jest.fn<(account: string) => Promise<string>>();
     getUserOpHash = jest.fn<(userOp: PackedUserOp) => Promise<string>>();
-    isValidOwnerAuth = jest.fn<(account: string, userOpHash: string, ownerAuth: string) => Promise<boolean>>();
+    isValidOwnerAuth =
+      jest.fn<(account: string, userOpHash: string, ownerAuth: string) => Promise<boolean>>();
     const blockchain = {
       getAccountOwner,
       getUserOpHash,

--- a/src/modules/bls/bls.service.ts
+++ b/src/modules/bls/bls.service.ts
@@ -101,7 +101,9 @@ export class BlsService {
     }
 
     if (!isValid) {
-      this.logger.warn(`Owner-auth rejected for account ${account}: eth_call isValidOwnerAuth returned false`);
+      this.logger.warn(
+        `Owner-auth rejected for account ${account}: eth_call isValidOwnerAuth returned false`
+      );
       throw new ForbiddenException("owner authorization required");
     }
 

--- a/src/modules/health/health.controller.ts
+++ b/src/modules/health/health.controller.ts
@@ -19,7 +19,9 @@ export class HealthController {
   constructor(@Optional() private readonly capabilities?: CapabilityRegistry) {}
 
   @Get()
-  @ApiOperation({ summary: "Service index — identity + version + enabled capabilities + endpoint map" })
+  @ApiOperation({
+    summary: "Service index — identity + version + enabled capabilities + endpoint map",
+  })
   root(): {
     service: string;
     status: string;
@@ -48,7 +50,11 @@ export class HealthController {
 
   @Get("health")
   @ApiOperation({ summary: "Liveness check + enabled capabilities" })
-  health(): { status: string; version: string; capabilities: Array<{ name: string; enabled: boolean }> } {
+  health(): {
+    status: string;
+    version: string;
+    capabilities: Array<{ name: string; enabled: boolean }>;
+  } {
     return { status: "ok", version: APP_VERSION, capabilities: this.capList() };
   }
 


### PR DESCRIPTION
Full test sweep surfaced 4 src files on master with prettier violations — merged unformatted via CLI in #141 (eth_call isValidOwnerAuth) and #142 (version endpoint).

**Formatting only, zero logic change.**

Files:
- src/modules/blockchain/blockchain.service.ts
- src/modules/bls/bls.service.ts
- src/modules/bls/bls.service.spec.ts
- src/modules/health/health.controller.ts

Verified: type-check clean, 145 tests pass, forge 59/59, conformance byte-exact, prettier --check src/ clean.