### PR TITLE
feat(#163): DVT stake-gated, operator-bound, PoP registration (Plan A v3)

### DIFF
--- a/contracts/src/AAStarValidator.sol
+++ b/contracts/src/AAStarValidator.sol
@@ -516,26 +516,72 @@ contract AAStarValidator {
         require(publicKey.length == G1_POINT_LENGTH, "Invalid public key length");
         require(!isRegistered[nodeId], "Node already registered");
 
-        if (requireStake) {
-            // Permissionless-but-staked: caller is the operator; one node per operator.
-            require(operatorNode[msg.sender] == bytes32(0), "Operator already has a node");
-            require(_isStaked(msg.sender), "Operator not staked for ROLE_DVT");
-            nodeOperator[nodeId] = msg.sender;
-            operatorNode[msg.sender] = nodeId;
-            emit NodeBound(nodeId, msg.sender);
-        } else {
-            // Bootstrap: owner registers; bind operator = owner as a placeholder and mark
-            // the node bootstrap so it retires when staking becomes mandatory.
-            require(msg.sender == owner, "Bootstrap: only owner");
-            nodeOperator[nodeId] = owner;
-            isBootstrap[nodeId] = true;
-        }
+        // Bootstrap-only path: owner registers (permissioned launch). Once staking is
+        // mandatory, the staked path (registerWithProof) is the only way in — this keeps
+        // the rogue-key-vulnerable no-PoP registration off the permissionless surface.
+        require(!requireStake, "Staking on: use registerWithProof");
+        require(msg.sender == owner, "Bootstrap: only owner");
+        nodeOperator[nodeId] = owner;
+        isBootstrap[nodeId] = true;
 
         registeredKeys[nodeId] = publicKey;
         isRegistered[nodeId] = true;
         registeredNodes.push(nodeId);
 
         emit PublicKeyRegistered(nodeId, publicKey);
+    }
+
+    /**
+     * @dev Permissionless-but-staked registration (Plan A v3). The OPERATOR (msg.sender)
+     * registers their own node: stake-gated, one node per operator, nodeId derived from
+     * the pubkey (no squatting), and a BLS proof-of-possession that closes the rogue-key
+     * hole in the aggregate verifier (you cannot PoP a key whose secret you don't hold).
+     *
+     * PoP: prove e(g1, popSig) == e(pubkey, popPoint). popPoint is the caller-provided G2
+     * message point their BLS key signed; soundness of possession holds for ANY popPoint
+     * (forging needs the pubkey's secret), so no on-chain hash-to-curve is required.
+     *
+     * @param publicKey  G1 public key (128 bytes, EIP-2537)
+     * @param popPoint   G2 message point the key signed (256 bytes)
+     * @param popSig     G2 BLS signature over popPoint by `publicKey` (256 bytes)
+     */
+    function registerWithProof(
+        bytes calldata publicKey,
+        bytes calldata popPoint,
+        bytes calldata popSig
+    ) external {
+        require(requireStake, "Staked registration disabled");
+        require(publicKey.length == G1_POINT_LENGTH, "Invalid public key length");
+        bytes32 nodeId = keccak256(publicKey); // derived — not caller-chosen (no squatting)
+        require(!isRegistered[nodeId], "Node already registered");
+        require(operatorNode[msg.sender] == bytes32(0), "Operator already has a node");
+        require(_isStaked(msg.sender), "Operator not staked for ROLE_DVT");
+        require(_verifyPoP(publicKey, popPoint, popSig), "Invalid proof-of-possession");
+
+        nodeOperator[nodeId] = msg.sender;
+        operatorNode[msg.sender] = nodeId;
+        registeredKeys[nodeId] = publicKey;
+        isRegistered[nodeId] = true;
+        registeredNodes.push(nodeId);
+
+        emit NodeBound(nodeId, msg.sender);
+        emit PublicKeyRegistered(nodeId, publicKey);
+    }
+
+    /// @dev BLS proof-of-possession: e(g1, popSig) == e(pubkey, popPoint). Reuses the same
+    ///      pairing construction as aggregate verification (generator, sig | -pubkey, point).
+    function _verifyPoP(
+        bytes calldata pubkey,
+        bytes calldata popPoint,
+        bytes calldata popSig
+    ) internal view returns (bool) {
+        if (popPoint.length != G2_POINT_LENGTH || popSig.length != G2_POINT_LENGTH) return false;
+        bytes memory negPk = _negateG1Point(pubkey);
+        bytes memory pairingData = _buildPairingDataFromComponents(negPk, popSig, popPoint);
+        (bool ok, bytes memory result) = PAIRING_PRECOMPILE.staticcall{ gas: _calculateRequiredGas(1) }(
+            pairingData
+        );
+        return ok && result.length == 32 && bytes32(result) == bytes32(uint256(1));
     }
 
     /**

--- a/contracts/src/AAStarValidator.sol
+++ b/contracts/src/AAStarValidator.sol
@@ -514,6 +514,7 @@ contract AAStarValidator {
     function registerPublicKey(bytes32 nodeId, bytes calldata publicKey) external {
         require(nodeId != bytes32(0), "Invalid node ID");
         require(publicKey.length == G1_POINT_LENGTH, "Invalid public key length");
+        require(!_isInfinity(publicKey), "pubkey is infinity");
         require(!isRegistered[nodeId], "Node already registered");
 
         // Bootstrap-only path: owner registers (permissioned launch). Once staking is
@@ -552,6 +553,11 @@ contract AAStarValidator {
     ) external {
         require(requireStake, "Staked registration disabled");
         require(publicKey.length == G1_POINT_LENGTH, "Invalid public key length");
+        // Reject the point-at-infinity encoding (all-zero). e(_, infinity)=1, so an
+        // infinity pubkey/popPoint/popSig would make the PoP pairing trivially pass with
+        // NO secret known — the rogue-key bypass this check exists to close. Non-infinity
+        // but off-subgroup points are rejected by the pairing precompile's subgroup check.
+        require(!_isInfinity(publicKey), "pubkey is infinity");
         bytes32 nodeId = keccak256(publicKey); // derived — not caller-chosen (no squatting)
         require(!isRegistered[nodeId], "Node already registered");
         require(operatorNode[msg.sender] == bytes32(0), "Operator already has a node");
@@ -576,12 +582,23 @@ contract AAStarValidator {
         bytes calldata popSig
     ) internal view returns (bool) {
         if (popPoint.length != G2_POINT_LENGTH || popSig.length != G2_POINT_LENGTH) return false;
+        // Defence in depth: infinity in any pairing operand makes e(...)=1 trivially.
+        if (_isInfinity(pubkey) || _isInfinity(popPoint) || _isInfinity(popSig)) return false;
         bytes memory negPk = _negateG1Point(pubkey);
         bytes memory pairingData = _buildPairingDataFromComponents(negPk, popSig, popPoint);
         (bool ok, bytes memory result) = PAIRING_PRECOMPILE.staticcall{ gas: _calculateRequiredGas(1) }(
             pairingData
         );
         return ok && result.length == 32 && bytes32(result) == bytes32(uint256(1));
+    }
+
+    /// @dev EIP-2537 encodes the point at infinity as all-zero bytes. Reject it wherever a
+    ///      non-degenerate point is required (a pairing with infinity is the identity in GT).
+    function _isInfinity(bytes calldata point) internal pure returns (bool) {
+        for (uint256 i = 0; i < point.length; i++) {
+            if (point[i] != 0) return false;
+        }
+        return true;
     }
 
     /**
@@ -592,10 +609,11 @@ contract AAStarValidator {
      */
     function syncNode(bytes32 nodeId) external {
         require(isRegistered[nodeId], "Node not registered");
-        bool stale = isBootstrap[nodeId] ? requireStake : !_isStaked(nodeOperator[nodeId]);
+        address op = nodeOperator[nodeId]; // capture before _deactivate clears it
+        bool stale = isBootstrap[nodeId] ? requireStake : !_isStaked(op);
         require(stale, "Node still active");
         _deactivate(nodeId);
-        emit NodeDeactivated(nodeId, nodeOperator[nodeId]);
+        emit NodeDeactivated(nodeId, op);
     }
 
     /// @dev True if `op` holds ROLE_DVT and >= minStake locked GToken in the Registry.
@@ -640,6 +658,9 @@ contract AAStarValidator {
      * @param newPublicKey New G1 public key (128 bytes)
      */
     function updatePublicKey(bytes32 nodeId, bytes calldata newPublicKey) external onlyOwner {
+        // Once staking is mandatory, keys are managed only via the staked path (nodeId is
+        // keccak(pubkey) + fresh PoP). An owner key-swap would break that invariant.
+        require(!requireStake, "Staking on: re-register via registerWithProof");
         require(isRegistered[nodeId], "Node not registered");
         require(newPublicKey.length == G1_POINT_LENGTH, "Invalid public key length");
 
@@ -657,6 +678,13 @@ contract AAStarValidator {
     function revokePublicKey(bytes32 nodeId) external onlyOwner {
         require(isRegistered[nodeId], "Node not registered");
 
+        // Clear the operator binding too, or operatorNode[op] would stay pointing at a
+        // revoked node and strand the operator's 1:1 slot forever (syncNode can't fix it
+        // once isRegistered is false).
+        address op = nodeOperator[nodeId];
+        if (op != address(0) && operatorNode[op] == nodeId) delete operatorNode[op];
+        delete nodeOperator[nodeId];
+        delete isBootstrap[nodeId];
         delete registeredKeys[nodeId];
         isRegistered[nodeId] = false;
 
@@ -679,14 +707,22 @@ contract AAStarValidator {
      * @param publicKeys Corresponding public key array
      */
     function batchRegisterPublicKeys(bytes32[] calldata nodeIds, bytes[] calldata publicKeys) external onlyOwner {
+        // Bootstrap-only, same as registerPublicKey: once staking is mandatory this owner
+        // path would let stake-less/PoP-less nodes into the active set.
+        require(!requireStake, "Staking on: use registerWithProof");
         require(nodeIds.length == publicKeys.length, "Array length mismatch");
         require(nodeIds.length > 0, "Empty arrays");
 
         for (uint256 i = 0; i < nodeIds.length; i++) {
             require(nodeIds[i] != bytes32(0), "Invalid node ID");
             require(publicKeys[i].length == G1_POINT_LENGTH, "Invalid public key length");
+            require(!_isInfinity(publicKeys[i]), "pubkey is infinity");
             require(!isRegistered[nodeIds[i]], "Node already registered");
 
+            // Mark bootstrap + bind operator=owner so these nodes are consistent with the
+            // registerPublicKey bootstrap path (and retire when requireStake turns on).
+            nodeOperator[nodeIds[i]] = owner;
+            isBootstrap[nodeIds[i]] = true;
             registeredKeys[nodeIds[i]] = publicKeys[i];
             isRegistered[nodeIds[i]] = true;
             registeredNodes.push(nodeIds[i]);

--- a/contracts/src/AAStarValidator.sol
+++ b/contracts/src/AAStarValidator.sol
@@ -658,11 +658,16 @@ contract AAStarValidator {
      * @param newPublicKey New G1 public key (128 bytes)
      */
     function updatePublicKey(bytes32 nodeId, bytes calldata newPublicKey) external onlyOwner {
-        // Once staking is mandatory, keys are managed only via the staked path (nodeId is
-        // keccak(pubkey) + fresh PoP). An owner key-swap would break that invariant.
-        require(!requireStake, "Staking on: re-register via registerWithProof");
+        // Only bootstrap nodes' keys are owner-mutable. A staked node is immutable-key
+        // (nodeId == keccak(pubkey), PoP-bound); to change it, re-register via
+        // registerWithProof. Otherwise the owner could toggle staking off, swap a staked
+        // node to a rogue/PoP-less key, and toggle back on — injecting an unbacked signer
+        // (the exact owner-injection this design removes). Codex #163 review.
         require(isRegistered[nodeId], "Node not registered");
+        require(isBootstrap[nodeId], "Not a bootstrap node");
+        require(!requireStake, "Staking on: re-register via registerWithProof");
         require(newPublicKey.length == G1_POINT_LENGTH, "Invalid public key length");
+        require(!_isInfinity(newPublicKey), "pubkey is infinity");
 
         bytes memory oldKey = registeredKeys[nodeId];
         registeredKeys[nodeId] = newPublicKey;

--- a/contracts/src/AAStarValidator.sol
+++ b/contracts/src/AAStarValidator.sol
@@ -21,6 +21,14 @@ pragma solidity ^0.8.19;
  * - Support batch operations
  * - Support signature verification through node identifiers
  */
+/// @dev Minimal read-interface into the SuperPaymaster Registry (economic single source
+///      of truth). AAStarValidator READS role+stake; it never manages stake itself.
+///      Matches Registry.hasRole (public mapping getter) + getEffectiveStake view.
+interface IDVTRegistry {
+    function hasRole(bytes32 roleId, address user) external view returns (bool);
+    function getEffectiveStake(address user, bytes32 roleId) external view returns (uint256);
+}
+
 contract AAStarValidator {
     // =============================================================
     //                           STORAGE
@@ -37,6 +45,26 @@ contract AAStarValidator {
 
     /// @dev Contract owner for administrative functions
     address public owner;
+
+    // --- Stake-binding (issue #163, Plan A v3) -----------------------------------
+    /// @dev The operator (EOA / Safe) that owns a nodeId — the slashing/economic anchor.
+    mapping(bytes32 => address) public nodeOperator;
+    /// @dev Reverse 1:1 lock — one active nodeId per operator in staked mode (anti-Sybil:
+    ///      one GToken stake cannot back many signing identities).
+    mapping(address => bytes32) public operatorNode;
+    /// @dev Nodes registered by the owner during bootstrap (no stake). Retired once
+    ///      requireStake is turned on (migration boundary — no permanent bypass).
+    mapping(bytes32 => bool) public isBootstrap;
+
+    /// @dev SuperPaymaster Registry (stake source of truth). Owner/Safe-settable.
+    address public registry;
+    /// @dev When true, registerPublicKey is permissionless-but-staked and bootstrap nodes
+    ///      stop being accepted in verification. When false, owner-only bootstrap (default).
+    bool public requireStake;
+    /// @dev Minimum locked GToken stake under ROLE_DVT to register/stay active.
+    uint256 public minStake;
+    /// @dev DVT role id in the SuperPaymaster Registry.
+    bytes32 public constant ROLE_DVT = keccak256("DVT");
 
     /// @dev Modifier to restrict access to owner only
     modifier onlyOwner() {
@@ -91,6 +119,13 @@ contract AAStarValidator {
     event PublicKeyRevoked(bytes32 indexed nodeId);
 
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    // --- Stake-binding (Plan A v3) ---
+    event NodeBound(bytes32 indexed nodeId, address indexed operator);
+    event NodeDeactivated(bytes32 indexed nodeId, address indexed operator);
+    event RegistrySet(address indexed registry);
+    event RequireStakeSet(bool requireStake);
+    event MinStakeSet(uint256 minStake);
 
     function validateAggregateSignature(
         bytes32[] calldata nodeIds,
@@ -193,6 +228,10 @@ contract AAStarValidator {
 
         for (uint256 i = 0; i < nodeIds.length; i++) {
             require(isRegistered[nodeIds[i]], "Node not registered");
+            // Migration boundary (Plan A v3): once staking is mandatory, bootstrap-era
+            // nodes are no longer accepted until they re-register via the staked path.
+            // Cheap per-node read; NOT a full per-verify stake re-check (that's syncNode).
+            require(!(requireStake && isBootstrap[nodeIds[i]]), "Bootstrap node retired");
             publicKeys[i] = registeredKeys[nodeIds[i]];
         }
     }
@@ -455,8 +494,19 @@ contract AAStarValidator {
     // =============================================================
 
     /**
-     * @dev Register public key for new node
-     * Anyone can register, but in the future must verify PNT token staking
+     * @dev Register a node's BLS public key, binding it to a staked operator (Plan A v3).
+     *
+     * Two modes, controlled by `requireStake`:
+     *  - requireStake == false (bootstrap, default): owner-only, records nodeId->pubkey and
+     *    marks it `isBootstrap` (retired once staking is turned on). Preserves the initial
+     *    permissioned launch where the owner grows the quorum.
+     *  - requireStake == true (permissionless-but-staked): the OPERATOR (msg.sender) calls;
+     *    they must hold ROLE_DVT and >= minStake locked GToken in the SuperPaymaster
+     *    Registry, and one operator may back only ONE active nodeId (anti-Sybil).
+     *
+     * NOTE (increment 1): does NOT yet enforce BLS proof-of-possession. Because the
+     * aggregate verifier sums pubkeys (rogue-key vulnerable), PoP MUST be added before
+     * relying on requireStake=true in production. Tracked in #163.
      *
      * @param nodeId Unique node identifier
      * @param publicKey G1 public key (128 bytes)
@@ -466,16 +516,75 @@ contract AAStarValidator {
         require(publicKey.length == G1_POINT_LENGTH, "Invalid public key length");
         require(!isRegistered[nodeId], "Node already registered");
 
-        // TODO: Verify that msg.sender has staked PNT tokens before allowing registration
-        // Example implementation:
-        // IPNTToken pntToken = IPNTToken(pntTokenAddress);
-        // require(pntToken.getStakedAmount(msg.sender) >= minimumStakeAmount, "Insufficient PNT stake");
+        if (requireStake) {
+            // Permissionless-but-staked: caller is the operator; one node per operator.
+            require(operatorNode[msg.sender] == bytes32(0), "Operator already has a node");
+            require(_isStaked(msg.sender), "Operator not staked for ROLE_DVT");
+            nodeOperator[nodeId] = msg.sender;
+            operatorNode[msg.sender] = nodeId;
+            emit NodeBound(nodeId, msg.sender);
+        } else {
+            // Bootstrap: owner registers; bind operator = owner as a placeholder and mark
+            // the node bootstrap so it retires when staking becomes mandatory.
+            require(msg.sender == owner, "Bootstrap: only owner");
+            nodeOperator[nodeId] = owner;
+            isBootstrap[nodeId] = true;
+        }
 
         registeredKeys[nodeId] = publicKey;
         isRegistered[nodeId] = true;
         registeredNodes.push(nodeId);
 
         emit PublicKeyRegistered(nodeId, publicKey);
+    }
+
+    /**
+     * @dev Permissionless re-validation: deactivate a node whose economic backing is gone.
+     *  - a staked node whose operator lost ROLE_DVT or dropped below minStake, or
+     *  - a bootstrap node once requireStake has been turned on (migration boundary).
+     * Anyone (a keeper) may call it — the check is authoritative, not the caller.
+     */
+    function syncNode(bytes32 nodeId) external {
+        require(isRegistered[nodeId], "Node not registered");
+        bool stale = isBootstrap[nodeId] ? requireStake : !_isStaked(nodeOperator[nodeId]);
+        require(stale, "Node still active");
+        _deactivate(nodeId);
+        emit NodeDeactivated(nodeId, nodeOperator[nodeId]);
+    }
+
+    /// @dev True if `op` holds ROLE_DVT and >= minStake locked GToken in the Registry.
+    function _isStaked(address op) internal view returns (bool) {
+        if (registry == address(0) || op == address(0)) return false;
+        IDVTRegistry r = IDVTRegistry(registry);
+        return r.hasRole(ROLE_DVT, op) && r.getEffectiveStake(op, ROLE_DVT) >= minStake;
+    }
+
+    /// @dev Remove a node from the active set + clear its operator binding.
+    function _deactivate(bytes32 nodeId) internal {
+        address op = nodeOperator[nodeId];
+        isRegistered[nodeId] = false;
+        delete registeredKeys[nodeId];
+        delete nodeOperator[nodeId];
+        delete isBootstrap[nodeId];
+        if (op != address(0) && operatorNode[op] == nodeId) delete operatorNode[op];
+        // registeredNodes[] is an unordered enumeration; leave the stale id (isRegistered
+        // gates all reads). Compaction is a gas trade-off deferred to a later pass.
+    }
+
+    // --- Owner/Safe governance (transfer owner to a Gnosis Safe after init) --------
+    function setRegistry(address _registry) external onlyOwner {
+        registry = _registry;
+        emit RegistrySet(_registry);
+    }
+
+    function setRequireStake(bool _v) external onlyOwner {
+        requireStake = _v;
+        emit RequireStakeSet(_v);
+    }
+
+    function setMinStake(uint256 _v) external onlyOwner {
+        minStake = _v;
+        emit MinStakeSet(_v);
     }
 
     /**

--- a/contracts/test/AAStarValidator.t.sol
+++ b/contracts/test/AAStarValidator.t.sol
@@ -165,18 +165,22 @@ contract AAStarValidatorTest is Test {
         validator.registerPublicKey(NODE_ID_1, PARTICIPANT_KEY_2);
     }
 
-    function test_RegisterPublicKey_AnyoneCanRegister() public {
-        // After removing onlyOwner modifier, anyone should be able to register
+    function test_RegisterPublicKey_BootstrapIsOwnerOnly() public {
+        // Plan A v3 (#163): in bootstrap mode (requireStake=false, default) registration is
+        // owner-only — the old "anyone, no stake" path is removed (Sybil/rogue-key risk).
         address nonOwner = address(0x5678);
         vm.prank(nonOwner);
-
-        vm.expectEmit(true, false, false, true);
-        emit PublicKeyRegistered(NODE_ID_1, PARTICIPANT_KEY_1);
-
+        vm.expectRevert("Bootstrap: only owner");
         validator.registerPublicKey(NODE_ID_1, PARTICIPANT_KEY_1);
 
+        // Owner can register in bootstrap; the node is marked bootstrap + bound to owner.
+        vm.expectEmit(true, false, false, true);
+        emit PublicKeyRegistered(NODE_ID_1, PARTICIPANT_KEY_1);
+        validator.registerPublicKey(NODE_ID_1, PARTICIPANT_KEY_1);
         assertEq(validator.registeredKeys(NODE_ID_1), PARTICIPANT_KEY_1, "Key should be registered");
         assertTrue(validator.isRegistered(NODE_ID_1), "Node should be marked as registered");
+        assertTrue(validator.isBootstrap(NODE_ID_1), "bootstrap node");
+        assertEq(validator.nodeOperator(NODE_ID_1), address(this), "operator = owner in bootstrap");
     }
 
     // =============================================================

--- a/contracts/test/AAStarValidatorStakeBinding.t.sol
+++ b/contracts/test/AAStarValidatorStakeBinding.t.sol
@@ -22,22 +22,24 @@ contract AAStarValidatorStakeBindingTest is Test {
 
     bytes32 constant ROLE_DVT = keccak256("DVT");
     uint256 constant MIN_STAKE = 30 ether;
-    // 128-byte G1 keys (content irrelevant for the binding logic under test).
-    bytes KEY_A = new bytes(128);
-    bytes KEY_B = new bytes(128);
-    bytes32 constant NODE_A = keccak256("nodeA");
-    bytes32 constant NODE_B = keccak256("nodeB");
-
     address operator1 = address(0xA1);
     address operator2 = address(0xA2);
+
+    // Known-answer PoP vectors (noble @noble/curves, DST AASTAR_DVT_POP_BLS12381G2_XMD:SHA-256_SSWU_RO_).
+    // e(g1, POP_SIG) == e(PUB, POP_POINT) holds (noble verify=true).
+    bytes V1_PUB = hex"000000000000000000000000000000001928f3beb93519eecf0145da903b40a4c97dca00b21f12ac0df3be9116ef2ef27b2ae6bcd4c5bc2d54ef5a70627efcb700000000000000000000000000000000108dadbaa4b636445639d5ae3089b3c43a8a1d47818edd1839d7383959a41c10fdc66849cfa1b08c5a11ec7e28981a1c";
+    bytes V1_POP_POINT = hex"00000000000000000000000000000000086f6d0cdf889dc6d987ee9c5446c45b206775fcf7c60ebde4e1e0250fb04be1a86a296bae0bad3bc81f27a76ada86d50000000000000000000000000000000007906cd1575d26570463bee46945d8ef77539df93d13e22aef436f0d538bb28d916d581fe1d71bbc0d62c7ba4b8edccb000000000000000000000000000000000389f33b01cdf1a04f541764ddf51ec2dbed718f2398f75f3fce7725c072d9340263ae52e06b7bf52eb3ab7ec72ca92000000000000000000000000000000000137ab9e24a3c0f637ae65f212458ed1a10250d85da32ae5bf72842062c6819149945d2c7091607690f3c61f53e52c8b9";
+    bytes V1_POP_SIG = hex"00000000000000000000000000000000022bd720bb56d00b92f4995e3e4342b2cb7fb8ca8d54e58ff20adc76760c2340c2b1e119a19db8640cffad3f0e41c850000000000000000000000000000000000eafa2b92b141289b6e189c9a0a4d3b1b9a9cd0e5d51b43482b7a1b261134049a601bda9fabb054c36e790fb6b6ca3e7000000000000000000000000000000000b6232777504abec794edddee6bb8b38b9fa3292d2376a3ddaed676bf0b5406c981292eb50ec1b2d8dffec72f1f9aab400000000000000000000000000000000019da6fdf9a09dd3b32c75176c36426118bab60496b3583c817dde359dadf72fc87ddd09a192bd32766938a92cf4ff5c";
+
+    bytes V2_PUB = hex"0000000000000000000000000000000019cdf3807146e68e041314ca93e1fee0991224ec2a74beb2866816fd0826ce7b6263ee31e953a86d1b72cc2215a577930000000000000000000000000000000007481b1f261aabacf45c6e4fc278055441bfaf99f604d1f835c0752ac9742b4522c9f5c77db40989e7da608505d48616";
+    bytes V2_POP_POINT = hex"000000000000000000000000000000000f73f219e773dd1ef6fe2d10a5c49921d8cdd723b33b34087a52617d067a2de251e945553c8bd9734ad664fb6f345fce00000000000000000000000000000000123a13ec0543aeed2afad244f7e4c9bc20ee778d6354947cbea7410820f8d907f5c025bb8e8598cbf5902a7982e1b323000000000000000000000000000000000c02e3e68f26c168a018698ba779272abe9ff0279d6f5280afc9fb3ab0160c06ecbddf2d33d0423b79a2751695f51a11000000000000000000000000000000000eaaecfea4c6ce69a92154ca4b2804d2f7017d468be09aeb0de61c4dbe2c2553afe4193e20a948afc382b97a2d36e8e4";
+    bytes V2_POP_SIG = hex"000000000000000000000000000000000142a94144f05fff297d81f022f4a81023db248cd04b17530e474c0a264a4a1970f53d0fdd2c75eb40767f198461e08e0000000000000000000000000000000004dfd312738238f2004bde8c5376d6262f6ae91ff8ba8d94fa4c840b1682fcfb1994738cf7a861f34411f0d3eead6f79000000000000000000000000000000000f0db21327df7234d3dab4e226caadea2f1447fa9ea5969db23d84dcf0b985c93de4dcf45041cb8c23ea8e276d0a60350000000000000000000000000000000000c933d07622ca99f9f8d9648354c07ab2d41fb7804d43f605adea83f6e4713e2d66e3ad0790ec39bf193ef3529c6693";
 
     function setUp() public {
         validator = new AAStarValidator(); // deployer (this) = owner
         registry = new StakeRegistry();
         validator.setRegistry(address(registry));
         validator.setMinStake(MIN_STAKE);
-        KEY_A[0] = 0x01;
-        KEY_B[0] = 0x02;
     }
 
     function _stake(address op, uint256 amount) internal {
@@ -45,44 +47,59 @@ contract AAStarValidatorStakeBindingTest is Test {
         registry.setStake(op, amount);
     }
 
-    // --- staked mode: permissionless-but-staked ---------------------------------
-    function test_StakedMode_operatorRegisters() public {
+    // --- staked registration with PoP -------------------------------------------
+    function test_registerWithProof_success() public {
         validator.setRequireStake(true);
         _stake(operator1, MIN_STAKE);
 
         vm.prank(operator1);
-        validator.registerPublicKey(NODE_A, KEY_A);
+        validator.registerWithProof(V1_PUB, V1_POP_POINT, V1_POP_SIG);
 
-        assertTrue(validator.isRegistered(NODE_A));
-        assertEq(validator.nodeOperator(NODE_A), operator1);
-        assertEq(validator.operatorNode(operator1), NODE_A);
-        assertFalse(validator.isBootstrap(NODE_A));
+        bytes32 nodeId = keccak256(V1_PUB);
+        assertTrue(validator.isRegistered(nodeId));
+        assertEq(validator.nodeOperator(nodeId), operator1);
+        assertEq(validator.operatorNode(operator1), nodeId);
+        assertFalse(validator.isBootstrap(nodeId));
     }
 
-    function test_StakedMode_rejectsUnstaked() public {
+    function test_registerWithProof_rejectsBadPoP() public {
         validator.setRequireStake(true);
-        // operator1 has no role/stake
+        _stake(operator1, MIN_STAKE);
+        // V1 pubkey with V2's signature/point → pairing fails.
+        vm.prank(operator1);
+        vm.expectRevert("Invalid proof-of-possession");
+        validator.registerWithProof(V1_PUB, V2_POP_POINT, V2_POP_SIG);
+    }
+
+    function test_registerWithProof_rejectsUnstaked() public {
+        validator.setRequireStake(true);
         vm.prank(operator1);
         vm.expectRevert("Operator not staked for ROLE_DVT");
-        validator.registerPublicKey(NODE_A, KEY_A);
+        validator.registerWithProof(V1_PUB, V1_POP_POINT, V1_POP_SIG);
     }
 
-    function test_StakedMode_rejectsBelowMinStake() public {
+    function test_registerWithProof_rejectsBelowMinStake() public {
         validator.setRequireStake(true);
         _stake(operator1, MIN_STAKE - 1);
         vm.prank(operator1);
         vm.expectRevert("Operator not staked for ROLE_DVT");
-        validator.registerPublicKey(NODE_A, KEY_A);
+        validator.registerWithProof(V1_PUB, V1_POP_POINT, V1_POP_SIG);
     }
 
-    function test_StakedMode_oneNodePerOperator() public {
+    function test_registerWithProof_oneNodePerOperator() public {
         validator.setRequireStake(true);
         _stake(operator1, MIN_STAKE);
         vm.startPrank(operator1);
-        validator.registerPublicKey(NODE_A, KEY_A);
+        validator.registerWithProof(V1_PUB, V1_POP_POINT, V1_POP_SIG);
         vm.expectRevert("Operator already has a node"); // anti-Sybil: 1 stake -> 1 node
-        validator.registerPublicKey(NODE_B, KEY_B);
+        validator.registerWithProof(V2_PUB, V2_POP_POINT, V2_POP_SIG);
         vm.stopPrank();
+    }
+
+    function test_registerPublicKey_revertsWhenStaking() public {
+        validator.setRequireStake(true);
+        vm.expectRevert("Staking on: use registerWithProof");
+        validator.registerPublicKey(keccak256("x"), V1_PUB);
     }
 
     // --- syncNode: deactivate stale nodes ---------------------------------------
@@ -90,36 +107,35 @@ contract AAStarValidatorStakeBindingTest is Test {
         validator.setRequireStake(true);
         _stake(operator1, MIN_STAKE);
         vm.prank(operator1);
-        validator.registerPublicKey(NODE_A, KEY_A);
+        validator.registerWithProof(V1_PUB, V1_POP_POINT, V1_POP_SIG);
+        bytes32 nodeId = keccak256(V1_PUB);
 
-        // operator exits stake
         registry.setStake(operator1, 0);
         registry.setRole(ROLE_DVT, operator1, false);
 
-        validator.syncNode(NODE_A); // anyone can call
-        assertFalse(validator.isRegistered(NODE_A), "deactivated");
-        assertEq(validator.operatorNode(operator1), bytes32(0), "binding cleared -> can re-stake+register");
+        validator.syncNode(nodeId); // anyone can call
+        assertFalse(validator.isRegistered(nodeId), "deactivated");
+        assertEq(validator.operatorNode(operator1), bytes32(0), "binding cleared -> can re-stake");
     }
 
     function test_syncNode_revertsWhenStillActive() public {
         validator.setRequireStake(true);
         _stake(operator1, MIN_STAKE);
         vm.prank(operator1);
-        validator.registerPublicKey(NODE_A, KEY_A);
+        validator.registerWithProof(V1_PUB, V1_POP_POINT, V1_POP_SIG);
         vm.expectRevert("Node still active");
-        validator.syncNode(NODE_A);
+        validator.syncNode(keccak256(V1_PUB));
     }
 
     // --- migration boundary: bootstrap nodes retire when staking turns on -------
     function test_migrationBoundary_bootstrapRetiredOnToggle() public {
-        // bootstrap register (owner, requireStake=false)
-        validator.registerPublicKey(NODE_A, KEY_A);
-        assertTrue(validator.isBootstrap(NODE_A));
+        bytes32 nodeId = keccak256("bootnode");
+        validator.registerPublicKey(nodeId, V1_PUB); // bootstrap (owner, requireStake=false)
+        assertTrue(validator.isBootstrap(nodeId));
 
-        // turn staking on -> bootstrap node can be synced out
         validator.setRequireStake(true);
-        validator.syncNode(NODE_A);
-        assertFalse(validator.isRegistered(NODE_A), "bootstrap node retired");
+        validator.syncNode(nodeId);
+        assertFalse(validator.isRegistered(nodeId), "bootstrap node retired");
     }
 
     function test_onlyOwner_setters() public {

--- a/contracts/test/AAStarValidatorStakeBinding.t.sol
+++ b/contracts/test/AAStarValidatorStakeBinding.t.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+import "../src/AAStarValidator.sol";
+
+/// SuperPaymaster Registry stand-in for the stake gate (IDVTRegistry): role + locked stake.
+contract StakeRegistry is IDVTRegistry {
+    mapping(bytes32 => mapping(address => bool)) public roles;
+    mapping(address => uint256) public stake;
+
+    function setRole(bytes32 roleId, address user, bool v) external { roles[roleId][user] = v; }
+    function setStake(address user, uint256 amount) external { stake[user] = amount; }
+
+    function hasRole(bytes32 roleId, address user) external view returns (bool) { return roles[roleId][user]; }
+    function getEffectiveStake(address user, bytes32) external view returns (uint256) { return stake[user]; }
+}
+
+contract AAStarValidatorStakeBindingTest is Test {
+    AAStarValidator validator;
+    StakeRegistry registry;
+
+    bytes32 constant ROLE_DVT = keccak256("DVT");
+    uint256 constant MIN_STAKE = 30 ether;
+    // 128-byte G1 keys (content irrelevant for the binding logic under test).
+    bytes KEY_A = new bytes(128);
+    bytes KEY_B = new bytes(128);
+    bytes32 constant NODE_A = keccak256("nodeA");
+    bytes32 constant NODE_B = keccak256("nodeB");
+
+    address operator1 = address(0xA1);
+    address operator2 = address(0xA2);
+
+    function setUp() public {
+        validator = new AAStarValidator(); // deployer (this) = owner
+        registry = new StakeRegistry();
+        validator.setRegistry(address(registry));
+        validator.setMinStake(MIN_STAKE);
+        KEY_A[0] = 0x01;
+        KEY_B[0] = 0x02;
+    }
+
+    function _stake(address op, uint256 amount) internal {
+        registry.setRole(ROLE_DVT, op, true);
+        registry.setStake(op, amount);
+    }
+
+    // --- staked mode: permissionless-but-staked ---------------------------------
+    function test_StakedMode_operatorRegisters() public {
+        validator.setRequireStake(true);
+        _stake(operator1, MIN_STAKE);
+
+        vm.prank(operator1);
+        validator.registerPublicKey(NODE_A, KEY_A);
+
+        assertTrue(validator.isRegistered(NODE_A));
+        assertEq(validator.nodeOperator(NODE_A), operator1);
+        assertEq(validator.operatorNode(operator1), NODE_A);
+        assertFalse(validator.isBootstrap(NODE_A));
+    }
+
+    function test_StakedMode_rejectsUnstaked() public {
+        validator.setRequireStake(true);
+        // operator1 has no role/stake
+        vm.prank(operator1);
+        vm.expectRevert("Operator not staked for ROLE_DVT");
+        validator.registerPublicKey(NODE_A, KEY_A);
+    }
+
+    function test_StakedMode_rejectsBelowMinStake() public {
+        validator.setRequireStake(true);
+        _stake(operator1, MIN_STAKE - 1);
+        vm.prank(operator1);
+        vm.expectRevert("Operator not staked for ROLE_DVT");
+        validator.registerPublicKey(NODE_A, KEY_A);
+    }
+
+    function test_StakedMode_oneNodePerOperator() public {
+        validator.setRequireStake(true);
+        _stake(operator1, MIN_STAKE);
+        vm.startPrank(operator1);
+        validator.registerPublicKey(NODE_A, KEY_A);
+        vm.expectRevert("Operator already has a node"); // anti-Sybil: 1 stake -> 1 node
+        validator.registerPublicKey(NODE_B, KEY_B);
+        vm.stopPrank();
+    }
+
+    // --- syncNode: deactivate stale nodes ---------------------------------------
+    function test_syncNode_deactivatesUnstakedOperator() public {
+        validator.setRequireStake(true);
+        _stake(operator1, MIN_STAKE);
+        vm.prank(operator1);
+        validator.registerPublicKey(NODE_A, KEY_A);
+
+        // operator exits stake
+        registry.setStake(operator1, 0);
+        registry.setRole(ROLE_DVT, operator1, false);
+
+        validator.syncNode(NODE_A); // anyone can call
+        assertFalse(validator.isRegistered(NODE_A), "deactivated");
+        assertEq(validator.operatorNode(operator1), bytes32(0), "binding cleared -> can re-stake+register");
+    }
+
+    function test_syncNode_revertsWhenStillActive() public {
+        validator.setRequireStake(true);
+        _stake(operator1, MIN_STAKE);
+        vm.prank(operator1);
+        validator.registerPublicKey(NODE_A, KEY_A);
+        vm.expectRevert("Node still active");
+        validator.syncNode(NODE_A);
+    }
+
+    // --- migration boundary: bootstrap nodes retire when staking turns on -------
+    function test_migrationBoundary_bootstrapRetiredOnToggle() public {
+        // bootstrap register (owner, requireStake=false)
+        validator.registerPublicKey(NODE_A, KEY_A);
+        assertTrue(validator.isBootstrap(NODE_A));
+
+        // turn staking on -> bootstrap node can be synced out
+        validator.setRequireStake(true);
+        validator.syncNode(NODE_A);
+        assertFalse(validator.isRegistered(NODE_A), "bootstrap node retired");
+    }
+
+    function test_onlyOwner_setters() public {
+        vm.prank(operator1);
+        vm.expectRevert("Only owner can call this function");
+        validator.setRequireStake(true);
+    }
+}

--- a/contracts/test/AAStarValidatorStakeBinding.t.sol
+++ b/contracts/test/AAStarValidatorStakeBinding.t.sol
@@ -143,4 +143,65 @@ contract AAStarValidatorStakeBindingTest is Test {
         vm.expectRevert("Only owner can call this function");
         validator.setRequireStake(true);
     }
+
+    // --- Codex fixes: infinity-point PoP bypass (was a critical hole) ------------
+    function test_PoP_rejectsInfinityPopPointAndSig() public {
+        validator.setRequireStake(true);
+        _stake(operator1, MIN_STAKE);
+        bytes memory zeroG2 = new bytes(256); // EIP-2537 infinity = all-zero
+        vm.prank(operator1);
+        // Without the fix this passed for ANY pubkey with no secret known.
+        vm.expectRevert("Invalid proof-of-possession");
+        validator.registerWithProof(V1_PUB, zeroG2, zeroG2);
+    }
+
+    function test_registerWithProof_rejectsInfinityPubkey() public {
+        validator.setRequireStake(true);
+        _stake(operator1, MIN_STAKE);
+        bytes memory zeroG1 = new bytes(128);
+        bytes memory zeroG2 = new bytes(256);
+        vm.prank(operator1);
+        vm.expectRevert("pubkey is infinity");
+        validator.registerWithProof(zeroG1, zeroG2, zeroG2);
+    }
+
+    function test_bootstrap_rejectsInfinityPubkey() public {
+        bytes memory zeroG1 = new bytes(128);
+        vm.expectRevert("pubkey is infinity");
+        validator.registerPublicKey(keccak256("x"), zeroG1);
+    }
+
+    // --- Codex fixes: revoke clears the 1:1 binding -----------------------------
+    function test_revoke_clearsOperatorBinding() public {
+        validator.setRequireStake(true);
+        _stake(operator1, MIN_STAKE);
+        vm.prank(operator1);
+        validator.registerWithProof(V1_PUB, V1_POP_POINT, V1_POP_SIG);
+        bytes32 nodeId = keccak256(V1_PUB);
+
+        validator.revokePublicKey(nodeId); // owner revokes
+        assertEq(validator.operatorNode(operator1), bytes32(0), "1:1 slot freed");
+
+        // operator can now register a fresh node (V2) — not stranded
+        vm.prank(operator1);
+        validator.registerWithProof(V2_PUB, V2_POP_POINT, V2_POP_SIG);
+        assertTrue(validator.isRegistered(keccak256(V2_PUB)));
+    }
+
+    // --- Codex fixes: owner bootstrap paths disabled once staking is on ---------
+    function test_batchRegister_revertsWhenStaking() public {
+        validator.setRequireStake(true);
+        bytes32[] memory ids = new bytes32[](1);
+        bytes[] memory keys = new bytes[](1);
+        ids[0] = keccak256("n");
+        keys[0] = V1_PUB;
+        vm.expectRevert("Staking on: use registerWithProof");
+        validator.batchRegisterPublicKeys(ids, keys);
+    }
+
+    function test_updatePublicKey_revertsWhenStaking() public {
+        validator.setRequireStake(true);
+        vm.expectRevert("Staking on: re-register via registerWithProof");
+        validator.updatePublicKey(keccak256("n"), V1_PUB);
+    }
 }

--- a/contracts/test/AAStarValidatorStakeBinding.t.sol
+++ b/contracts/test/AAStarValidatorStakeBinding.t.sol
@@ -199,9 +199,25 @@ contract AAStarValidatorStakeBindingTest is Test {
         validator.batchRegisterPublicKeys(ids, keys);
     }
 
-    function test_updatePublicKey_revertsWhenStaking() public {
+    function test_updatePublicKey_bootstrapNodeRevertsWhenStaking() public {
+        bytes32 nodeId = keccak256("boot");
+        validator.registerPublicKey(nodeId, V1_PUB); // bootstrap node (requireStake=false)
         validator.setRequireStake(true);
         vm.expectRevert("Staking on: re-register via registerWithProof");
-        validator.updatePublicKey(keccak256("n"), V1_PUB);
+        validator.updatePublicKey(nodeId, V2_PUB);
+    }
+
+    // Codex #163 verification pass: owner cannot toggle staking off, mutate a STAKED
+    // (non-bootstrap) node's key to a PoP-less one, and toggle back on.
+    function test_updatePublicKey_cannotMutateStakedNode() public {
+        validator.setRequireStake(true);
+        _stake(operator1, MIN_STAKE);
+        vm.prank(operator1);
+        validator.registerWithProof(V1_PUB, V1_POP_POINT, V1_POP_SIG);
+        bytes32 stakedNode = keccak256(V1_PUB);
+
+        validator.setRequireStake(false); // owner toggles staking off
+        vm.expectRevert("Not a bootstrap node"); // staked node key is immutable
+        validator.updatePublicKey(stakedNode, V2_PUB);
     }
 }


### PR DESCRIPTION
Unifies the DVT crypto layer (AAStarValidator) with the SuperPaymaster economic layer (issue #163 / SuperPaymaster #321): a signing node is now bound to a GToken-staked operator, with a BLS proof-of-possession. Designed with the threat model that the DVT is a SECOND factor (can grief, not steal) — so defenses are right-sized, not over-built.

## What's in
- **registerWithProof(pubkey, popPoint, popSig)** — the staked path: `nodeId=keccak256(pubkey)` (no squatting), stake-gated via the SuperPaymaster Registry (`hasRole(ROLE_DVT)` + `getEffectiveStake ≥ minStake`), **one node per operator** (anti-Sybil), and a **BLS PoP** (`e(g1,popSig)==e(pubkey,popPoint)`, reusing the EIP-2537 pairing — no on-chain hash-to-curve).
- **registerPublicKey / batchRegister** — bootstrap-only (owner), retire once staking is mandatory.
- **requireStake toggle** (owner/Safe), **syncNode** permissionless deactivation on stake loss, **nodeOperator view** for slashing linkage, Safe-multisig governance setters.
- Single stake source of truth = SuperPaymaster (read-only here); SuperPaymaster core unchanged.

## Process (per the plan)
- Design → **Codex challenge** (v2) → **threat-calibrated v3** (dropped over-defense: per-verify liveness, heavy timelock) → implement (increments 1+2) → **Codex reviewed the diff** → caught a **critical infinity-point PoP bypass** I introduced → fixed → **Codex verification pass** → caught the updatePublicKey owner-injection path → fixed.
- Codex confirmed the caller-chosen-popPoint approach is **sound once infinity is rejected**.

## Tests
**76/76 forge tests.** Regression tests for: infinity PoP bypass, zero-pubkey, one-node-per-operator, stake-gate, syncNode, migration boundary, revoke-clears-binding, batch/update guards, staked-node-key-immutable.

## Follow-ups (app-side, separate)
node_state.json `nodeId=keccak(pubkey)` for the staked flow · onboarding `stake` subcommand · full cross-repo E2E. PoP requires `requireStake=true` before production reliance (bootstrap onlyOwner today).

Relates #163, SuperPaymaster #321, #157, #50.