### PR TITLE
feat(#100): i.MX93 GA path — arm64 bundle + systemd self-heal (no Docker/firmware)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ deploy/node*/.env
 
 # test coverage report
 coverage/
+dist-bundle/

--- a/deploy/imx93/README.md
+++ b/deploy/imx93/README.md
@@ -1,0 +1,109 @@
+# Run a DVT node on i.MX93 (Yocto, systemd) — no Docker, no firmware change
+
+The GA deployment path for a **resource-constrained arm64 board** (NXP i.MX93, 2
+GB, Yocto BSP). It avoids Docker/Podman entirely — on Yocto those need the
+`meta-virtualization` layer and a **firmware rebuild + reflash**, which is not
+worth it for a single signer. Instead we ship a **self-contained bundle** (its
+own glibc `linux-arm64` Node runtime + compiled app + prod deps) and run it
+under **systemd** — which every NXP i.MX Yocto image already has as init.
+
+> For always-on **non-embedded** hosts (Mac mini, x86 VPS), use the Docker path
+> instead — see [`../README.md`](../README.md) and `docker-compose.mainnet.yml`.
+
+## Why this shape (i.MX93 / Yocto)
+
+| Concern                                     | How it's handled                                                             |
+| ------------------------------------------- | ---------------------------------------------------------------------------- |
+| No Node.js in the Yocto image               | Bundle ships its **own** `linux-arm64` glibc Node binary                     |
+| No Docker/Podman without a firmware rebuild | Pure systemd — already present                                               |
+| App updates without reflashing              | Swap the bundle + `systemctl restart` (firmware untouched)                   |
+| Flash wear (eMMC)                           | Near-stateless app; only writes are logs → journald (volatile-capable)       |
+| 2 GB RAM                                    | `MemoryMax=512M` per node; run **one** node per board (N-of-M = more boards) |
+| Self-heal                                   | `Restart=always` (crash) **+** a health-probe timer (hung-but-alive)         |
+
+The build never happens on the board — you cross-package on your Mac/CI and the
+board only unpacks. All production deps are pure-JS (noble/ethers/nestjs), so
+the `node_modules` tree is cross-arch safe.
+
+## 1. Build the bundle (on your Mac / CI)
+
+```bash
+./deploy/imx93/build-bundle.sh
+# → dist-bundle/aastar-dvt-<version>-linux-arm64.tar.gz  (~80 MB: Node runtime + app + deps)
+```
+
+Resolves the latest LTS `node-v20.x-linux-arm64` (glibc — matches Yocto),
+compiles the app, installs prod-only deps resolved for `linux/arm64`, and tars
+it all up.
+
+## 2. Copy to the board
+
+```bash
+scp dist-bundle/aastar-dvt-*-linux-arm64.tar.gz  root@<board-ip>:/tmp/
+scp -r deploy/imx93  root@<board-ip>:/tmp/imx93     # the install script + units
+```
+
+## 3. Install (on the board)
+
+```bash
+cd /tmp/imx93
+./install.sh /tmp/aastar-dvt-*-linux-arm64.tar.gz node1
+```
+
+This unpacks to `/opt/aastar-dvt/`, symlinks `current`, installs the systemd
+units, and enables the node + its health timer. Then:
+
+1. **Put the node's BLS key**: `/opt/aastar-dvt/state/node1/node_state.json`
+   (its OWN secret key — `chmod 600`; never share/clone it).
+2. **Fill the env**: `/opt/aastar-dvt/env/node1.env` (PORT, ETH_RPC_URL,
+   VALIDATOR_CONTRACT_ADDRESS; relay/keeper keys if used).
+3. Restart: `systemctl restart aastar-dvt@node1`.
+
+## 4. Verify
+
+```bash
+systemctl status aastar-dvt@node1
+curl -s http://127.0.0.1:4001/health | jq .version      # matches the bundle
+systemctl list-timers 'aastar-dvt-health@*'             # probe scheduled
+journalctl -u aastar-dvt@node1 -f
+```
+
+## Self-heal, exercised
+
+```bash
+# crash recovery (Restart=always):
+systemctl kill -s SIGKILL aastar-dvt@node1 ; sleep 5 ; systemctl is-active aastar-dvt@node1  # → active
+
+# hung-but-alive recovery (health timer restarts it):
+#   the aastar-dvt-health@node1.timer curls /health every 30s and restarts the
+#   node if it stops answering. Watch it act:
+journalctl -u 'aastar-dvt-health@node1' -f
+```
+
+## Upgrade / rollback
+
+```bash
+# upgrade: build a new bundle, copy, re-run install.sh — it atomically repoints `current`.
+./install.sh /tmp/aastar-dvt-<new>-linux-arm64.tar.gz node1
+
+# rollback: point current back at a prior release and restart.
+ln -sfn /opt/aastar-dvt/releases/<old-version> /opt/aastar-dvt/current
+systemctl restart aastar-dvt@node1
+```
+
+## HA (whole-board failure)
+
+Per-board self-heal does NOT cover the board dying. DVT co-signing HA = a
+**second board with its OWN pre-registered BLS key** + N-of-M — never key
+cloning. Relay/ Keeper are stateless → run ≥2 boards; the SDK fails over across
+node URLs. BLS keys stay on their own board (later: EIP-2335 encrypted at rest,
+#50④), never in a shared KMS. See issues #100 / #50.
+
+## Notes
+
+- **Read-only rootfs?** If your hardened Yocto image mounts `/` read-only, point
+  `ROOT` in `install.sh` at a writable data partition and place the unit files
+  via a systemd drop-in on a writable path.
+- **Init system**: assumes systemd (NXP i.MX Yocto default). If your image was
+  built with sysvinit/busybox, use an init script + cron probe instead (same two
+  layers).

--- a/deploy/imx93/aastar-dvt-health@.service
+++ b/deploy/imx93/aastar-dvt-health@.service
@@ -1,0 +1,13 @@
+# Self-heal layer 2 (the "autoheal" equivalent): probe the node's /health and
+# restart it if it's UP-but-not-serving (hung process — Restart=always alone can't
+# catch that). Driven by aastar-dvt-health@.timer. Instance = node id (aastar-dvt@%i).
+[Unit]
+Description=Health probe + restart for aastar-dvt@%i
+After=aastar-dvt@%i.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=/opt/aastar-dvt/env/%i.env
+# curl the node's own /health; on failure (non-2xx / refused / timeout) restart it.
+# --max-time guards against the probe itself hanging on a stuck socket.
+ExecStart=/bin/sh -c 'curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/health" >/dev/null || { echo "aastar-dvt@%i unhealthy — restarting"; systemctl restart aastar-dvt@%i.service; }'

--- a/deploy/imx93/aastar-dvt-health@.timer
+++ b/deploy/imx93/aastar-dvt-health@.timer
@@ -1,0 +1,14 @@
+# Fires the health probe every 30s (mirrors the Docker healthcheck cadence).
+# Enable per node:  systemctl enable --now aastar-dvt-health@node1.timer
+[Unit]
+Description=Periodic health probe for aastar-dvt@%i
+
+[Timer]
+# First check 30s after boot, then every 30s. Persistent=false — no catch-up bursts.
+OnBootSec=30s
+OnUnitActiveSec=30s
+AccuracySec=5s
+Unit=aastar-dvt-health@%i.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/imx93/aastar-dvt@.service
+++ b/deploy/imx93/aastar-dvt@.service
@@ -1,0 +1,44 @@
+# systemd template unit for an AAStar DVT node on i.MX93 (Yocto, glibc).
+# Instance name = node id, e.g. `aastar-dvt@node1`. Enable/start:
+#   systemctl enable --now aastar-dvt@node1
+#
+# Self-heal layer 1: Restart=always → recover from crash / OOM / non-zero exit,
+# and (via `enable`) auto-start on boot. The hung-but-alive case is handled by the
+# companion aastar-dvt-health@.timer (probes /health, restarts on failure).
+[Unit]
+Description=AAStar DVT signer node (%i)
+Documentation=https://github.com/AAStarCommunity/YetAnotherAA-Validator
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Per-node config: PORT, ETH_RPC_URL, VALIDATOR_CONTRACT_ADDRESS, relay/keeper keys…
+EnvironmentFile=/opt/aastar-dvt/env/%i.env
+# The BLS private key for THIS node (its own node_state.json). cwd = state dir so the
+# app finds ./node_state.json exactly like the dev/script deployments.
+WorkingDirectory=/opt/aastar-dvt/state/%i
+ExecStart=/opt/aastar-dvt/current/node /opt/aastar-dvt/current/dist/main.js
+
+Restart=always
+RestartSec=3
+# Don't let a crash-loop hammer the flash/CPU: cap restarts, back off if it storms.
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+# --- hardening (defence in depth for a key-holding process) ---
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+# Only the state dir is writable; everything else read-only.
+ReadWritePaths=/opt/aastar-dvt/state/%i
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+# Resource guard rails for a 2GB board (tune per node count).
+MemoryMax=512M
+MemoryHigh=384M
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/imx93/build-bundle.sh
+++ b/deploy/imx93/build-bundle.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Build a self-contained arm64 DVT bundle for i.MX93 (Yocto, systemd, glibc).
+#
+# Runs on your dev Mac / CI — NOT on the board. Produces a tarball containing
+# everything the board needs to run the DVT with ZERO firmware changes:
+#   - a glibc linux-arm64 Node runtime  (board's Yocto image has no Node)
+#   - dist/            (compiled app)
+#   - node_modules/    (production deps only — all pure-JS, cross-arch safe)
+#   - package.json
+#
+# The board never compiles anything: it just unpacks + `systemctl start`.
+#
+#   ./deploy/imx93/build-bundle.sh                 # → dist-bundle/aastar-dvt-<ver>-linux-arm64.tar.gz
+#   NODE_MAJOR=20 OUT=/tmp ./deploy/imx93/build-bundle.sh
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO"
+
+NODE_MAJOR="${NODE_MAJOR:-20}" # match the repo's Node line (Dockerfile: node:20)
+OUT="${OUT:-$REPO/dist-bundle}"
+VERSION="$(node -p "require('./package.json').version")"
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+echo "▶ building DVT bundle v$VERSION for linux-arm64 (Node $NODE_MAJOR)"
+
+# 1. Compile the app.
+echo "  • nest build"
+npm run build >/dev/null
+
+# 2. Production node_modules for the TARGET platform. --os/--cpu make npm resolve
+#    optional deps for linux-arm64 (not the host Mac), so no darwin junk sneaks in.
+#    All our prod deps are pure-JS (noble/ethers/nestjs), so this tree runs as-is.
+echo "  • npm ci --omit=dev (linux/arm64 resolution)"
+cp package.json package-lock.json "$STAGE/"
+( cd "$STAGE" && npm ci --omit=dev --os=linux --cpu=arm64 --ignore-scripts >/dev/null )
+
+# 3. Fetch the glibc linux-arm64 Node runtime (NXP Yocto is glibc → official build works).
+#    latest-vNN.x always points at the newest LTS patch, so we never pin a dead URL.
+BASE="https://nodejs.org/dist/latest-v${NODE_MAJOR}.x"
+TARBALL="$(curl -fsSL "$BASE/" | grep -oE "node-v${NODE_MAJOR}\.[0-9]+\.[0-9]+-linux-arm64\.tar\.xz" | head -1)"
+[ -n "$TARBALL" ] || { echo "‼ could not resolve Node linux-arm64 tarball from $BASE"; exit 1; }
+echo "  • fetching $TARBALL"
+curl -fsSL "$BASE/$TARBALL" -o "$STAGE/node.tar.xz"
+tar -xJf "$STAGE/node.tar.xz" -C "$STAGE"
+NODE_BIN="$STAGE/${TARBALL%.tar.xz}/bin/node"
+[ -x "$NODE_BIN" ] || { echo "‼ node binary not found after extract"; exit 1; }
+
+# 4. Assemble the bundle.
+BUNDLE="$STAGE/bundle"
+mkdir -p "$BUNDLE"
+cp "$NODE_BIN" "$BUNDLE/node"
+cp -R dist "$BUNDLE/dist"
+cp -R "$STAGE/node_modules" "$BUNDLE/node_modules"
+cp package.json "$BUNDLE/package.json"
+printf '%s\n' "$VERSION" >"$BUNDLE/VERSION"
+
+# 5. Tar it up.
+mkdir -p "$OUT"
+ARCHIVE="$OUT/aastar-dvt-${VERSION}-linux-arm64.tar.gz"
+tar -czf "$ARCHIVE" -C "$BUNDLE" .
+SIZE="$(du -h "$ARCHIVE" | cut -f1)"
+
+# Node version comes from the tarball name — we CAN'T exec the linux-arm64 binary
+# on the (macOS/x86) build host to ask it.
+NODE_VER="${TARBALL#node-}"; NODE_VER="${NODE_VER%%-linux-arm64*}"
+echo "✅ $ARCHIVE ($SIZE)"
+echo "   node: $NODE_VER (linux-arm64/glibc)  |  app: v$VERSION"
+echo "   copy to the board, then run deploy/imx93/install.sh there."

--- a/deploy/imx93/install.sh
+++ b/deploy/imx93/install.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Install / upgrade an AAStar DVT node on the i.MX93 board (Yocto, systemd).
+# Runs ON THE BOARD. No compiler, no Docker, no firmware change — just unpack a
+# self-contained bundle (built on your Mac via build-bundle.sh) and wire up systemd.
+#
+#   ./install.sh aastar-dvt-1.7.1-linux-arm64.tar.gz [node1]
+#
+# Layout it creates under /opt/aastar-dvt:
+#   releases/<ver>/   unpacked bundles (node + dist + node_modules)
+#   current ->        symlink to the active release (atomic upgrade / rollback)
+#   env/<node>.env    per-node config (PORT, RPC, contract, relay/keeper keys)
+#   state/<node>/     per-node node_state.json (its OWN secret BLS key)
+set -euo pipefail
+
+TARBALL="${1:?usage: install.sh <bundle.tar.gz> [node-id]}"
+NODE_ID="${2:-node1}"
+ROOT="/opt/aastar-dvt"
+UNIT_DIR="/etc/systemd/system"
+
+[ -f "$TARBALL" ] || { echo "‼ bundle not found: $TARBALL"; exit 1; }
+
+# Preflight: rootfs must be writable here. Some hardened Yocto images ship a
+# read-only rootfs — then point ROOT at a writable data partition and bind the units.
+for d in "$ROOT" "$UNIT_DIR"; do
+  mkdir -p "$d" 2>/dev/null || { echo "‼ $d not writable — read-only rootfs? use a writable partition"; exit 1; }
+done
+
+SELF="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+mkdir -p "$ROOT/releases" "$ROOT/env" "$ROOT/state/$NODE_ID"
+
+# 1. Unpack the bundle into releases/<VERSION>.
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+tar -xzf "$TARBALL" -C "$TMP"
+VER="$(cat "$TMP/VERSION")"
+REL="$ROOT/releases/$VER"
+rm -rf "$REL"; mkdir -p "$REL"
+cp -R "$TMP"/. "$REL/"
+chmod +x "$REL/node"
+echo "• unpacked v$VER → $REL"
+
+# 2. Atomic switch: current -> this release (rollback = repoint + restart).
+ln -sfn "$REL" "$ROOT/current"
+echo "• current → v$VER"
+
+# 3. Seed per-node env + state if absent (never overwrite existing secrets/config).
+ENVF="$ROOT/env/$NODE_ID.env"
+if [ ! -f "$ENVF" ]; then
+  cat >"$ENVF" <<EOF
+# AAStar DVT — $NODE_ID (fill these in)
+PORT=4001
+ETH_RPC_URL=
+VALIDATOR_CONTRACT_ADDRESS=
+ENTRY_POINT_ADDRESS=0x0000000071727De22E5E9d8BAf0edAc6f37da032
+# Optional capabilities (need their OWN funded keys — keep separate from the BLS key):
+# RELAY_ENABLED=false
+# RELAY_OPERATOR_PK=
+# KEEPER_ENABLED=false
+# KEEPER_PRIVATE_KEY=
+EOF
+  chmod 600 "$ENVF"
+  echo "• wrote env template → $ENVF  (EDIT IT before starting)"
+fi
+if [ ! -f "$ROOT/state/$NODE_ID/node_state.json" ]; then
+  echo "⚠ missing $ROOT/state/$NODE_ID/node_state.json — put this node's OWN BLS key there (chmod 600)"
+fi
+
+# 4. Install systemd units (idempotent).
+cp "$SELF/aastar-dvt@.service" "$SELF/aastar-dvt-health@.service" "$SELF/aastar-dvt-health@.timer" "$UNIT_DIR/"
+chmod 600 "$ENVF" 2>/dev/null || true
+systemctl daemon-reload
+echo "• installed systemd units"
+
+# 5. Enable + (re)start this node and its health probe.
+systemctl enable "aastar-dvt@$NODE_ID.service" "aastar-dvt-health@$NODE_ID.timer" >/dev/null 2>&1 || true
+systemctl restart "aastar-dvt@$NODE_ID.service"
+systemctl restart "aastar-dvt-health@$NODE_ID.timer"
+
+echo ""
+echo "✅ v$VER active for $NODE_ID"
+echo "   systemctl status aastar-dvt@$NODE_ID"
+echo "   journalctl -u aastar-dvt@$NODE_ID -f"
+PORT_VAL="$(grep -E '^PORT=' "$ENVF" | cut -d= -f2)"
+echo "   curl -s http://127.0.0.1:${PORT_VAL:-4001}/health   # {version:\"$VER\",...}"


### PR DESCRIPTION
## Why
The i.MX93 board runs **Yocto (NXP BSP, systemd, glibc, 2GB)**. Docker/Podman on Yocto need the `meta-virtualization` layer → a **firmware rebuild + reflash** — not worth it for one signer, and it fights Yocto's locked-image model. Verified fact: NXP i.MX Yocto BSP defaults to **systemd** as init ([source](https://community.nxp.com/t5/i-MX-Processors/How-to-automatically-start-services-with-systemd-in-Yocto/m-p/746499)).

So the i.MX93 GA path ships a **self-contained bundle** (own glibc linux-arm64 Node + app + prod deps) run under **systemd** — zero firmware change, app updates without reflashing.

## Deliverables (`deploy/imx93/`)
| File | Role |
|---|---|
| `build-bundle.sh` | Mac/CI: cross-packages Node+dist+deps → tarball. **Board never compiles.** |
| `aastar-dvt@.service` | node unit, `Restart=always` (crash) + memory caps + hardening |
| `aastar-dvt-health@.{service,timer}` | /health probe every 30s → restart hung-but-alive (= Docker healthcheck+autoheal) |
| `install.sh` | board: atomic release symlink (upgrade/rollback), per-node env+state |
| `README.md` | runbook + HA note |

## Verified (actually ran it)
- `build-bundle.sh` produced an **81MB** tarball; `file node` → **ELF aarch64, GNU/Linux, /lib/ld-linux-aarch64.so.1** (glibc — matches Yocto) ✅
- prod deps confirmed pure-JS (noble/ethers/nestjs) → `node_modules` cross-arch safe
- bash `-n` syntax clean on both scripts; README prettier-clean

## Self-heal parity with the Docker path (#152)
- crash / OOM / reboot → `Restart=always`
- hung-but-alive → health timer restart (systemd equivalent of autoheal)

## Scope
- Docker path (`docker-compose.mainnet.yml`, #152) stays for **non-embedded** hosts (Mac mini / VPS).
- `dist-bundle/` gitignored (build artifact).
- Not in scope: EIP-2335 keystore (#50④), monitoring (#2), N-of-M (#4).