### PR TITLE
feat(#3 #100): relay eth_call preflight + fix ops-status NaN interval

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -68,7 +68,9 @@ export default () => {
     opsAlertNode: process.env.OPS_ALERT_NODE || undefined,
     // Scheduled status heartbeat (#100). 0 = off. Pushes a periodic "still alive +
     // health check" summary to the ops channel, plus online/offline on boot/shutdown.
-    opsStatusIntervalMs: parseInt(process.env.OPS_STATUS_INTERVAL_MS || "0", 10),
+    // `|| 0` guards a non-numeric value (parseInt → NaN) from leaking through as an
+    // interval, which would make setInterval fire continuously (eval#299).
+    opsStatusIntervalMs: parseInt(process.env.OPS_STATUS_INTERVAL_MS || "0", 10) || 0,
 
     // Out-of-band confirmation (scheme A, #50 ⑤). Opt-in; a high-value op is withheld
     // until the user approves over an independent channel. Fail-closed if undeliverable.

--- a/src/modules/ops-alert/status-reporter.service.ts
+++ b/src/modules/ops-alert/status-reporter.service.ts
@@ -46,7 +46,11 @@ export class StatusReporterService implements OnApplicationBootstrap, OnApplicat
   }
 
   onApplicationBootstrap(): void {
-    if (this.intervalMs <= 0 || !this.opsAlert.isEnabled()) return;
+    // Defensive: a non-finite interval (bad env) must never reach setInterval, or it
+    // fires continuously. Config already guards this; belt-and-braces here too.
+    if (!Number.isFinite(this.intervalMs) || this.intervalMs <= 0 || !this.opsAlert.isEnabled()) {
+      return;
+    }
     this.startedAtMs = this.clock();
     this.opsAlert.alert("info", `🟢 online — v${APP_VERSION}`);
     this.timer = setInterval(() => void this.report(), this.intervalMs);

--- a/src/modules/relay/relay.constants.ts
+++ b/src/modules/relay/relay.constants.ts
@@ -63,5 +63,6 @@ export type RelayErrorCode =
   | "SIGNATURE_INVALID"
   | "NOT_WHITELISTED"
   | "RATE_LIMITED"
+  | "PREFLIGHT_REVERTED"
   | "SUBMIT_FAILED"
   | "INFRA_NOT_READY";

--- a/src/modules/relay/relay.controller.ts
+++ b/src/modules/relay/relay.controller.ts
@@ -52,6 +52,9 @@ export class RelayController {
         return 429;
       case "INFRA_NOT_READY":
         return 503;
+      case "PREFLIGHT_REVERTED":
+        // The request would revert on-chain — a client/intent problem, not our infra.
+        return 422;
       case "SUBMIT_FAILED":
         return 502;
       default:

--- a/src/modules/relay/relay.service.spec.ts
+++ b/src/modules/relay/relay.service.spec.ts
@@ -172,7 +172,7 @@ describe("RelayService", () => {
     it("enforces the per-address hourly cap", async () => {
       const svc = makeService();
       // Inject a stub wallet (with a provider for the fee-bump) so relay()
-      // proceeds past INFRA_NOT_READY.
+      // proceeds past INFRA_NOT_READY. `call` = the #3 preflight (succeeds here).
       (svc as any).wallet = {
         address: buyer.address,
         provider: {
@@ -181,6 +181,7 @@ describe("RelayService", () => {
             maxPriorityFeePerGas: 2_000_000_000n,
           }),
         },
+        call: async () => "0x",
         sendTransaction: async () => ({ hash: "0xdead" }),
       };
 
@@ -190,6 +191,53 @@ describe("RelayService", () => {
       expect(r1.ok).toBe(true);
       expect(r2.ok).toBe(true);
       expect(r3).toMatchObject({ ok: false, code: "RATE_LIMITED" });
+    });
+  });
+
+  describe("eth_call preflight (#3)", () => {
+    it("rejects a would-revert tx WITHOUT submitting (no gas burned)", async () => {
+      const svc = makeService();
+      let submitted = false;
+      (svc as any).wallet = {
+        address: buyer.address,
+        provider: {
+          getFeeData: async () => ({ maxFeePerGas: 3_000_000_000n, maxPriorityFeePerGas: 2n }),
+        },
+        // Preflight reverts → sendTransaction must NOT be reached.
+        call: async () => {
+          throw Object.assign(new Error("execution reverted: Expired"), {
+            shortMessage: "execution reverted: Expired",
+          });
+        },
+        sendTransaction: async () => {
+          submitted = true;
+          return { hash: "0xdead" };
+        },
+      };
+
+      const r = await svc.relay(await signedBody());
+      expect(r).toMatchObject({ ok: false, code: "PREFLIGHT_REVERTED" });
+      expect(submitted).toBe(false); // the whole point: no doomed tx, no gas spent
+    });
+
+    it("submits when the preflight call succeeds", async () => {
+      const svc = makeService();
+      let submitted = false;
+      (svc as any).wallet = {
+        address: buyer.address,
+        provider: {
+          getFeeData: async () => ({ maxFeePerGas: 3_000_000_000n, maxPriorityFeePerGas: 2n }),
+        },
+        call: async () => "0x",
+        sendTransaction: async () => {
+          submitted = true;
+          return { hash: "0xbeef" };
+        },
+      };
+
+      const r = await svc.relay(await signedBody());
+      expect(r).toMatchObject({ ok: true, txHash: "0xbeef" });
+      expect(submitted).toBe(true);
     });
   });
 });

--- a/src/modules/relay/relay.service.ts
+++ b/src/modules/relay/relay.service.ts
@@ -301,6 +301,23 @@ export class RelayService implements OnApplicationBootstrap {
   }
 
   private async sendTx(callData: string, matchedRule: string): Promise<RelayResult> {
+    // #3 (#100) eth_call preflight: static-call the exact tx first. A call that WOULD
+    // revert (expired intent, bad signature that slipped validation, insufficient
+    // allowance, paused contract…) is rejected here for FREE — no gas burned — instead
+    // of submitting a doomed tx that spends the operator's ETH. Also blunts griefing:
+    // an attacker spamming revert-bound requests can no longer drain the hot wallet.
+    // Best-effort (state can change before submit), so a later on-chain revert is still
+    // caught by the sendTransaction catch below.
+    try {
+      await this.wallet!.call({ to: this.buyHelper, data: callData, value: 0n });
+    } catch (e: unknown) {
+      const msg =
+        (e as { shortMessage?: string })?.shortMessage ??
+        (e instanceof Error ? e.message : String(e));
+      this.logger.warn(`Relay preflight reverted — not submitting (${matchedRule}): ${msg}`);
+      return { ok: false, code: "PREFLIGHT_REVERTED", reason: msg };
+    }
+
     try {
       // Bump fees (estimate +15%, priority floor) so the tx mines promptly — a
       // BuyIntent carries a deadline, and an underpriced tx that mines late


### PR DESCRIPTION
GA hardening **#3** (issue #100: "提交前 eth_call 预检 — 测试网欠的债，主网必须补").

## Business value
The relay pays gas from a hot wallet. Without a preflight, a tx that **will revert** on-chain still gets submitted → **burns the operator's ETH** and enables **griefing** (spam revert-bound requests to drain the wallet). A static `eth_call` before submit rejects would-be-reverts **for free**.

## Change
- `sendTx`: `wallet.call({to, data})` before `sendTransaction`. On revert → return `PREFLIGHT_REVERTED` (HTTP 422), **no gas spent**. Mirrors the keeper's existing `canUpdatePrice()` staticCall pattern.
- Best-effort (state can change before submit) → a later on-chain revert is still caught by the existing submit catch.

## Also (eval#299 from #155 review)
`OPS_STATUS_INTERVAL_MS` non-numeric → `parseInt` NaN slipped past `?? 0` and would make `setInterval` fire continuously. Guarded with `|| 0` (config) + `Number.isFinite()` (reporter).

## Verified
- 3 new relay tests: would-revert → **not submitted** (asserts `sendTransaction` never called) / success → submitted / rate-limit stub updated with `.call`
- 161 tests pass, type-check + prettier + lint(0 err) clean, build OK

## Next (per your queue)
#5 EIP-2335 keystore (security-sensitive, careful) · #4 N-of-M → recommend a **design issue** (cross-repo/ops, not a single DVT PR). rust-signer **b** (board bench) then **c** (systemd unit).