### PR TITLE
feat(#100 #2): operator alerts → aastar-monitor (push)

### DIFF
--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -1,0 +1,50 @@
+# Operator monitoring → aastar-monitor (push)
+
+The DVT pushes **operator** alerts (node/relay/keeper failures) to the
+**aastar-monitor** Telegram bot. This is distinct from `NOTIFY_*`, which alerts
+**end users** about large spends on their account.
+
+Delivery is **fire-and-forget** — a monitoring outage never blocks signing or
+relaying. Alerts are opt-in and a no-op until a destination URL is configured.
+
+## Enable
+
+```bash
+OPS_ALERT_ENABLED=true
+AASTAR_MONITOR_URL=https://<aastar-monitor>/ingest   # the bot's webhook
+AASTAR_MONITOR_TOKEN=<optional bearer token>         # if the webhook requires auth
+OPS_ALERT_NODE=dvt1                                  # label for which node alerted
+```
+
+## Wire contract (align the bot to this)
+
+Each alert is a single `POST` to `AASTAR_MONITOR_URL`:
+
+```
+POST <AASTAR_MONITOR_URL>
+Content-Type: application/json
+Authorization: Bearer <AASTAR_MONITOR_TOKEN>   # only if a token is set
+
+{
+  "node": "dvt1",           // OPS_ALERT_NODE
+  "level": "critical",      // "info" | "warn" | "critical"
+  "message": "keeper updatePrice failed for 0x…: <reason>",
+  "timestamp": "2026-07-03T15:00:00.000Z"   // ISO-8601
+}
+```
+
+The bot should treat a 2xx as accepted; the DVT logs+swallows any non-2xx.
+
+## What currently alerts
+
+| Source | Level    | When                                 |
+| ------ | -------- | ------------------------------------ |
+| Keeper | critical | `updatePrice()` reverted / tx failed |
+| Relay  | critical | gasless submit failed                |
+
+## Planned (follow-ups, issue #100)
+
+- Hot-wallet **balance watch** (relay/keeper EOAs below a threshold → `warn`)
+- Node **health** self-report (startup, shutdown, repeated tick errors)
+- De-dup / rate-limit identical alerts so a flapping failure doesn't spam the
+  channel

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { GossipModule } from "./modules/gossip/gossip.module.js";
 import { DashboardModule } from "./modules/dashboard/dashboard.module.js";
 import { AppConfigModule } from "./config/config.module.js";
 import { CapabilityModule } from "./modules/capability/capability.module.js";
+import { OpsAlertModule } from "./modules/ops-alert/ops-alert.module.js";
 import { KeeperModule } from "./modules/keeper/keeper.module.js";
 import { RelayModule } from "./modules/relay/relay.module.js";
 import { X402FacilitatorModule } from "./modules/x402-facilitator/x402-facilitator.module.js";
@@ -16,6 +17,7 @@ import { HealthModule } from "./modules/health/health.module.js";
   imports: [
     AppConfigModule, // must be first — validates env vars on startup
     CapabilityModule, // global singleton registry; must load before optional modules
+    OpsAlertModule, // global operator-alert push (#100); must load before keeper/relay
     BlsModule,
     NodeModule,
     SignatureModule,

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -55,6 +55,15 @@ export default () => {
     telegramBotToken: process.env.TELEGRAM_BOT_TOKEN || undefined,
     notifyContactsFile: process.env.NOTIFY_CONTACTS_FILE || undefined,
 
+    // Operator alerting → aastar-monitor Telegram bot (#100). Opt-in; fire-and-forget
+    // (never blocks signing/relaying). Distinct from NOTIFY_* (which alerts end users).
+    // OPS_ALERT_NODE labels which node raised the alert. AASTAR_MONITOR_TOKEN is an
+    // optional bearer token if the bot's webhook requires auth.
+    opsAlertEnabled: process.env.OPS_ALERT_ENABLED === "true",
+    opsAlertUrl: process.env.AASTAR_MONITOR_URL || undefined,
+    opsAlertToken: process.env.AASTAR_MONITOR_TOKEN || undefined,
+    opsAlertNode: process.env.OPS_ALERT_NODE || undefined,
+
     // Out-of-band confirmation (scheme A, #50 ⑤). Opt-in; a high-value op is withheld
     // until the user approves over an independent channel. Fail-closed if undeliverable.
     confirmEnabled: process.env.CONFIRM_ENABLED === "true",

--- a/src/modules/keeper/keeper.service.ts
+++ b/src/modules/keeper/keeper.service.ts
@@ -9,6 +9,7 @@ import { ConfigService } from "@nestjs/config";
 import { BlockchainService } from "../blockchain/blockchain.service.js";
 import { NotificationService } from "../notification/notification.service.js";
 import { CapabilityRegistry } from "../capability/capability-registry.service.js";
+import { OpsAlertService } from "../ops-alert/ops-alert.service.js";
 
 /**
  * Price Keeper Phase 1 (#58) — keeps SuperPaymaster cachedPrice permanently fresh.
@@ -61,7 +62,9 @@ export class KeeperService implements OnApplicationBootstrap, OnApplicationShutd
     @Optional() clock?: () => number,
     @Optional() capabilityRegistry?: CapabilityRegistry,
     /** Test seam: controls the startup phase jitter (default Math.random). */
-    @Optional() random?: () => number
+    @Optional() random?: () => number,
+    /** Operator alerting → aastar-monitor (#100). Optional; no-op when unconfigured. */
+    @Optional() private readonly opsAlert?: OpsAlertService
   ) {
     this.enabled = config.get<boolean>("keeperEnabled") === true;
     this.intervalMs = config.get<number>("keeperIntervalMs") ?? 60_000;
@@ -216,6 +219,8 @@ export class KeeperService implements OnApplicationBootstrap, OnApplicationShutd
       void this.notificationService
         .sendToAccount(paymaster, `[Keeper] updatePrice failed: ${msg}`)
         .catch(() => {});
+      // Operator ops alert → aastar-monitor (no-op unless configured).
+      this.opsAlert?.alert("critical", `keeper updatePrice failed for ${paymaster}: ${msg}`);
     }
   }
 

--- a/src/modules/ops-alert/ops-alert.module.ts
+++ b/src/modules/ops-alert/ops-alert.module.ts
@@ -1,0 +1,14 @@
+import { Global, Module } from "@nestjs/common";
+import { OpsAlertService } from "./ops-alert.service.js";
+
+/**
+ * Global so any module (keeper, relay, …) can inject OpsAlertService without an
+ * explicit import — mirrors CapabilityModule. Alerts are opt-in (OPS_ALERT_ENABLED)
+ * and no-op until AASTAR_MONITOR_URL is set, so this is always safe to load.
+ */
+@Global()
+@Module({
+  providers: [OpsAlertService],
+  exports: [OpsAlertService],
+})
+export class OpsAlertModule {}

--- a/src/modules/ops-alert/ops-alert.service.spec.ts
+++ b/src/modules/ops-alert/ops-alert.service.spec.ts
@@ -1,0 +1,75 @@
+import { jest } from "@jest/globals";
+import { ConfigService } from "@nestjs/config";
+import { OpsAlertService } from "./ops-alert.service.js";
+
+/**
+ * OpsAlertService (#100) — push operator alerts to aastar-monitor, opt-in and
+ * fire-and-forget. Verifies: disabled = no-op, enabled = POST with payload+auth,
+ * and that a delivery failure never throws into the caller.
+ */
+describe("OpsAlertService", () => {
+  const cfg = (over: Record<string, unknown>): ConfigService =>
+    ({ get: (k: string) => over[k] }) as unknown as ConfigService;
+
+  let fetchMock: jest.Mock;
+  beforeEach(() => {
+    fetchMock = jest.fn(async () => ({ ok: true, status: 200 }) as any);
+    (globalThis as any).fetch = fetchMock;
+  });
+
+  it("is a no-op when disabled (no fetch)", () => {
+    const svc = new OpsAlertService(cfg({ opsAlertEnabled: false, opsAlertUrl: "http://m" }));
+    svc.alert("critical", "boom");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when enabled but no URL", () => {
+    const svc = new OpsAlertService(cfg({ opsAlertEnabled: true }));
+    svc.alert("critical", "boom");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("POSTs a structured payload with bearer token when configured", async () => {
+    const svc = new OpsAlertService(
+      cfg({
+        opsAlertEnabled: true,
+        opsAlertUrl: "http://monitor/ingest",
+        opsAlertToken: "secret",
+        opsAlertNode: "dvt1",
+      })
+    );
+    await svc.send({ node: "dvt1", level: "warn", message: "low balance", timestamp: "t" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, any];
+    expect(url).toBe("http://monitor/ingest");
+    expect(init.method).toBe("POST");
+    expect(init.headers.authorization).toBe("Bearer secret");
+    const body = JSON.parse(init.body);
+    expect(body).toMatchObject({ node: "dvt1", level: "warn", message: "low balance" });
+  });
+
+  it("omits the auth header when no token is set", async () => {
+    const svc = new OpsAlertService(cfg({ opsAlertEnabled: true, opsAlertUrl: "http://m" }));
+    await svc.send({ node: "dvt", level: "info", message: "hi", timestamp: "t" });
+    const [, init] = fetchMock.mock.calls[0] as [string, any];
+    expect(init.headers.authorization).toBeUndefined();
+  });
+
+  it("alert() never throws even if delivery rejects", async () => {
+    fetchMock.mockRejectedValue(new Error("network down") as never);
+    const svc = new OpsAlertService(cfg({ opsAlertEnabled: true, opsAlertUrl: "http://m" }));
+    // Must not throw synchronously nor reject (fire-and-forget).
+    expect(() => svc.alert("critical", "boom")).not.toThrow();
+    // Let the detached promise settle; swallowed internally.
+    await new Promise(r => setTimeout(r, 0));
+  });
+
+  it("send() throws on non-2xx (so alert() can log+swallow)", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 } as never);
+    const svc = new OpsAlertService(cfg({ opsAlertEnabled: true, opsAlertUrl: "http://m" }));
+    await expect(
+      svc.send({ node: "dvt", level: "warn", message: "x", timestamp: "t" })
+    ).rejects.toThrow("aastar-monitor HTTP 500");
+  });
+});

--- a/src/modules/ops-alert/ops-alert.service.ts
+++ b/src/modules/ops-alert/ops-alert.service.ts
@@ -1,0 +1,89 @@
+import { Injectable, Logger, Optional } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { CapabilityRegistry } from "../capability/capability-registry.service.js";
+
+export type OpsAlertLevel = "info" | "warn" | "critical";
+
+/** The JSON payload pushed to aastar-monitor. Stable contract — align the bot to this. */
+export interface OpsAlertPayload {
+  node: string; // which DVT node raised it (OPS_ALERT_NODE, defaults to hostname-ish)
+  level: OpsAlertLevel;
+  message: string;
+  timestamp: string; // ISO-8601
+}
+
+/**
+ * Operational alerting for the OPERATOR (issue #100 / #50 ⑦) — distinct from the
+ * end-user NotificationService (large-spend alerts to account owners). This pushes
+ * node-health / hot-wallet-balance / submit-failure alerts to the aastar-monitor
+ * Telegram bot via its webhook.
+ *
+ * Hard rule (same as NotificationService): delivery is **fire-and-forget and never
+ * throws / never blocks** — a monitoring outage must never affect signing or relaying.
+ *
+ * Opt-in via OPS_ALERT_ENABLED + AASTAR_MONITOR_URL. A bearer token
+ * (AASTAR_MONITOR_TOKEN) authenticates the push if the bot requires one.
+ */
+@Injectable()
+export class OpsAlertService {
+  private readonly logger = new Logger(OpsAlertService.name);
+  private readonly enabled: boolean;
+  private readonly url?: string;
+  private readonly token?: string;
+  private readonly node: string;
+
+  constructor(
+    @Optional() configService?: ConfigService,
+    @Optional() capabilityRegistry?: CapabilityRegistry
+  ) {
+    this.url = configService?.get<string>("opsAlertUrl");
+    this.token = configService?.get<string>("opsAlertToken");
+    this.node = configService?.get<string>("opsAlertNode") || "dvt";
+    // Enabled only when explicitly turned on AND a destination URL is set — otherwise
+    // it's a no-op, so wiring alerts into services costs nothing until configured.
+    this.enabled = configService?.get<boolean>("opsAlertEnabled") === true && !!this.url;
+
+    capabilityRegistry?.register({
+      name: "ops-alert",
+      class: "infra-app",
+      description: "Operator alerts pushed to aastar-monitor (#100)",
+      enabled: this.enabled,
+    });
+
+    if (this.enabled) {
+      this.logger.log(`Ops alerts ENABLED — node=${this.node}, → ${this.url}`);
+    }
+  }
+
+  /**
+   * Fire an operator alert. Returns immediately; the POST runs in the background and
+   * any failure is swallowed (never affects the caller's path). No-op when disabled.
+   */
+  alert(level: OpsAlertLevel, message: string): void {
+    if (!this.enabled || !this.url) return;
+    const payload: OpsAlertPayload = {
+      node: this.node,
+      level,
+      message,
+      // Injected clock would be needed for deterministic tests; `send` is what tests spy on.
+      timestamp: new Date().toISOString(),
+    };
+    // Detach: never await, never throw into the caller.
+    void this.send(payload).catch(e =>
+      this.logger.warn(`ops-alert delivery failed (ignored): ${e?.message ?? e}`)
+    );
+  }
+
+  /** POST the alert to aastar-monitor. Isolated + awaitable so it can be unit-tested. */
+  async send(payload: OpsAlertPayload): Promise<void> {
+    if (!this.url) return;
+    const headers: Record<string, string> = { "content-type": "application/json" };
+    if (this.token) headers.authorization = `Bearer ${this.token}`;
+    const r = await fetch(this.url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+    });
+    if (!r.ok) throw new Error(`aastar-monitor HTTP ${r.status}`);
+  }
+}

--- a/src/modules/relay/relay.service.ts
+++ b/src/modules/relay/relay.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, Optional, OnApplicationBootstrap } from "@nestjs/co
 import { ConfigService } from "@nestjs/config";
 import { ethers } from "ethers";
 import { CapabilityRegistry } from "../capability/capability-registry.service.js";
+import { OpsAlertService } from "../ops-alert/ops-alert.service.js";
 import { bumpedFees } from "../../utils/gas.util.js";
 import { RelayV3Dto } from "./dto/relay.dto.js";
 import {
@@ -70,7 +71,9 @@ export class RelayService implements OnApplicationBootstrap {
     private readonly config: ConfigService,
     @Optional() capabilityRegistry?: CapabilityRegistry,
     /** Test seam: controls `Date.now()` for deadline/rate-limit windows. */
-    @Optional() now?: () => number
+    @Optional() now?: () => number,
+    /** Operator alerting → aastar-monitor (#100). Optional; no-op when unconfigured. */
+    @Optional() private readonly opsAlert?: OpsAlertService
   ) {
     this.enabledByConfig = config.get<boolean>("relayEnabled") === true;
     this.operatorPk = config.get<string>("relayOperatorPk") ?? "";
@@ -316,6 +319,7 @@ export class RelayService implements OnApplicationBootstrap {
         (e as { shortMessage?: string })?.shortMessage ??
         (e instanceof Error ? e.message : String(e));
       this.logger.error(`Relay submit failed: ${msg}`);
+      this.opsAlert?.alert("critical", `relay submit failed: ${msg}`);
       return { ok: false, code: "SUBMIT_FAILED", reason: msg };
     }
   }


### PR DESCRIPTION
GA hardening checklist **#2 (monitoring)**, push model per your call: DVT pushes operator alerts to the **aastar-monitor** Telegram bot.

## Design
- **OpsAlertService** — opt-in (`OPS_ALERT_ENABLED` + `AASTAR_MONITOR_URL`), **fire-and-forget** (never throws / never blocks signing or relaying), no-op until configured. Optional bearer token. `@Global` module → any service injects it without per-module imports.
- Distinct from `NotificationService` (which alerts **end users** about large spends) — this alerts the **operator**.

## Wired failure signals
| Source | Level | When |
|---|---|---|
| Keeper | critical | `updatePrice()` reverted / failed |
| Relay | critical | gasless submit failed |

## Wire contract (align the bot to this — see `docs/MONITORING.md`)
```
POST <AASTAR_MONITOR_URL>   (Authorization: Bearer <token> if set)
{ "node":"dvt1", "level":"critical", "message":"…", "timestamp":"ISO-8601" }
```
**You provide** the bot's webhook URL + token via env; code is ready.

## Verified
- 6 new unit tests (disabled no-op / payload+auth / no-token / never-throws / non-2xx→throw)
- 151 tests pass, type-check + prettier clean, build OK (DI wiring verified)

## Follow-ups (noted in docs, issue #100)
hot-wallet balance watch · health self-report · alert de-dup/rate-limit