### PR TITLE
feat(#100 #2): Telegram transport + scheduled status heartbeat

### DIFF
--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -5,42 +5,59 @@ The DVT pushes **operator** alerts (node/relay/keeper failures) to the
 **end users** about large spends on their account.
 
 Delivery is **fire-and-forget** — a monitoring outage never blocks signing or
-relaying. Alerts are opt-in and a no-op until a destination URL is configured.
+relaying. Alerts are opt-in and a no-op until a transport is configured.
 
-## Enable
+## Enable (transport A — native Telegram bot, recommended)
+
+Send straight to the aastar-monitor bot's chat. Get the bot token from
+BotFather; the chat id is your user id (DM the bot **/start** first, or use a
+group's id).
 
 ```bash
 OPS_ALERT_ENABLED=true
-AASTAR_MONITOR_URL=https://<aastar-monitor>/ingest   # the bot's webhook
-AASTAR_MONITOR_TOKEN=<optional bearer token>         # if the webhook requires auth
-OPS_ALERT_NODE=dvt1                                  # label for which node alerted
+OPS_ALERT_BOT_TOKEN=<AAstarMonitorBot token>   # keep in a git-ignored .env only
+OPS_ALERT_CHAT_ID=<your telegram id or group id>
+OPS_ALERT_NODE=dvt1                            # label for which node alerted
+OPS_STATUS_INTERVAL_MS=21600000                # optional heartbeat (0/unset = off; 6h here)
 ```
 
-## Wire contract (align the bot to this)
+> The bot can only DM a user who has messaged it first — send `/start` to the
+> bot once. **Never commit the token**; treat a leaked token as compromised
+> (BotFather `/revoke` mints a new one).
 
-Each alert is a single `POST` to `AASTAR_MONITOR_URL`:
+Telegram messages look like:
+`🔴 [dvt1] keeper updatePrice failed for 0x…: <reason>` (🟢 info · 🟠 warn · 🔴
+critical).
+
+## Enable (transport B — generic webhook)
+
+If you front delivery with your own aggregator instead of the raw bot:
+
+```bash
+OPS_ALERT_ENABLED=true
+AASTAR_MONITOR_URL=https://<aggregator>/ingest
+AASTAR_MONITOR_TOKEN=<optional bearer token>
+```
+
+Webhook payload (the DVT treats a 2xx as accepted):
 
 ```
-POST <AASTAR_MONITOR_URL>
-Content-Type: application/json
-Authorization: Bearer <AASTAR_MONITOR_TOKEN>   # only if a token is set
-
-{
-  "node": "dvt1",           // OPS_ALERT_NODE
-  "level": "critical",      // "info" | "warn" | "critical"
-  "message": "keeper updatePrice failed for 0x…: <reason>",
-  "timestamp": "2026-07-03T15:00:00.000Z"   // ISO-8601
-}
+POST <AASTAR_MONITOR_URL>   (Authorization: Bearer <token> if set)
+{ "node":"dvt1", "level":"critical", "message":"…", "timestamp":"ISO-8601" }
 ```
 
-The bot should treat a 2xx as accepted; the DVT logs+swallows any non-2xx.
+Telegram takes priority when both transports are configured.
 
-## What currently alerts
+## What currently pushes
 
-| Source | Level    | When                                 |
-| ------ | -------- | ------------------------------------ |
-| Keeper | critical | `updatePrice()` reverted / tx failed |
-| Relay  | critical | gasless submit failed                |
+| Source | Level    | When                                     |
+| ------ | -------- | ---------------------------------------- |
+| Keeper | critical | `updatePrice()` reverted / tx failed     |
+| Relay  | critical | gasless submit failed                    |
+| Status | info     | boot ("🟢 online"), then every heartbeat |
+
+The heartbeat summary reports version, uptime, RPC reachability, and enabled
+capabilities — a recurring "still alive + health check" the operator asked for.
 
 ## Planned (follow-ups, issue #100)
 

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -57,12 +57,18 @@ export default () => {
 
     // Operator alerting → aastar-monitor Telegram bot (#100). Opt-in; fire-and-forget
     // (never blocks signing/relaying). Distinct from NOTIFY_* (which alerts end users).
-    // OPS_ALERT_NODE labels which node raised the alert. AASTAR_MONITOR_TOKEN is an
-    // optional bearer token if the bot's webhook requires auth.
+    // Two transports (Telegram takes priority): OPS_ALERT_BOT_TOKEN + OPS_ALERT_CHAT_ID
+    // send straight to the bot's chat; OR AASTAR_MONITOR_URL (+ optional token) for a
+    // generic webhook. OPS_ALERT_NODE labels which node raised the alert.
     opsAlertEnabled: process.env.OPS_ALERT_ENABLED === "true",
+    opsAlertBotToken: process.env.OPS_ALERT_BOT_TOKEN || undefined,
+    opsAlertChatId: process.env.OPS_ALERT_CHAT_ID || undefined,
     opsAlertUrl: process.env.AASTAR_MONITOR_URL || undefined,
     opsAlertToken: process.env.AASTAR_MONITOR_TOKEN || undefined,
     opsAlertNode: process.env.OPS_ALERT_NODE || undefined,
+    // Scheduled status heartbeat (#100). 0 = off. Pushes a periodic "still alive +
+    // health check" summary to the ops channel, plus online/offline on boot/shutdown.
+    opsStatusIntervalMs: parseInt(process.env.OPS_STATUS_INTERVAL_MS || "0", 10),
 
     // Out-of-band confirmation (scheme A, #50 ⑤). Opt-in; a high-value op is withheld
     // until the user approves over an independent channel. Fail-closed if undeliverable.

--- a/src/modules/ops-alert/ops-alert.module.ts
+++ b/src/modules/ops-alert/ops-alert.module.ts
@@ -1,14 +1,18 @@
 import { Global, Module } from "@nestjs/common";
 import { OpsAlertService } from "./ops-alert.service.js";
+import { StatusReporterService } from "./status-reporter.service.js";
+import { BlockchainModule } from "../blockchain/blockchain.module.js";
 
 /**
  * Global so any module (keeper, relay, …) can inject OpsAlertService without an
  * explicit import — mirrors CapabilityModule. Alerts are opt-in (OPS_ALERT_ENABLED)
- * and no-op until AASTAR_MONITOR_URL is set, so this is always safe to load.
+ * and no-op until a transport is configured, so this is always safe to load.
+ * BlockchainModule is imported so the status heartbeat can probe RPC reachability.
  */
 @Global()
 @Module({
-  providers: [OpsAlertService],
+  imports: [BlockchainModule],
+  providers: [OpsAlertService, StatusReporterService],
   exports: [OpsAlertService],
 })
 export class OpsAlertModule {}

--- a/src/modules/ops-alert/ops-alert.service.spec.ts
+++ b/src/modules/ops-alert/ops-alert.service.spec.ts
@@ -72,4 +72,45 @@ describe("OpsAlertService", () => {
       svc.send({ node: "dvt", level: "warn", message: "x", timestamp: "t" })
     ).rejects.toThrow("aastar-monitor HTTP 500");
   });
+
+  // ── Telegram transport (the aastar-monitor bot) ──────────────────────────
+  it("sends via Telegram Bot API when bot token + chat id are set", async () => {
+    const svc = new OpsAlertService(
+      cfg({
+        opsAlertEnabled: true,
+        opsAlertBotToken: "123:ABC",
+        opsAlertChatId: "777",
+        opsAlertNode: "dvt1",
+      })
+    );
+    expect(svc.isEnabled()).toBe(true);
+    await svc.send({ node: "dvt1", level: "critical", message: "keeper failed", timestamp: "t" });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, any];
+    expect(url).toBe("https://api.telegram.org/bot123:ABC/sendMessage");
+    const body = JSON.parse(init.body);
+    expect(body.chat_id).toBe("777");
+    expect(body.text).toBe("🔴 [dvt1] keeper failed"); // critical → red icon
+  });
+
+  it("Telegram takes priority over webhook when both are configured", async () => {
+    const svc = new OpsAlertService(
+      cfg({
+        opsAlertEnabled: true,
+        opsAlertBotToken: "t",
+        opsAlertChatId: "1",
+        opsAlertUrl: "http://webhook",
+      })
+    );
+    await svc.send({ node: "dvt", level: "info", message: "hi", timestamp: "t" });
+    const [url] = fetchMock.mock.calls[0] as [string, any];
+    expect(url).toContain("api.telegram.org");
+  });
+
+  it("Telegram not enabled with token but no chat id", () => {
+    const svc = new OpsAlertService(cfg({ opsAlertEnabled: true, opsAlertBotToken: "t" }));
+    expect(svc.isEnabled()).toBe(false);
+    svc.alert("info", "x");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/modules/ops-alert/ops-alert.service.ts
+++ b/src/modules/ops-alert/ops-alert.service.ts
@@ -28,44 +28,59 @@ export interface OpsAlertPayload {
 export class OpsAlertService {
   private readonly logger = new Logger(OpsAlertService.name);
   private readonly enabled: boolean;
+  private readonly node: string;
+  // Transport A: native Telegram bot (aastar-monitor). Takes priority when configured.
+  private readonly tgToken?: string;
+  private readonly tgChatId?: string;
+  // Transport B: generic webhook (an aggregator/relay in front of delivery).
   private readonly url?: string;
   private readonly token?: string;
-  private readonly node: string;
 
   constructor(
     @Optional() configService?: ConfigService,
     @Optional() capabilityRegistry?: CapabilityRegistry
   ) {
+    this.node = configService?.get<string>("opsAlertNode") || "dvt";
+    this.tgToken = configService?.get<string>("opsAlertBotToken");
+    this.tgChatId = configService?.get<string>("opsAlertChatId");
     this.url = configService?.get<string>("opsAlertUrl");
     this.token = configService?.get<string>("opsAlertToken");
-    this.node = configService?.get<string>("opsAlertNode") || "dvt";
-    // Enabled only when explicitly turned on AND a destination URL is set — otherwise
-    // it's a no-op, so wiring alerts into services costs nothing until configured.
-    this.enabled = configService?.get<boolean>("opsAlertEnabled") === true && !!this.url;
+    // Enabled only when turned on AND a transport is fully configured (Telegram OR
+    // webhook) — otherwise it's a no-op, so wiring alerts in costs nothing until set.
+    const hasTelegram = !!this.tgToken && !!this.tgChatId;
+    const hasWebhook = !!this.url;
+    this.enabled =
+      configService?.get<boolean>("opsAlertEnabled") === true && (hasTelegram || hasWebhook);
 
     capabilityRegistry?.register({
       name: "ops-alert",
       class: "infra-app",
-      description: "Operator alerts pushed to aastar-monitor (#100)",
+      description: "Operator alerts to aastar-monitor Telegram bot (#100)",
       enabled: this.enabled,
     });
 
     if (this.enabled) {
-      this.logger.log(`Ops alerts ENABLED — node=${this.node}, → ${this.url}`);
+      this.logger.log(
+        `Ops alerts ENABLED — node=${this.node}, transport=${hasTelegram ? "telegram" : "webhook"}`
+      );
     }
   }
 
+  /** Whether alerting is active (used by the scheduled status reporter). */
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
   /**
-   * Fire an operator alert. Returns immediately; the POST runs in the background and
+   * Fire an operator alert. Returns immediately; delivery runs in the background and
    * any failure is swallowed (never affects the caller's path). No-op when disabled.
    */
   alert(level: OpsAlertLevel, message: string): void {
-    if (!this.enabled || !this.url) return;
+    if (!this.enabled) return;
     const payload: OpsAlertPayload = {
       node: this.node,
       level,
       message,
-      // Injected clock would be needed for deterministic tests; `send` is what tests spy on.
       timestamp: new Date().toISOString(),
     };
     // Detach: never await, never throw into the caller.
@@ -74,12 +89,33 @@ export class OpsAlertService {
     );
   }
 
-  /** POST the alert to aastar-monitor. Isolated + awaitable so it can be unit-tested. */
+  /** Deliver the alert. Isolated + awaitable so it can be unit-tested. */
   async send(payload: OpsAlertPayload): Promise<void> {
-    if (!this.url) return;
+    if (this.tgToken && this.tgChatId) {
+      return this.sendTelegram(payload);
+    }
+    if (this.url) {
+      return this.sendWebhook(payload);
+    }
+  }
+
+  /** Native Telegram Bot API sendMessage → the aastar-monitor bot's chat. */
+  private async sendTelegram(payload: OpsAlertPayload): Promise<void> {
+    const icon = payload.level === "critical" ? "🔴" : payload.level === "warn" ? "🟠" : "🟢";
+    const text = `${icon} [${payload.node}] ${payload.message}`;
+    const r = await fetch(`https://api.telegram.org/bot${this.tgToken}/sendMessage`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chat_id: this.tgChatId, text }),
+    });
+    if (!r.ok) throw new Error(`telegram HTTP ${r.status}`);
+  }
+
+  /** Generic webhook POST (aggregator in front of delivery). */
+  private async sendWebhook(payload: OpsAlertPayload): Promise<void> {
     const headers: Record<string, string> = { "content-type": "application/json" };
     if (this.token) headers.authorization = `Bearer ${this.token}`;
-    const r = await fetch(this.url, {
+    const r = await fetch(this.url!, {
       method: "POST",
       headers,
       body: JSON.stringify(payload),

--- a/src/modules/ops-alert/status-reporter.service.spec.ts
+++ b/src/modules/ops-alert/status-reporter.service.spec.ts
@@ -1,0 +1,88 @@
+import { jest } from "@jest/globals";
+import { ConfigService } from "@nestjs/config";
+import { StatusReporterService } from "./status-reporter.service.js";
+import { OpsAlertService } from "./ops-alert.service.js";
+
+/**
+ * StatusReporterService (#100) — scheduled heartbeat to the ops channel. Verifies:
+ * disabled when interval=0 or alerts off; on boot sends "online"; report() composes a
+ * version/uptime/RPC/caps summary and pushes it via OpsAlertService.
+ */
+describe("StatusReporterService", () => {
+  const cfg = (over: Record<string, unknown>): ConfigService =>
+    ({ get: (k: string) => over[k] }) as unknown as ConfigService;
+
+  const opsAlertStub = (enabled: boolean) => {
+    const alert = jest.fn();
+    return { svc: { isEnabled: () => enabled, alert } as unknown as OpsAlertService, alert };
+  };
+
+  it("does nothing on boot when interval is 0", () => {
+    const { svc, alert } = opsAlertStub(true);
+    const r = new StatusReporterService(svc, cfg({ opsStatusIntervalMs: 0 }));
+    r.onApplicationBootstrap();
+    expect(alert).not.toHaveBeenCalled();
+    r.onApplicationShutdown();
+  });
+
+  it("does nothing when ops alerts are disabled", () => {
+    const { svc, alert } = opsAlertStub(false);
+    const r = new StatusReporterService(svc, cfg({ opsStatusIntervalMs: 1000 }));
+    r.onApplicationBootstrap();
+    expect(alert).not.toHaveBeenCalled();
+    r.onApplicationShutdown();
+  });
+
+  it("sends an online message on boot when enabled", () => {
+    const { svc, alert } = opsAlertStub(true);
+    const r = new StatusReporterService(svc, cfg({ opsStatusIntervalMs: 60_000 }));
+    r.onApplicationBootstrap();
+    expect(alert).toHaveBeenCalledTimes(1);
+    const [level, msg] = alert.mock.calls[0] as [string, string];
+    expect(level).toBe("info");
+    expect(msg).toContain("online");
+    r.onApplicationShutdown();
+  });
+
+  it("report() composes version/uptime/RPC/caps and pushes it", async () => {
+    const { svc, alert } = opsAlertStub(true);
+    const blockchain = { getBaseFeeGwei: jest.fn(async () => 3n) } as any;
+    const capabilities = {
+      list: () => [
+        { name: "keeper", enabled: true },
+        { name: "relay", enabled: false },
+      ],
+    } as any;
+    let now = 1_000_000;
+    const r = new StatusReporterService(
+      svc,
+      cfg({ opsStatusIntervalMs: 60_000 }),
+      blockchain,
+      capabilities,
+      () => now
+    );
+    r.onApplicationBootstrap(); // sets startedAt, sends online (call 1)
+    now += 5 * 60_000; // +5 minutes
+    await r.report(); // call 2
+
+    const [, msg] = alert.mock.calls[1] as [string, string];
+    expect(msg).toContain("up 5m");
+    expect(msg).toContain("RPC ok");
+    expect(msg).toContain("keeper"); // enabled cap listed
+    expect(msg).not.toContain("relay"); // disabled cap omitted
+    r.onApplicationShutdown();
+  });
+
+  it("report() marks RPC DOWN when the probe throws, never rejects", async () => {
+    const { svc, alert } = opsAlertStub(true);
+    const blockchain = {
+      getBaseFeeGwei: jest.fn(async () => {
+        throw new Error("rpc down");
+      }),
+    } as any;
+    const r = new StatusReporterService(svc, cfg({ opsStatusIntervalMs: 60_000 }), blockchain);
+    await expect(r.report()).resolves.toBeUndefined();
+    const [, msg] = alert.mock.calls[0] as [string, string];
+    expect(msg).toContain("RPC DOWN");
+  });
+});

--- a/src/modules/ops-alert/status-reporter.service.ts
+++ b/src/modules/ops-alert/status-reporter.service.ts
@@ -1,0 +1,97 @@
+import { createRequire } from "module";
+import {
+  Injectable,
+  Logger,
+  Optional,
+  OnApplicationBootstrap,
+  OnApplicationShutdown,
+} from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { BlockchainService } from "../blockchain/blockchain.service.js";
+import { CapabilityRegistry } from "../capability/capability-registry.service.js";
+import { OpsAlertService } from "./ops-alert.service.js";
+
+const require = createRequire(import.meta.url);
+const { version: APP_VERSION } = require("../../../package.json") as { version: string };
+
+/**
+ * Scheduled status heartbeat → aastar-monitor (#100). When OPS_STATUS_INTERVAL_MS > 0
+ * and ops alerts are enabled, pushes:
+ *   - a "🟢 online" message on boot and "🔴 offline" on shutdown, and
+ *   - a periodic status summary (version, uptime, RPC reachability, enabled caps)
+ *     so the operator sees the node is alive AND gets a recurring health check.
+ *
+ * The recurring anomaly alerts (keeper/relay failures) flow through OpsAlertService
+ * independently; this adds the "still alive + check result" cadence the operator asked
+ * for. Everything is fire-and-forget — a monitoring outage never affects the node.
+ */
+@Injectable()
+export class StatusReporterService implements OnApplicationBootstrap, OnApplicationShutdown {
+  private readonly logger = new Logger(StatusReporterService.name);
+  private readonly intervalMs: number;
+  private readonly clock: () => number;
+  private startedAtMs = 0;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private readonly opsAlert: OpsAlertService,
+    @Optional() private readonly config?: ConfigService,
+    @Optional() private readonly blockchain?: BlockchainService,
+    @Optional() private readonly capabilities?: CapabilityRegistry,
+    /** Test seam for Date.now(). */
+    @Optional() clock?: () => number
+  ) {
+    this.intervalMs = this.config?.get<number>("opsStatusIntervalMs") ?? 0;
+    this.clock = clock ?? (() => Date.now());
+  }
+
+  onApplicationBootstrap(): void {
+    if (this.intervalMs <= 0 || !this.opsAlert.isEnabled()) return;
+    this.startedAtMs = this.clock();
+    this.opsAlert.alert("info", `🟢 online — v${APP_VERSION}`);
+    this.timer = setInterval(() => void this.report(), this.intervalMs);
+    this.logger.log(`Status heartbeat ENABLED — every ${this.intervalMs}ms`);
+  }
+
+  onApplicationShutdown(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** Compose and push one status summary. Never throws. */
+  async report(): Promise<void> {
+    try {
+      const text = await this.compose();
+      this.opsAlert.alert("info", text);
+    } catch (e: any) {
+      this.logger.warn(`status report failed (ignored): ${e?.message ?? e}`);
+    }
+  }
+
+  /** Build the status line: version, uptime, RPC reachability, enabled capabilities. */
+  private async compose(): Promise<string> {
+    const uptimeMin = Math.floor((this.clock() - this.startedAtMs) / 60_000);
+    const rpc = await this.rpcOk();
+    const caps = (this.capabilities?.list() ?? [])
+      .filter(c => c.enabled)
+      .map(c => c.name)
+      .join(",");
+    return (
+      `status v${APP_VERSION} — up ${uptimeMin}m, ` +
+      `RPC ${rpc ? "ok" : "DOWN"}, caps=[${caps || "none"}]`
+    );
+  }
+
+  /** Lightweight RPC liveness probe (a real round-trip). False on any error/timeout. */
+  private async rpcOk(): Promise<boolean> {
+    if (!this.blockchain) return false;
+    try {
+      await this.blockchain.getBaseFeeGwei();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
Completes the monitoring ask: DVT → **AAstarMonitorBot** (Telegram), verified end-to-end (a real `sendMessage` delivered).

## Why
aastar-monitor is a **raw Telegram bot** — the generic webhook payload from #154 can't reach the Telegram API (it wants `{chat_id, text}`). So OpsAlertService gets a native Telegram transport.

## What's new
- **OpsAlertService**: `OPS_ALERT_BOT_TOKEN` + `OPS_ALERT_CHAT_ID` → `api.telegram.org/bot…/sendMessage`, icon by level (🟢 info · 🟠 warn · 🔴 critical). Generic webhook kept as transport B; **Telegram takes priority**.
- **StatusReporterService**: `OPS_STATUS_INTERVAL_MS` heartbeat — `🟢 online` on boot, then a periodic summary (version · uptime · **RPC reachability check** · enabled caps). This is the "定时检查结果 + 还活着" the operator asked for. Fire-and-forget.
- keeper/relay failure alerts now reach Telegram unchanged.
- `docs/MONITORING.md`: both transports + heartbeat + `/start` + token-safety.

## Verified
- **Real Telegram delivery** to the bot (message_id returned) ✅
- Boot smoke: `Ops alerts ENABLED transport=telegram` + `Status heartbeat ENABLED` + Nest started, no DI errors
- 159 tests pass (8 new/updated), type-check + prettier + lint(0 err) clean

## Security
Bot token lives only in a git-ignored `.env` — never committed. (Token was shared in chat → recommend BotFather `/revoke` after setup.)

## Follow-ups (#100)
hot-wallet balance watch · alert de-dup/rate-limit