### PR TITLE
chore(release): v1.9.0 — Plan A v3 DVT stake-binding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yetanotheraa-validator",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yetanotheraa-validator",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cli": "^11.0.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yetanotheraa-validator",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Production-ready BLS signature validation infrastructure for ERC-4337 account abstraction",
   "main": "dist/main.js",
   "type": "module",


### PR DESCRIPTION
Captures the Plan A v3 work (#163): stake-gated + operator-bound + BLS-PoP DVT registration, onboarding `pop` subcommand + nodeId=keccak(pubkey), deploy script + release flow. Full E2E proven local (forge) + Sepolia (validator 0xaAc436f262F6beeC4dd02008DA8ED20AD69E4cC2). Also backfilled the v1.8.0 tag.

Merge → tag v1.9.0 + GitHub release.