### PR TITLE
feat(#5 #50④): EIP-2335 encrypted BLS keystore at rest

### DIFF
--- a/docs/KEYSTORE.md
+++ b/docs/KEYSTORE.md
@@ -1,0 +1,50 @@
+# BLS key at rest — EIP-2335 encrypted keystore (#5 / #50 ④)
+
+By default `node_state.json` stores the BLS private key in **plaintext**
+(git-ignored, but readable by anyone with the file). On a physical board
+(i.MX93) that can be stolen or backed up, that's a real at-rest risk. #5 lets
+you store the key **encrypted** in the same file using the EIP-2335 keystore
+format (the format Ethereum validators use, same BLS12-381 curve), decrypted at
+boot with a passphrase supplied from **outside** the disk.
+
+**Boundary:** this protects the key AT REST only. It does not defend a
+compromised running process (the key is decrypted in memory to sign) or someone
+who has the passphrase. For hardware-bound keys you'd need an HSM / the board's
+EdgeLock (future).
+
+## Migrate an existing node (plaintext → encrypted)
+
+```bash
+npm run build   # the migration script imports the compiled keystore util
+NODE_KEY_PASSPHRASE='your-strong-passphrase' node scripts/encrypt-node-key.mjs deploy/node1/node_state.json
+# KDF=pbkdf2 for a lighter derivation on tiny boards; default scrypt is stronger (~256MB).
+```
+
+This replaces the plaintext `privateKey` with an encrypted `keystore` field and
+writes a `node_state.json.bak` (STILL plaintext). Verify the node boots with the
+passphrase, then **securely delete the `.bak`**.
+
+## Run with the passphrase
+
+Supply `NODE_KEY_PASSPHRASE` from **outside the machine's disk** — never store
+it next to the keystore:
+
+- **systemd**: a `LoadCredential=` / `systemd-creds` credential (sealed to the
+  TPM/EdgeLock if available) → the node auto-restarts unattended AND the key
+  stays encrypted at rest.
+- **env var** injected at boot by your orchestrator.
+- **typed by a human** at boot — most secure at rest, but the node can't
+  self-restart unattended (a 3am crash stays down until someone types it).
+  Trade-off per node.
+
+At boot the node logs `BLS key loaded from encrypted keystore (EIP-2335)`.
+Fail-closed: an encrypted keystore with **no** passphrase, or a **wrong** one,
+aborts startup — the node never runs with an unusable/blank key.
+
+## Notes
+
+- Plaintext `privateKey` is still accepted (dev / existing nodes) — encryption
+  is opt-in per node by running the migration. `saveNodeState` never writes the
+  decrypted key back to disk when a keystore is present.
+- scrypt (default) uses ~256 MB during derivation; on a 2 GB board prefer
+  `KDF=pbkdf2` if that spike contends with the node + signer.

--- a/scripts/encrypt-node-key.mjs
+++ b/scripts/encrypt-node-key.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+// Migrate a plaintext node_state.json to an EIP-2335 encrypted keystore (#5).
+// The plaintext privateKey is replaced by an encrypted `keystore` field; nothing else
+// changes. The passphrase is read from NODE_KEY_PASSPHRASE (never passed on argv, so it
+// doesn't land in shell history / process listings).
+//
+//   NODE_KEY_PASSPHRASE='…' node scripts/encrypt-node-key.mjs deploy/node1/node_state.json
+//   # optional: KDF=pbkdf2 (lighter on tiny boards) | KDF=scrypt (default, stronger)
+//
+// A .bak of the original is written next to the file. Verify the node boots with the
+// passphrase, then SECURELY DELETE the .bak (it still holds the plaintext key).
+import { readFileSync, writeFileSync } from "fs";
+import { encryptKeystore, isKeystore } from "../dist/utils/keystore.util.js";
+
+const file = process.argv[2];
+if (!file) {
+  console.error("usage: NODE_KEY_PASSPHRASE=… node scripts/encrypt-node-key.mjs <node_state.json>");
+  process.exit(1);
+}
+const passphrase = process.env.NODE_KEY_PASSPHRASE;
+if (!passphrase) {
+  console.error("‼ set NODE_KEY_PASSPHRASE (not passed on argv)");
+  process.exit(1);
+}
+const kdf = process.env.KDF === "pbkdf2" ? "pbkdf2" : "scrypt";
+
+const state = JSON.parse(readFileSync(file, "utf8"));
+if (isKeystore(state.keystore)) {
+  console.error("‼ already encrypted (keystore present) — nothing to do");
+  process.exit(1);
+}
+if (typeof state.privateKey !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(state.privateKey)) {
+  console.error("‼ node_state.json has no valid plaintext privateKey (0x + 64 hex)");
+  process.exit(1);
+}
+
+const secret = Uint8Array.from(Buffer.from(state.privateKey.slice(2), "hex"));
+const keystore = encryptKeystore(secret, passphrase, {
+  kdf,
+  pubkey: state.publicKey?.replace(/^0x/, ""),
+  description: `aastar-dvt ${state.nodeId ?? ""}`.trim(),
+});
+
+// Back up the plaintext original, then replace privateKey with the keystore.
+writeFileSync(`${file}.bak`, readFileSync(file));
+const { privateKey: _omit, ...rest } = state;
+writeFileSync(file, JSON.stringify({ ...rest, keystore }, null, 2) + "\n");
+
+console.log(`✅ encrypted ${file} (kdf=${kdf})`);
+console.log(`   backup (STILL PLAINTEXT): ${file}.bak — verify boot, then securely delete it`);
+console.log(`   run the node with NODE_KEY_PASSPHRASE set to decrypt at boot.`);

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -95,6 +95,12 @@ export default () => {
     // backend-independent (algorithm/wire is the fixed kernel — see conformance/).
     signerBackend: process.env.SIGNER_BACKEND || "local",
 
+    // EIP-2335 keystore passphrase (#5, #50 ④). When node_state.json holds an encrypted
+    // keystore, this decrypts it at boot. Supply it from OUTSIDE the machine's disk —
+    // an env var injected at boot (systemd LoadCredential, an orchestrator, or typed).
+    // Never store it next to the keystore. Unset + encrypted keystore → fail to boot.
+    keyPassphrase: process.env.NODE_KEY_PASSPHRASE || undefined,
+
     // Price Keeper (#58). Opt-in; keeps paymaster cachedPrice permanently fresh via
     // on-chain updatePrice() calls when approaching the staleness threshold. Requires
     // ETH_PRIVATE_KEY (or a dedicated KEEPER_PRIVATE_KEY in a future phase). Default off.

--- a/src/interfaces/node.interface.ts
+++ b/src/interfaces/node.interface.ts
@@ -9,7 +9,14 @@ export interface NodeKeyPair {
 export interface NodeState {
   nodeId: string;
   nodeName: string;
+  /**
+   * Raw BLS private key (0x-hex). On disk it is EITHER this plaintext field (dev/legacy)
+   * OR an encrypted `keystore` (#5, EIP-2335 — prod). When a keystore is present it is
+   * decrypted at load using NODE_KEY_PASSPHRASE and this field is populated in memory.
+   */
   privateKey: string;
+  /** EIP-2335 encrypted keystore (#5). When set, `privateKey` is derived from it at load. */
+  keystore?: import("../utils/keystore.util.js").Eip2335Keystore;
   publicKey: string;
   stakeStatus?: "not_staked" | "staked" | "unstaking";
   stakeAmount?: string;

--- a/src/modules/node/node.keystore.spec.ts
+++ b/src/modules/node/node.keystore.spec.ts
@@ -1,0 +1,111 @@
+import { jest } from "@jest/globals";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { ConfigService } from "@nestjs/config";
+import { NodeService } from "./node.service.js";
+import { encryptKeystore } from "../../utils/keystore.util.js";
+
+/**
+ * #5 — node.service loads its BLS key from an EIP-2335 keystore (NODE_KEY_PASSPHRASE)
+ * and NEVER writes the decrypted plaintext back to disk. Exercises the private
+ * resolvePrivateKey / saveNodeState via a temp node_state.json (no NestJS bootstrap).
+ */
+describe("NodeService — EIP-2335 keystore load (#5)", () => {
+  const SK_HEX = "0000000000000000000000000000000000000000000000000000000000000001";
+  const PASS = "corr3ct-h0rse";
+
+  const makeService = (passphrase?: string): NodeService => {
+    const config = {
+      get: (k: string) =>
+        k === "keyPassphrase" ? passphrase : k === "validatorContractAddress" ? "0x00" : undefined,
+    } as unknown as ConfigService;
+    // BlsService/BlockchainService are unused on the load path we test.
+    return new NodeService({} as any, {} as any, config);
+  };
+
+  const withState = (
+    state: object,
+    fn: (svc: NodeService, file: string) => void,
+    pass?: string
+  ) => {
+    const dir = mkdtempSync(join(tmpdir(), "ks-"));
+    const file = join(dir, "node_state.json");
+    writeFileSync(file, JSON.stringify(state));
+    const svc = makeService(pass);
+    (svc as any).nodeStateFilePath = file;
+    try {
+      fn(svc, file);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  };
+
+  const keystoreState = () => ({
+    nodeId: "0xabc",
+    nodeName: "n",
+    publicKey: "0x97f1",
+    createdAt: "t",
+    description: "d",
+    keystore: encryptKeystore(Buffer.from(SK_HEX, "hex"), PASS, { kdf: "pbkdf2" }),
+  });
+
+  it("decrypts the keystore with the passphrase and populates privateKey", () => {
+    withState(
+      keystoreState(),
+      svc => {
+        (svc as any).loadExistingNodeState();
+        expect((svc as any).nodeState.privateKey).toBe("0x" + SK_HEX);
+      },
+      PASS
+    );
+  });
+
+  it("fails closed when the keystore has no passphrase", () => {
+    withState(keystoreState(), svc => {
+      expect(() => (svc as any).loadExistingNodeState()).toThrow(/NODE_KEY_PASSPHRASE is not set/);
+    });
+  });
+
+  it("fails closed on a wrong passphrase (checksum mismatch)", () => {
+    withState(
+      keystoreState(),
+      svc => {
+        expect(() => (svc as any).loadExistingNodeState()).toThrow(/wrong passphrase/i);
+      },
+      "nope"
+    );
+  });
+
+  it("saveNodeState NEVER writes the decrypted plaintext key back to disk", () => {
+    withState(
+      keystoreState(),
+      (svc, file) => {
+        (svc as any).loadExistingNodeState(); // populates in-memory privateKey
+        expect((svc as any).nodeState.privateKey).toBe("0x" + SK_HEX);
+        (svc as any).saveNodeState();
+        const onDisk = JSON.parse(readFileSync(file, "utf8"));
+        expect(onDisk.privateKey).toBeUndefined(); // the whole point
+        expect(onDisk.keystore?.version).toBe(4);
+      },
+      PASS
+    );
+  });
+
+  it("still supports a plaintext privateKey (dev/legacy)", () => {
+    withState(
+      {
+        nodeId: "0x1",
+        nodeName: "n",
+        publicKey: "0x",
+        createdAt: "t",
+        description: "d",
+        privateKey: "0x" + SK_HEX,
+      },
+      svc => {
+        (svc as any).loadExistingNodeState();
+        expect((svc as any).nodeState.privateKey).toBe("0x" + SK_HEX);
+      }
+    );
+  });
+});

--- a/src/modules/node/node.service.ts
+++ b/src/modules/node/node.service.ts
@@ -6,6 +6,7 @@ import { join } from "path";
 import { BlsService } from "../bls/bls.service.js";
 import { BlockchainService } from "../blockchain/blockchain.service.js";
 import { randomBytes, createHash } from "crypto";
+import { decryptKeystore, isKeystore } from "../../utils/keystore.util.js";
 
 @Injectable()
 export class NodeService implements OnModuleInit {
@@ -48,17 +49,49 @@ export class NodeService implements OnModuleInit {
   }
 
   private loadExistingNodeState(): void {
+    let state: NodeState;
     try {
-      const stateData = readFileSync(this.nodeStateFilePath, "utf8");
-      this.nodeState = JSON.parse(stateData);
+      state = JSON.parse(readFileSync(this.nodeStateFilePath, "utf8"));
     } catch (error: any) {
       throw new Error(`Failed to load node state: ${error.message}`);
     }
+    this.nodeState = this.resolvePrivateKey(state);
+  }
+
+  /**
+   * Resolve the in-memory private key (#5). If the on-disk state carries an EIP-2335
+   * `keystore`, decrypt it with NODE_KEY_PASSPHRASE and populate `privateKey`. Plaintext
+   * `privateKey` (dev/legacy) is used as-is. Fails closed: an encrypted keystore with no
+   * passphrase — or a wrong one — throws, so the node never boots with an unusable key.
+   */
+  private resolvePrivateKey(state: NodeState): NodeState {
+    if (isKeystore(state.keystore)) {
+      const passphrase = this.configService.get<string>("keyPassphrase");
+      if (!passphrase) {
+        throw new Error(
+          "node_state.json holds an encrypted keystore but NODE_KEY_PASSPHRASE is not set"
+        );
+      }
+      const secret = decryptKeystore(state.keystore, passphrase); // throws on wrong passphrase
+      state.privateKey = "0x" + Buffer.from(secret).toString("hex");
+      this.logger.log("BLS key loaded from encrypted keystore (EIP-2335)");
+    } else if (!state.privateKey) {
+      throw new Error("node_state.json has neither a keystore nor a plaintext privateKey");
+    }
+    return state;
   }
 
   saveNodeState(): void {
     try {
-      writeFileSync(this.nodeStateFilePath, JSON.stringify(this.nodeState, null, 2), "utf8");
+      // SECURITY (#5): when the key is stored encrypted (keystore present), NEVER write
+      // the in-memory-decrypted plaintext privateKey back to disk — that would defeat
+      // the at-rest encryption. Persist the keystore form only.
+      let toWrite = this.nodeState;
+      if (this.nodeState && isKeystore(this.nodeState.keystore)) {
+        const { privateKey: _omit, ...rest } = this.nodeState;
+        toWrite = rest as NodeState;
+      }
+      writeFileSync(this.nodeStateFilePath, JSON.stringify(toWrite, null, 2), "utf8");
     } catch (error: any) {
       throw new Error(`Failed to save node state: ${error.message}`);
     }

--- a/src/utils/keystore.util.spec.ts
+++ b/src/utils/keystore.util.spec.ts
@@ -1,0 +1,71 @@
+import { decryptKeystore, encryptKeystore, isKeystore, Eip2335Keystore } from "./keystore.util.js";
+
+/**
+ * Verify our EIP-2335 implementation against the TWO official spec test vectors
+ * (scrypt + pbkdf2). Both encrypt the same secret with the same password/salt/iv and
+ * must reproduce the spec's cipher.message + checksum.message byte-for-byte; decrypt
+ * must recover the secret. This is the correctness gate for a security-critical module.
+ */
+describe("EIP-2335 keystore (official vectors)", () => {
+  // https://eips.ethereum.org/EIPS/eip-2335 — 𝔱𝔢𝔰𝔱𝔭𝔞𝔰𝔰𝔴𝔬𝔯𝔡🔑 (NFKD → "testpassword🔑")
+  const PASSWORD = "𝔱𝔢𝔰𝔱𝔭𝔞𝔰𝔰𝔴𝔬𝔯𝔡🔑";
+  const SECRET_HEX = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
+  const SALT = "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3";
+  const IV = "264daa3f303d7259501c93d997d84fe6";
+  const secret = Buffer.from(SECRET_HEX, "hex");
+
+  const VECTORS = [
+    {
+      kdf: "scrypt" as const,
+      cipher: "06ae90d55fe0a6e9c5c3bc5b170827b2e5cce3929ed3f116c2811e6366dfe20f",
+      checksum: "d2217fe5f3e9a1e34581ef8a78f7c9928e436d36dacc5e846690a5581e8ea484",
+    },
+    {
+      kdf: "pbkdf2" as const,
+      cipher: "cee03fde2af33149775b7223e7845e4fb2c8ae1792e5f99fe9ecf474cc8c16ad",
+      checksum: "8a9f5d9912ed7e75ea794bc5a89bca5f193721d30868ade6f73043c6ea6febf1",
+    },
+  ];
+
+  for (const v of VECTORS) {
+    it(`${v.kdf}: encrypt reproduces the spec cipher + checksum`, () => {
+      const ks = encryptKeystore(secret, PASSWORD, {
+        kdf: v.kdf,
+        salt: Buffer.from(SALT, "hex"),
+        iv: Buffer.from(IV, "hex"),
+      });
+      expect(ks.crypto.cipher.message).toBe(v.cipher);
+      expect(ks.crypto.checksum.message).toBe(v.checksum);
+    });
+
+    it(`${v.kdf}: decrypt recovers the secret`, () => {
+      const ks = encryptKeystore(secret, PASSWORD, {
+        kdf: v.kdf,
+        salt: Buffer.from(SALT, "hex"),
+        iv: Buffer.from(IV, "hex"),
+      });
+      expect(Buffer.from(decryptKeystore(ks, PASSWORD)).toString("hex")).toBe(SECRET_HEX);
+    });
+  }
+
+  it("wrong passphrase throws (checksum mismatch), never returns a bad key", () => {
+    const ks = encryptKeystore(secret, "correct horse", { kdf: "pbkdf2" });
+    expect(() => decryptKeystore(ks, "wrong")).toThrow(/wrong passphrase/i);
+  });
+
+  it("round-trips a random 32-byte key", () => {
+    const key = Buffer.from("11".repeat(32), "hex");
+    const ks = encryptKeystore(new Uint8Array(key), "s3cret!", { kdf: "pbkdf2" });
+    expect(Buffer.from(decryptKeystore(ks, "s3cret!")).toString("hex")).toBe(key.toString("hex"));
+  });
+
+  it("rejects a non-32-byte secret", () => {
+    expect(() => encryptKeystore(new Uint8Array(31), "x")).toThrow(/32 bytes/);
+  });
+
+  it("isKeystore distinguishes a keystore from a plaintext node_state", () => {
+    const ks = encryptKeystore(secret, "x", { kdf: "pbkdf2" });
+    expect(isKeystore(ks)).toBe(true);
+    expect(isKeystore({ nodeId: "x", privateKey: "0x01" })).toBe(false);
+  });
+});

--- a/src/utils/keystore.util.ts
+++ b/src/utils/keystore.util.ts
@@ -1,0 +1,148 @@
+import {
+  createHash,
+  createCipheriv,
+  createDecipheriv,
+  scryptSync,
+  pbkdf2Sync,
+  randomBytes,
+  randomUUID,
+} from "crypto";
+
+/**
+ * EIP-2335 BLS12-381 keystore (#50 ④, #5). Encrypts a 32-byte BLS secret at rest with
+ * an operator passphrase so a leaked disk/backup does NOT expose the key. Same format
+ * Ethereum validators use, same curve — a natural fit for the DVT's BLS key.
+ *
+ * Implemented on Node's built-in crypto (scrypt/pbkdf2 + aes-128-ctr + sha256) and
+ * VERIFIED byte-for-byte against the two official EIP-2335 test vectors (see spec).
+ * No third-party crypto dependency.
+ *
+ * SECURITY BOUNDARY: this protects the key AT REST only. The passphrase must NOT be
+ * stored next to the file — supply it at boot via NODE_KEY_PASSPHRASE (env / systemd
+ * credential). It does not protect against a compromised running process (the key is
+ * decrypted in memory to sign) nor against someone who has the passphrase.
+ */
+export interface Eip2335Keystore {
+  crypto: {
+    kdf: {
+      function: "scrypt" | "pbkdf2";
+      params: Record<string, unknown>;
+      message: "";
+    };
+    checksum: { function: "sha256"; params: Record<string, never>; message: string };
+    cipher: { function: "aes-128-ctr"; params: { iv: string }; message: string };
+  };
+  pubkey?: string;
+  uuid: string;
+  version: 4;
+  description?: string;
+}
+
+/** EIP-2335 password prep: NFKD-normalize, strip C0/C1 control codes, UTF-8 encode. */
+function normalizePassword(pw: string): Buffer {
+  const nfkd = pw.normalize("NFKD");
+  const stripped = [...nfkd]
+    .filter(ch => {
+      const c = ch.codePointAt(0)!;
+      return !(c <= 0x1f || (c >= 0x7f && c <= 0x9f));
+    })
+    .join("");
+  return Buffer.from(stripped, "utf8");
+}
+
+/** scrypt memory ≈ 128·N·r. For N=262144,r=8 that's ~256 MB; give Node headroom. */
+function deriveKey(kdf: Eip2335Keystore["crypto"]["kdf"], password: Buffer, salt: Buffer): Buffer {
+  const p = kdf.params as Record<string, number>;
+  const dklen = Number(p.dklen ?? 32);
+  if (kdf.function === "scrypt") {
+    return scryptSync(password, salt, dklen, {
+      N: Number(p.n),
+      r: Number(p.r),
+      p: Number(p.p),
+      maxmem: 512 * 1024 * 1024,
+    });
+  }
+  // pbkdf2, prf = hmac-sha256 (the only prf EIP-2335 defines)
+  return pbkdf2Sync(password, salt, Number(p.c), dklen, "sha256");
+}
+
+/**
+ * Decrypt an EIP-2335 keystore to the raw 32-byte BLS secret. Throws on a wrong
+ * passphrase (checksum mismatch) — never returns a garbage key.
+ */
+export function decryptKeystore(ks: Eip2335Keystore, password: string): Uint8Array {
+  const salt = Buffer.from(String(ks.crypto.kdf.params.salt), "hex");
+  const dk = deriveKey(ks.crypto.kdf, normalizePassword(password), salt);
+  const cipherMsg = Buffer.from(ks.crypto.cipher.message, "hex");
+
+  // checksum = sha256(decryption_key[16:32] ‖ cipher.message) — verifies the passphrase.
+  const checksum = createHash("sha256")
+    .update(Buffer.concat([dk.subarray(16, 32), cipherMsg]))
+    .digest("hex");
+  if (checksum !== ks.crypto.checksum.message) {
+    throw new Error("keystore: wrong passphrase (checksum mismatch)");
+  }
+
+  // AES-128-CTR with key = decryption_key[0:16], iv from the keystore.
+  const iv = Buffer.from(ks.crypto.cipher.params.iv, "hex");
+  const decipher = createDecipheriv("aes-128-ctr", dk.subarray(0, 16), iv);
+  const secret = Buffer.concat([decipher.update(cipherMsg), decipher.final()]);
+  return new Uint8Array(secret);
+}
+
+export interface EncryptOpts {
+  kdf?: "scrypt" | "pbkdf2";
+  pubkey?: string;
+  description?: string;
+  /** Deterministic salt/iv/uuid — ONLY for tests / golden-vector verification. */
+  salt?: Buffer;
+  iv?: Buffer;
+  uuid?: string;
+}
+
+/** Encrypt a 32-byte BLS secret into an EIP-2335 keystore. */
+export function encryptKeystore(
+  secret: Uint8Array,
+  password: string,
+  opts: EncryptOpts = {}
+): Eip2335Keystore {
+  if (secret.length !== 32) {
+    throw new Error("keystore: BLS secret must be 32 bytes");
+  }
+  const kdfFn = opts.kdf ?? "scrypt";
+  const salt = opts.salt ?? randomBytes(32);
+  const iv = opts.iv ?? randomBytes(16);
+  const params: Record<string, unknown> =
+    kdfFn === "scrypt"
+      ? { dklen: 32, n: 262144, p: 1, r: 8, salt: salt.toString("hex") }
+      : { dklen: 32, c: 262144, prf: "hmac-sha256", salt: salt.toString("hex") };
+
+  const dk = deriveKey({ function: kdfFn, params, message: "" }, normalizePassword(password), salt);
+  const cipher = createCipheriv("aes-128-ctr", dk.subarray(0, 16), iv);
+  const cipherMsg = Buffer.concat([cipher.update(Buffer.from(secret)), cipher.final()]);
+  const checksum = createHash("sha256")
+    .update(Buffer.concat([dk.subarray(16, 32), cipherMsg]))
+    .digest("hex");
+
+  return {
+    crypto: {
+      kdf: { function: kdfFn, params, message: "" },
+      checksum: { function: "sha256", params: {}, message: checksum },
+      cipher: {
+        function: "aes-128-ctr",
+        params: { iv: iv.toString("hex") },
+        message: cipherMsg.toString("hex"),
+      },
+    },
+    pubkey: opts.pubkey,
+    uuid: opts.uuid ?? randomUUID(),
+    version: 4,
+    description: opts.description,
+  };
+}
+
+/** Structural check — is this object an EIP-2335 keystore (vs a plaintext node_state)? */
+export function isKeystore(obj: unknown): obj is Eip2335Keystore {
+  const o = obj as Eip2335Keystore;
+  return !!o && typeof o === "object" && o.version === 4 && !!o.crypto?.cipher?.message;
+}


### PR DESCRIPTION
Encrypt the node's BLS key at rest (EIP-2335) so a stolen disk / leaked backup can't read it — the physical-board (i.MX93) threat. Passphrase supplied from OUTSIDE the disk at boot (env now; typed/EdgeLock pluggable later).

## Verified
- **Crypto core vs BOTH official EIP-2335 test vectors** (scrypt + pbkdf2 reproduce spec cipher+checksum byte-for-byte; decrypt recovers the secret) — Node built-in crypto, no dependency.
- **End-to-end**: migrate plaintext → keystore → boot decrypts (correct pass) / **fails closed** (missing + wrong pass) → decrypted plaintext **never** re-persisted.
- 174 tests (13 new: 8 official-vector + 5 node-integration), type-check + prettier + lint(0 err) clean.

## What's here
- `keystore.util`: `encrypt/decryptKeystore` (scrypt/pbkdf2 + aes-128-ctr + sha256).
- `node.service`: decrypts an on-disk `keystore` with `NODE_KEY_PASSPHRASE` at load; fail-closed on missing/wrong pass; `saveNodeState` never writes the decrypted key back (leak guard).
- `scripts/encrypt-node-key.mjs`: plaintext → keystore migration (passphrase via env; `.bak` for verify-then-delete).
- `docs/KEYSTORE.md`: migration + passphrase delivery (systemd cred / env / typed) + the at-rest-only boundary.

## Design notes
- **Plaintext still accepted** (dev/legacy) — encryption is **opt-in per node** via the migration, so existing dvt1/2/3 + all tests keep working; no forced big-bang migration.
- Passphrase = env for now (self-heal-friendly, per your call); the human-typed / EdgeLock options are documented as the future pluggable sources.
- Boundary is at-rest only (not a running-process or HSM guarantee) — stated plainly in the docs.