### PR TITLE
feat(#163): Plan A v3 validator deploy script + Sepolia E2E proven

### DIFF
--- a/contracts/script/DeployStakeBoundValidator.s.sol
+++ b/contracts/script/DeployStakeBoundValidator.s.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+/**
+ * @title DeployStakeBoundValidator
+ * @dev Deploy the Plan A v3 AAStarValidator (#163) and wire it to the SuperPaymaster
+ *      Registry (stake source of truth). SuperPaymaster registry/staking/GToken are
+ *      already deployed — this only deploys the DVT validator and points it at them.
+ *
+ *  SP_REGISTRY  = SuperPaymaster Registry (default: Sepolia deploy)
+ *  MIN_STAKE    = ROLE_DVT floor (default 30 ether GToken)
+ *  REQUIRE_STAKE= "true" to enable permissionless-but-staked immediately (default false =
+ *                 bootstrap; toggle on after nodes re-register via registerWithProof)
+ *
+ *  forge script script/DeployStakeBoundValidator.s.sol --rpc-url <RPC> --private-key <KEY> --broadcast
+ */
+
+import "forge-std/Script.sol";
+import "../src/AAStarValidator.sol";
+
+contract DeployStakeBoundValidator is Script {
+    // SuperPaymaster Sepolia (deployments/config.sepolia.json)
+    address constant SP_REGISTRY_SEPOLIA = 0xf5Bf37ca83AfdAab73691bA7eCcDfA69b8708E71;
+
+    function run() external {
+        address registry = vm.envOr("SP_REGISTRY", SP_REGISTRY_SEPOLIA);
+        uint256 minStake = vm.envOr("MIN_STAKE", uint256(30 ether));
+        bool requireStake = vm.envOr("REQUIRE_STAKE", false);
+
+        vm.startBroadcast();
+
+        AAStarValidator validator = new AAStarValidator();
+        validator.setRegistry(registry);
+        validator.setMinStake(minStake);
+        if (requireStake) validator.setRequireStake(true);
+
+        vm.stopBroadcast();
+
+        console.log("=== Plan A v3 AAStarValidator deployed ===");
+        console.log("validator:    ", address(validator));
+        console.log("registry:     ", registry);
+        console.log("minStake:     ", minStake);
+        console.log("requireStake: ", requireStake);
+        console.log("owner:        ", validator.owner());
+        console.log("");
+        console.log("Next: transfer owner to a Gnosis Safe; nodes stake+registerRole on SP");
+        console.log("then registerWithProof (deploy/onboarding/onboard.mjs pop <operator>).");
+    }
+}

--- a/deployments/AAStarValidator.abi.json
+++ b/deployments/AAStarValidator.abi.json
@@ -1,0 +1,657 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "ROLE_DVT",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "batchRegisterPublicKeys",
+    "inputs": [
+      {
+        "name": "nodeIds",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      },
+      {
+        "name": "publicKeys",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getGasEstimate",
+    "inputs": [
+      {
+        "name": "nodeCount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "gasEstimate",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getRegisteredNodeCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "count",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRegisteredNodes",
+    "inputs": [
+      {
+        "name": "offset",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "limit",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "nodeIds",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      },
+      {
+        "name": "publicKeys",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getSignatureFormat",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "format",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "isBootstrap",
+    "inputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isRegistered",
+    "inputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "minStake",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "nodeOperator",
+    "inputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "operatorNode",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "registerPublicKey",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "publicKey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "registerWithProof",
+    "inputs": [
+      {
+        "name": "publicKey",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "popPoint",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "popSig",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "registeredKeys",
+    "inputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "registeredNodes",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "registry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "requireStake",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "revokePublicKey",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setMinStake",
+    "inputs": [
+      {
+        "name": "_v",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setRegistry",
+    "inputs": [
+      {
+        "name": "_registry",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setRequireStake",
+    "inputs": [
+      {
+        "name": "_v",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "syncNode",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updatePublicKey",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "newPublicKey",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "validateAggregateSignature",
+    "inputs": [
+      {
+        "name": "nodeIds",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      },
+      {
+        "name": "signature",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "messagePoint",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "isValid",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "verifyAggregateSignature",
+    "inputs": [
+      {
+        "name": "nodeIds",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      },
+      {
+        "name": "signature",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "messagePoint",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "isValid",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "MinStakeSet",
+    "inputs": [
+      {
+        "name": "minStake",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NodeBound",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NodeDeactivated",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PublicKeyRegistered",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "publicKey",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PublicKeyRevoked",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PublicKeyUpdated",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "oldKey",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "newKey",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RegistrySet",
+    "inputs": [
+      {
+        "name": "registry",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RequireStakeSet",
+    "inputs": [
+      {
+        "name": "requireStake",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SignatureValidated",
+    "inputs": [
+      {
+        "name": "messageHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "publicKeysCount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "isValid",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      },
+      {
+        "name": "gasUsed",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  }
+]

--- a/deployments/validator.sepolia.json
+++ b/deployments/validator.sepolia.json
@@ -1,0 +1,5 @@
+{
+  "network": "sepolia",
+  "aaStarValidator": "0xaAc436f262F6beeC4dd02008DA8ED20AD69E4cC2",
+  "note": "Plan A v3 stake-bound (#163)"
+}

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,80 @@
+# Release flow — DVT validator + SuperPaymaster + SDK sync
+
+The DVT validator (this repo) reads stake from SuperPaymaster and is consumed by
+the SDK. A release therefore spans three repos. This is the settled flow.
+
+## Roles
+
+- **SuperPaymaster** (`AAStarCommunity/SuperPaymaster`) — economic layer:
+  Registry / GTokenStaking / GToken / DVTValidator. Deployed once per network;
+  the DVT validator only READS it (`hasRole`, `getEffectiveStake`). Rarely
+  re-released.
+- **YetAnotherAA-Validator** (this repo) — the `AAStarValidator` (Plan A v3):
+  pubkey registry + aggregate BLS verify + stake-gated `registerWithProof`.
+  Re-deployed on a contract change.
+- **aastar-sdk** — consumes the validator ABI + address (aggregation wire,
+  nodeIds).
+
+## 1. Contract change → test
+
+```bash
+cd contracts && forge test          # unit + stake-binding + local E2E (Path A)
+```
+
+## 2. Deploy the validator (needs the SuperPaymaster addresses for the target network)
+
+```bash
+# SP addresses live in SuperPaymaster/deployments/config.<network>.json (registry, gToken,
+# staking). The script defaults to the Sepolia registry; override via SP_REGISTRY.
+cd contracts
+SP_REGISTRY=0x… MIN_STAKE=30000000000000000000 \
+  forge script script/DeployStakeBoundValidator.s.sol --rpc-url <RPC> --private-key <KEY> --broadcast
+# → prints the deployed validator address. Keys: SuperPaymaster/.env.sepolia (Jason/Anni).
+```
+
+Leave `requireStake=false` (bootstrap) until nodes have re-registered via
+`registerWithProof`; then `cast send <validator> "setRequireStake(bool)" true`.
+
+## 3. Wire nodes (per operator) — stake → PoP register
+
+```bash
+# stake (operator, on SuperPaymaster): approve + registerRole(ROLE_DVT, 30 GToken)
+cast send <GToken> "approve(address,uint256)" <staking> 33000000000000000000 --private-key <op>
+cast send <registry> "registerRole(bytes32,address,bytes)" \
+  0x3b5016dc6721b132ddcb7027030b137a739df81e419695dae0899a866c1c514d <op> \
+  $(cast abi-encode "x(uint256)" 30000000000000000000) --private-key <op>
+
+# PoP + register (on the validator)
+node deploy/onboarding/onboard.mjs pop <operatorAddress>   # emits registerWithProof params
+cast send <validator> "registerWithProof(bytes,bytes,bytes)" <pubkey> <popPoint> <popSig> --private-key <op>
+```
+
+Verified end-to-end on Sepolia (validator
+`0xaAc436f262F6beeC4dd02008DA8ED20AD69E4cC2`):
+`validateAggregateSignature([nodeId], coSig, messagePoint) == true`.
+
+## 4. Sync the SDK (ABI + address)
+
+```bash
+VALIDATOR=<deployed> NETWORK=<network> ./scripts/sync-validator-abi.sh ../aastar-sdk
+#   → writes deployments/AAStarValidator.abi.json + validator.<network>.json,
+#     and copies them into the SDK's abi/ + deployments/. Then in the SDK:
+#     commit, bump the version, and update any hardcoded nodeId config (nodeId is now
+#     keccak256(pubkey) — see aastar-sdk#270).
+```
+
+## 5. Release notes
+
+- Version-bump this repo (`npm run release:patch|minor|major`), tag, GitHub
+  release.
+- If the ABI/address changed, land the SDK PR (step 4) referencing this release.
+- Cross-link: SuperPaymaster #321 (stake source), aastar-sdk #270 (SDK impact),
+  #163.
+
+## Notes
+
+- Stake is managed ONLY in SuperPaymaster — never redeploy
+  GToken/registry/staking for a DVT-validator change; just re-point
+  `SP_REGISTRY`.
+- Governance: transfer the validator `owner` to a Gnosis Safe multisig after
+  deploy (`transferOwnership`).

--- a/scripts/sync-validator-abi.sh
+++ b/scripts/sync-validator-abi.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Export the AAStarValidator ABI + a deployed-address record for the SDK to consume
+# (aastar-sdk#270). Run after a validator (re)deploy. No secrets touched.
+#
+#   VALIDATOR=0x… NETWORK=sepolia ./scripts/sync-validator-abi.sh [sdk-path]
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+NETWORK="${NETWORK:-sepolia}"
+VALIDATOR="${VALIDATOR:?set VALIDATOR=0x… (the deployed Plan A v3 validator)}"
+OUT="$REPO/deployments"; mkdir -p "$OUT"
+
+# 1. ABI from the forge artifact (source of truth after `forge build`).
+( cd "$REPO/contracts" && forge build src/AAStarValidator.sol >/dev/null )
+jq '.abi' "$REPO/contracts/out/AAStarValidator.sol/AAStarValidator.json" > "$OUT/AAStarValidator.abi.json"
+echo "✅ ABI → $OUT/AAStarValidator.abi.json"
+
+# 2. Address record (append/replace per network).
+ADDR_FILE="$OUT/validator.$NETWORK.json"
+jq -n --arg v "$VALIDATOR" --arg n "$NETWORK" \
+  '{network:$n, aaStarValidator:$v, note:"Plan A v3 stake-bound (#163)"}' > "$ADDR_FILE"
+echo "✅ address → $ADDR_FILE ($VALIDATOR)"
+
+# 3. Optional: copy into the SDK if a path is given.
+SDK="${1:-}"
+if [ -n "$SDK" ] && [ -d "$SDK" ]; then
+  mkdir -p "$SDK/abi" "$SDK/deployments"
+  cp "$OUT/AAStarValidator.abi.json" "$SDK/abi/AAStarValidator.abi.json"
+  cp "$ADDR_FILE" "$SDK/deployments/"
+  echo "✅ synced into SDK at $SDK (abi/ + deployments/) — commit + bump there"
+else
+  echo "ℹ  pass the aastar-sdk path to auto-copy: ./scripts/sync-validator-abi.sh ../aastar-sdk"
+fi


### PR DESCRIPTION
The deploy+wire script for the Plan A v3 stake-bound AAStarValidator, and **Path B (testnet) is complete** — the full flow ran on **Sepolia**:

| Step | Result |
|---|---|
| deploy + wire validator | `0xaAc436f262F6beeC4dd02008DA8ED20AD69E4cC2` (owner Jason, → SP registry, minStake 30 GT) |
| stake | Jason `approve` + `Registry.registerRole(ROLE_DVT, 30 GT)` → hasRole=true, stake=30 |
| `setRequireStake(true)` | ✅ |
| `registerWithProof(pubkey, popPoint, popSig)` | ✅ isRegistered=true, nodeOperator=Jason |
| `validateAggregateSignature([nodeId], coSig, messagePoint)` | **true** |

SuperPaymaster registry/staking/GToken are unchanged (only read). PoP generated by `deploy/onboarding/onboard.mjs pop`. Local Path A (forge, PR #167) + testnet Path B both green.

Deployed addresses recorded. Related: SuperPaymaster #321, aastar-sdk #270.