### PR TITLE
feat(#100): Docker self-heal — healthcheck + autoheal + mainnet compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,12 @@ EXPOSE 3000
 # Set NODE_ENV to production
 ENV NODE_ENV=production
 
+# Liveness probe: hit /health on the node's own PORT (default 3000). Uses Node's
+# built-in global fetch (Node 20) so no curl/wget dependency is needed on Alpine.
+# Marks the container unhealthy on crash-hang (process alive but not serving) — the
+# autoheal sidecar (docker-compose) then restarts it. Exit 0 = healthy, 1 = unhealthy.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||3000)+'/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
 # Run the application
 CMD ["node", "dist/main.js"]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -110,6 +110,34 @@ docker compose -f docker-compose.testnet.yml --env-file deploy/.env.testnet up -
 docker compose -f docker-compose.testnet.yml ps     # all healthy
 ```
 
+Self-heal is built in (issue #100):
+
+- **`restart: unless-stopped`** — recovers from crash / OOM / non-zero exit and
+  auto-starts on host reboot.
+- **`healthcheck` + `autoheal` sidecar** — recovers from a _hung-but-alive_
+  process (port still bound but `/health` stopped answering — which `restart:`
+  alone does NOT catch). Each node's healthcheck probes `/health`; the
+  `willfarrell/autoheal` container watches for `unhealthy` status (label
+  `autoheal=true`) and restarts it.
+
+```bash
+docker compose -f docker-compose.testnet.yml ps          # STATUS shows (healthy)
+docker inspect --format '{{.State.Health.Status}}' dvt-node-1   # healthy | unhealthy
+docker logs dvt-autoheal                                  # restart events
+```
+
+For **mainnet**, use `docker-compose.mainnet.yml` (single-host DVT + Keeper +
+Relay three-in-one, same self-heal).
+
+> **HA (整机宕机) — 单机自愈的边界.** The self-heal above covers _process_
+> failure on one host; it does NOT cover the whole host dying (still a single
+> point). Relay/Keeper are stateless → scale to ≥2 hosts freely (SDK supports
+> multi-URL failover). DVT co-signing HA is achieved by running a **second
+> operator with its OWN pre-registered BLS key** and an N-of-M threshold — NOT
+> by cloning the key (which is unsafe and unnecessary). BLS keys stay encrypted
+> at rest on each host (EIP-2335, planned #50④), never in a shared KMS. See
+> issue #100 / #50.
+
 **Option B — local-process manager script (no Docker):** runs the 3 nodes on
 4001/2/3 + the cloudflared named tunnel as plain processes. Full lifecycle:
 
@@ -192,19 +220,19 @@ override `RELAY_*` for a different deployment. See
 
 共 2 个进程，6 个逻辑服务：
 
-| 服务 | 端口 | 说明 |
-|------|------|------|
-| DVT node 1 | 4001 | BLS 联合签名节点 |
-| DVT node 2 | 4002 | BLS 联合签名节点 |
-| DVT node 3 | 4003 | BLS 联合签名节点 |
-| cloudflared | — | 将三节点暴露为 dvt1/2/3.aastar.io |
-| relay（内置） | 同节点端口 | Gasless 代币购买中继，`POST /v3/relay` |
-| keeper（内置） | 同节点端口 | 节点签名策略 / 心跳 |
-| x402-facilitator（内置） | 同节点端口 | x402 支付撮合 |
-| **price-keeper** | — | 独立进程，每 3 分钟刷新 SuperPaymaster 价格预言机 |
+| 服务                     | 端口       | 说明                                              |
+| ------------------------ | ---------- | ------------------------------------------------- |
+| DVT node 1               | 4001       | BLS 联合签名节点                                  |
+| DVT node 2               | 4002       | BLS 联合签名节点                                  |
+| DVT node 3               | 4003       | BLS 联合签名节点                                  |
+| cloudflared              | —          | 将三节点暴露为 dvt1/2/3.aastar.io                 |
+| relay（内置）            | 同节点端口 | Gasless 代币购买中继，`POST /v3/relay`            |
+| keeper（内置）           | 同节点端口 | 节点签名策略 / 心跳                               |
+| x402-facilitator（内置） | 同节点端口 | x402 支付撮合                                     |
+| **price-keeper**         | —          | 独立进程，每 3 分钟刷新 SuperPaymaster 价格预言机 |
 
-> relay / keeper / x402-facilitator 是 DVT 节点的内置模块，随节点启停，不需要单独管理。
-> price-keeper 是独立进程，由 LaunchAgent 托管。
+> relay / keeper /
+> x402-facilitator 是 DVT 节点的内置模块，随节点启停，不需要单独管理。price-keeper 是独立进程，由 LaunchAgent 托管。
 
 ---
 
@@ -216,6 +244,7 @@ cd ~/Dev/aastar/YetAnotherAA-Validator
 ```
 
 输出示例：
+
 ```
 local nodes:
   node1 :4001  ✅ UP
@@ -296,12 +325,13 @@ tail -f ~/Dev/aastar/aastar-sdk/keeper.log
 
 ### 开机自启（macOS LaunchAgent）
 
-两个 plist 已配置在 `~/Library/LaunchAgents/`，Mac 登录后自动启动，无需手动操作：
+两个 plist 已配置在
+`~/Library/LaunchAgents/`，Mac 登录后自动启动，无需手动操作：
 
-| plist 文件 | 管理的服务 | 崩溃自动重启 |
-|-----------|----------|------------|
-| `io.aastar.dvt-testnet.plist` | DVT 三节点 + cloudflared | 否（脚本后台化后退出属正常） |
-| `io.aastar.price-keeper.plist` | price-keeper | 是 |
+| plist 文件                     | 管理的服务               | 崩溃自动重启                 |
+| ------------------------------ | ------------------------ | ---------------------------- |
+| `io.aastar.dvt-testnet.plist`  | DVT 三节点 + cloudflared | 否（脚本后台化后退出属正常） |
+| `io.aastar.price-keeper.plist` | price-keeper             | 是                           |
 
 手动加载 / 卸载（通常不需要）：
 
@@ -327,11 +357,12 @@ launchctl list io.aastar.price-keeper
 
 ### ⚠️ price-keeper 为什么不能停
 
-price-keeper 每 3 分钟调用一次 `SuperPaymaster.updatePrice()`。
-一旦停止 → aPNTs 价格过期 → `getRealtimeTokenCost` revert → 用户看到
+price-keeper 每 3 分钟调用一次 `SuperPaymaster.updatePrice()`。一旦停止 →
+aPNTs 价格过期 → `getRealtimeTokenCost` revert → 用户看到
 `InsufficientBalance`（哪怕账户有 1000 万 aPNTs 也没用）。
 
-签名账户：anni EOA `0xEcAACb915f7D92e9916f449F7ad42BD0408733c9`（持有 `PRICE_UPDATER_ROLE`）。
+签名账户：anni EOA `0xEcAACb915f7D92e9916f449F7ad42BD0408733c9`（持有
+`PRICE_UPDATER_ROLE`）。
 
 ---
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -106,6 +106,10 @@ approval):**
 **Option A — Docker (recommended for always-on hosts, e.g. Mac mini):**
 
 ```bash
+# PREFLIGHT: every node key must exist first — a missing bind-mount source makes
+# Docker silently create an empty DIRECTORY over /app/node_state.json (confusing break).
+for i in 1 2 3; do test -f deploy/node$i/node_state.json || { echo "missing node$i key"; exit 1; }; done
+
 docker compose -f docker-compose.testnet.yml --env-file deploy/.env.testnet up -d --build
 docker compose -f docker-compose.testnet.yml ps     # all healthy
 ```

--- a/docker-compose.mainnet.yml
+++ b/docker-compose.mainnet.yml
@@ -15,6 +15,10 @@
 #   - restart: unless-stopped        → crash / OOM / host-reboot recovery
 #   - healthcheck + autoheal sidecar → HUNG-but-alive recovery (serving stopped)
 name: dvt-mainnet
+# ⚠️ PREFLIGHT: deploy/node1/node_state.json MUST exist before `up`. A missing
+# bind-mount source makes Docker silently create an EMPTY DIRECTORY there, which
+# mounts over /app/node_state.json and breaks the node confusingly. Guard with:
+#   test -f deploy/node1/node_state.json || { echo "missing node1 key"; exit 1; }
 
 services:
   dvt-node-1:
@@ -65,7 +69,11 @@ services:
     restart: unless-stopped
     command: tunnel --no-autoupdate run --token ${CLOUDFLARE_TUNNEL_TOKEN:?set CLOUDFLARE_TUNNEL_TOKEN in deploy/.env.mainnet}
     networks: [dvt]
-    depends_on: [dvt-node-1]
+    # Wait until the node is actually SERVING (healthy), not merely started — else the
+    # tunnel routes to a node that isn't answering yet (502s on boot).
+    depends_on:
+      dvt-node-1:
+        condition: service_healthy
 
   # Restarts any container labelled autoheal=true that Docker marks UNHEALTHY.
   autoheal:

--- a/docker-compose.mainnet.yml
+++ b/docker-compose.mainnet.yml
@@ -1,0 +1,86 @@
+# Mainnet DVT — single-host, self-healing (issue #100).
+#
+# One operator = one host running the "three-in-one": DVT co-signing + Keeper
+# (price keep-alive) + Relay (gasless). Multiple operators each run this → N-of-M.
+# High availability across operators comes from running independent hosts (see the
+# HA discussion / Plan B: a second operator with its OWN pre-registered BLS key),
+# NOT from cloning one key. This file gives per-host self-heal only.
+#
+#   1. cp deploy/.env.mainnet.example deploy/.env.mainnet  &&  fill it in
+#   2. put this host's node_state.json (its OWN secret BLS key) in deploy/node1/
+#   3. docker compose -f docker-compose.mainnet.yml --env-file deploy/.env.mainnet up -d --build
+#   4. register this node's BLS pubkey on the mainnet validator (see deploy/README.md)
+#
+# Self-heal:
+#   - restart: unless-stopped        → crash / OOM / host-reboot recovery
+#   - healthcheck + autoheal sidecar → HUNG-but-alive recovery (serving stopped)
+name: dvt-mainnet
+
+services:
+  dvt-node-1:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: aastar-dvt:latest
+    container_name: dvt-mainnet-node-1
+    restart: unless-stopped
+    environment:
+      ETH_RPC_URL: ${ETH_RPC_URL:?set ETH_RPC_URL in deploy/.env.mainnet}
+      VALIDATOR_CONTRACT_ADDRESS: ${VALIDATOR_CONTRACT_ADDRESS:?set VALIDATOR_CONTRACT_ADDRESS (mainnet)}
+      ENTRY_POINT_ADDRESS: ${ENTRY_POINT_ADDRESS:-0x0000000071727De22E5E9d8BAf0edAc6f37da032}
+      PORT: 3001
+      PUBLIC_URL: ${NODE1_PUBLIC_URL:-}
+      # Owner-authorization gate is always on (eth_call isValidOwnerAuth).
+      POLICY_ENABLED: ${POLICY_ENABLED:-false}
+      POLICY_REGISTRY_ADDRESS: ${POLICY_REGISTRY_ADDRESS:-}
+      # Relay (gasless) — needs a funded mainnet operator key (KEEP SEPARATE from BLS key).
+      RELAY_ENABLED: ${RELAY_ENABLED:-false}
+      RELAY_OPERATOR_PK: ${RELAY_OPERATOR_PK:-}
+      # Keeper (price keep-alive) — needs a funded mainnet key (SEPARATE again).
+      KEEPER_ENABLED: ${KEEPER_ENABLED:-false}
+      KEEPER_PRIVATE_KEY: ${KEEPER_PRIVATE_KEY:-}
+      KEEPER_PAYMASTER_ADDRESS: ${KEEPER_PAYMASTER_ADDRESS:-}
+    volumes:
+      - ./deploy/node1/node_state.json:/app/node_state.json:ro
+    ports: ["127.0.0.1:3001:3001"] # localhost-only; public access via the tunnel
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:'+process.env.PORT+'/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 30s
+      timeout: 5s
+      start_period: 20s
+      retries: 3
+    labels:
+      autoheal: "true"
+    networks: [dvt]
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: dvt-mainnet-cloudflared
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run --token ${CLOUDFLARE_TUNNEL_TOKEN:?set CLOUDFLARE_TUNNEL_TOKEN in deploy/.env.mainnet}
+    networks: [dvt]
+    depends_on: [dvt-node-1]
+
+  # Restarts any container labelled autoheal=true that Docker marks UNHEALTHY.
+  autoheal:
+    image: willfarrell/autoheal:latest
+    container_name: dvt-mainnet-autoheal
+    restart: unless-stopped
+    environment:
+      AUTOHEAL_CONTAINER_LABEL: autoheal
+      AUTOHEAL_INTERVAL: 10
+      AUTOHEAL_START_PERIOD: 30
+      CURL_TIMEOUT: 30
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks: [dvt]
+
+networks:
+  dvt:
+    driver: bridge

--- a/docker-compose.testnet.yml
+++ b/docker-compose.testnet.yml
@@ -22,8 +22,28 @@ x-dvt-node: &dvt-node
     context: .
     dockerfile: Dockerfile
   image: aastar-dvt:latest
+  # Self-heal layer 1: restart on crash / OOM / non-zero exit + on host reboot.
   restart: unless-stopped
   networks: [dvt]
+  # Self-heal layer 2: detect a HUNG-but-alive process (serving stopped, port still
+  # bound → restart:unless-stopped alone would NOT catch it). The autoheal sidecar
+  # watches this status and restarts the container when it goes unhealthy.
+  # Uses the Dockerfile HEALTHCHECK ($PORT-aware); overridden here for visibility.
+  healthcheck:
+    test:
+      [
+        "CMD",
+        "node",
+        "-e",
+        "fetch('http://127.0.0.1:'+process.env.PORT+'/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+      ]
+    interval: 30s
+    timeout: 5s
+    start_period: 20s
+    retries: 3
+  # Opt the container into autoheal (only containers with this label are watched).
+  labels:
+    autoheal: "true"
 
 services:
   dvt-node-1:
@@ -68,6 +88,23 @@ services:
     command: tunnel --no-autoupdate run --token ${CLOUDFLARE_TUNNEL_TOKEN:?set CLOUDFLARE_TUNNEL_TOKEN in deploy/.env.testnet}
     networks: [dvt]
     depends_on: [dvt-node-1, dvt-node-2, dvt-node-3]
+
+  # Self-heal layer 2 (executor): restarts any container marked `autoheal=true` that
+  # Docker reports UNHEALTHY. This is what turns a failing healthcheck into an actual
+  # restart — `restart: unless-stopped` only reacts to exit, not to "unhealthy".
+  # Mounts the Docker socket read-only-ish (needs write to restart); scoped by label.
+  autoheal:
+    image: willfarrell/autoheal:latest
+    container_name: dvt-autoheal
+    restart: unless-stopped
+    environment:
+      AUTOHEAL_CONTAINER_LABEL: autoheal # only watch containers with label autoheal=true
+      AUTOHEAL_INTERVAL: 10 # check every 10s
+      AUTOHEAL_START_PERIOD: 30 # grace before first check
+      CURL_TIMEOUT: 30
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks: [dvt]
 
 networks:
   dvt:

--- a/docker-compose.testnet.yml
+++ b/docker-compose.testnet.yml
@@ -9,6 +9,10 @@
 # The cloudflared sidecar exposes the 3 nodes at stable public hostnames you configure
 # in the Cloudflare dashboard (Public Hostnames → http://dvt-node-N:300N). See deploy/README.md.
 name: dvt-testnet
+# ⚠️ PREFLIGHT: each deploy/node{1,2,3}/node_state.json MUST exist before `up`.
+# A missing bind-mount source makes Docker silently create an EMPTY DIRECTORY there,
+# which mounts over /app/node_state.json and breaks the node confusingly. Guard with:
+#   for i in 1 2 3; do test -f deploy/node$i/node_state.json || { echo "missing node$i key"; exit 1; }; done
 
 x-dvt-env: &dvt-env
   ETH_RPC_URL: ${ETH_RPC_URL:?set ETH_RPC_URL in deploy/.env.testnet}
@@ -87,7 +91,15 @@ services:
     restart: unless-stopped
     command: tunnel --no-autoupdate run --token ${CLOUDFLARE_TUNNEL_TOKEN:?set CLOUDFLARE_TUNNEL_TOKEN in deploy/.env.testnet}
     networks: [dvt]
-    depends_on: [dvt-node-1, dvt-node-2, dvt-node-3]
+    # Wait until each node is actually SERVING (healthy), not merely started — else
+    # the tunnel comes up and routes to nodes that aren't answering yet (502s on boot).
+    depends_on:
+      dvt-node-1:
+        condition: service_healthy
+      dvt-node-2:
+        condition: service_healthy
+      dvt-node-3:
+        condition: service_healthy
 
   # Self-heal layer 2 (executor): restarts any container marked `autoheal=true` that
   # Docker reports UNHEALTHY. This is what turns a failing healthcheck into an actual


### PR DESCRIPTION
GA hardening checklist item #1 (issue #100 ①). Zero change to node_state.json or the signing path — running nodes untouched.

## Two-layer per-host self-heal
| Failure mode | Covered by |
|---|---|
| crash / OOM / non-zero exit / host reboot | `restart: unless-stopped` (already there) |
| **hung-but-alive** (port bound, /health dead) | **NEW: HEALTHCHECK + autoheal sidecar** |

`restart: unless-stopped` alone does NOT restart a container that Docker marks *unhealthy* — that needs an executor. `willfarrell/autoheal` watches `autoheal=true` containers and restarts them on unhealthy.

## Changes
- **Dockerfile**: `HEALTHCHECK` probing `/health` via Node global fetch (no curl/wget dep on Alpine); PORT-aware.
- **docker-compose.testnet.yml**: per-node healthcheck + `autoheal=true` label + autoheal sidecar.
- **docker-compose.mainnet.yml**: NEW — single-host DVT+Keeper+Relay three-in-one, same self-heal, mainnet env defaults.
- **deploy/README.md**: self-heal usage + HA boundary note (whole-host failure → 2nd operator w/ own pre-registered BLS key + N-of-M, not key cloning; keys stay EIP-2335 encrypted at rest, no shared KMS).

## Verified
- both compose files pass `docker compose config`
- healthcheck one-liner: exit 0 on live `/health` (4001), exit 1 on dead port
- prettier clean on changed files

## Not in scope (later checklist items)
#2 monitoring/alerting, #3 relay eth_call pre-check, #4 ≥2-host N-of-M, #5 EIP-2335 keystore, #6 audit.