### PR TITLE
chore(#163 Phase1): Sepolia router-validator address + retired-account doc cleanup

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -44,32 +44,23 @@ ERC-4337 compliant smart contract wallets with:
 - **Flexible Validation**: Support for both AAStarValidator and standard ECDSA
 - **Modular Design**: Clean separation between account logic and validation
 
-#### AAStarAccountFactory (v0.6/v0.7/v0.8)
-
-Factory contracts for deterministic account deployment:
-
-- **CREATE2 Deployment**: Deterministic account addresses
-- **Salt-based**: Support for multiple accounts per creator
-- **Version-specific**: Separate factories for each EntryPoint version
+> The account + factory contracts were retired (#163 Phase 1) — see the note below. Account
+> deployment now lives in `airaccount-contract`.
 
 ## Project Structure
+
+> **Note (#163 Phase 1):** the ERC-4337 account + factory contracts (`AAStarAccountBase`,
+> `AAStarAccountV6/7/8`, `AAStarAccountFactoryV6/7/8`) and their `DeployAAStar*` bundle scripts
+> were **retired**. This repo now ships the DVT **validator only**; the production account line is
+> `airaccount-contract`'s `AAStarAirAccountV7` (EntryPoint v0.7, behind its ValidatorRouter).
+> `AAStarValidator` is router-mountable via `IAAStarAlgorithm.validate()` (algId 0x01).
 
 ```
 contracts/
 ├── src/
-│   ├── AAStarValidator.sol              # BLS validator contract
-│   ├── AAStarAccountBase.sol            # Base account implementation
-│   ├── AAStarAccountV6.sol              # EntryPoint v0.6 account
-│   ├── AAStarAccountV7.sol              # EntryPoint v0.7 account
-│   ├── AAStarAccountV8.sol              # EntryPoint v0.8 account
-│   ├── AAStarAccountFactoryV6.sol       # v0.6 factory
-│   ├── AAStarAccountFactoryV7.sol       # v0.7 factory
-│   ├── AAStarAccountFactoryV8.sol       # v0.8 factory
-│   └── interfaces/                      # Contract interfaces
+│   └── AAStarValidator.sol              # DVT BLS validator + IAAStarAlgorithm.validate() (algId 0x01)
 ├── script/
-│   ├── DeployAAStar.s.sol              # v0.6 deployment script
-│   ├── DeployAAStarV7.s.sol            # v0.7 deployment script
-│   └── DeployAAStarV8.s.sol            # v0.8 deployment script
+│   └── DeployStakeBoundValidator.s.sol # deploy + wire to SuperPaymaster Registry (Plan A v3)
 ├── test/                                # Contract tests
 ├── lib/                                 # Dependencies (Foundry)
 ├── foundry.toml                         # Foundry configuration

--- a/deployments/AAStarValidator.abi.json
+++ b/deployments/AAStarValidator.abi.json
@@ -111,6 +111,25 @@
   },
   {
     "type": "function",
+    "name": "hashToG2",
+    "inputs": [
+      {
+        "name": "message",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "isBootstrap",
     "inputs": [
       {
@@ -411,6 +430,30 @@
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "validate",
+    "inputs": [
+      {
+        "name": "hash",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "signature",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
     "type": "function",

--- a/deployments/validator.sepolia.json
+++ b/deployments/validator.sepolia.json
@@ -1,5 +1,5 @@
 {
   "network": "sepolia",
-  "aaStarValidator": "0xaAc436f262F6beeC4dd02008DA8ED20AD69E4cC2",
+  "aaStarValidator": "0x539B9681aFd5BFbCaa655Fe4c6BdcFe1fa7864bC",
   "note": "Plan A v3 stake-bound (#163)"
 }

--- a/src/modules/policy/policy.service.ts
+++ b/src/modules/policy/policy.service.ts
@@ -67,7 +67,9 @@ interface PolicyCall {
 const ALLOW = 0;
 const REQUIRE_DVT = 1;
 
-// Account call surface (contracts/src/AAStarAccountBase.sol).
+// Account call surface — the standard ERC-4337 execute/executeBatch selectors of the
+// production account (airaccount-contract's AAStarAirAccountV7; the local reference
+// accounts were retired, see contracts/README.md).
 const EXECUTE_SELECTOR = ethers.id("execute(address,uint256,bytes)").slice(0, 10);
 const EXECUTE_BATCH_SELECTOR = ethers.id("executeBatch(address[],uint256[],bytes[])").slice(0, 10);
 const NULL_SELECTOR = "0x00000000";


### PR DESCRIPTION
Wraps up dvt Phase 1.

- **deployments/**: records the validate()-capable router validator **`0x539B9681aFd5BFbCaa655Fe4c6BdcFe1fa7864bC`** (Sepolia, on-chain verified: `hashToG2`==golden, `validate()`==0 for the golden aggregate) + refreshed ABI for the SDK.
- **eval#346 Info fix**: contracts/README.md file-tree + factory section now reflect validator-only; policy.service.ts comment repointed to airaccount's account surface. Remaining README.md / DVT_VALUE.md mentions are historical analysis (kept intentionally).

dvt Phase 1 is complete (PR #170 validate(), #171 retire legacy, this = redeploy+docs). Handed the address to airaccount for its v0.27.0+ ValidatorRouter mount (CC-10). #163.