### PR TITLE
feat(#163 Phase2 inc1): DVT audit module — credit-over-limit slash proposal (Codex-fixed)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ deploy/node*/.env
 # test coverage report
 coverage/
 dist-bundle/
+deploy/.dvt-test-registration.env
+deploy/node*/data/
+audit-proofs/

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import { OpsAlertModule } from "./modules/ops-alert/ops-alert.module.js";
 import { KeeperModule } from "./modules/keeper/keeper.module.js";
 import { RelayModule } from "./modules/relay/relay.module.js";
 import { X402FacilitatorModule } from "./modules/x402-facilitator/x402-facilitator.module.js";
+import { AuditModule } from "./modules/audit/audit.module.js";
 import { HealthModule } from "./modules/health/health.module.js";
 
 @Module({
@@ -27,6 +28,7 @@ import { HealthModule } from "./modules/health/health.module.js";
     KeeperModule,
     RelayModule,
     X402FacilitatorModule,
+    AuditModule,
     HealthModule,
   ],
 })

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -176,6 +176,30 @@ export default () => {
     x402AuthSecret: process.env.X402_AUTH_SECRET || undefined,
     x402AuthTtlMs: parseInt(process.env.X402_AUTH_TTL_MS || "300000", 10),
 
+    // DVT Phase 2 (目标2) — autonomous audit of SuperPaymaster operators (#—, increment 1).
+    // Opt-in; default off → behavior unchanged. When enabled, a background poll reads each
+    // watchlisted operator's on-chain credit / reputation / stake state from the SuperPaymaster
+    // stack and, on a confirmed credit-over-limit violation, archives a content-addressed slash
+    // proof and files a slash proposal on the DVTValidator. The multi-node BLS quorum co-sign +
+    // verifyAndExecute is DEFERRED to increment 2 (needs gossip aggregation across DVT nodes).
+    //
+    // AUDIT_WATCHLIST: comma-separated operator addresses to monitor.
+    // AUDIT_CREDIT_THRESHOLD_BPS: flag when debt usage ≥ this fraction of the credit limit
+    //   (10000 bps = 100% = availableCredit exhausted / debt exceeds limit).
+    // Registry defaults to the Sepolia SuperPaymaster registry; SuperPaymaster / DVTValidator /
+    // GTokenStaking addresses must be supplied per deployment.
+    auditEnabled: process.env.AUDIT_ENABLED === "true",
+    auditIntervalMs: parseInt(process.env.AUDIT_INTERVAL_MS || "60000", 10),
+    auditWatchlist: parseAllowlist(process.env.AUDIT_WATCHLIST || ""),
+    auditCreditThresholdBps: parseInt(process.env.AUDIT_CREDIT_THRESHOLD_BPS || "10000", 10),
+    auditProofDir: process.env.AUDIT_PROOF_DIR || "./audit-proofs",
+    auditChainId: parseInt(process.env.AUDIT_CHAIN_ID || "11155111", 10),
+    auditRegistryAddress:
+      process.env.AUDIT_REGISTRY_ADDRESS || "0xf5Bf37ca83AfdAab73691bA7eCcDfA69b8708E71",
+    auditSuperPaymasterAddress: process.env.AUDIT_SUPER_PAYMASTER_ADDRESS || undefined,
+    auditDvtValidatorAddress: process.env.AUDIT_DVT_VALIDATOR_ADDRESS || undefined,
+    auditGtokenStakingAddress: process.env.AUDIT_GTOKEN_STAKING_ADDRESS || undefined,
+
     // Gossip Network
     gossipPublicUrl: process.env.GOSSIP_PUBLIC_URL || `ws://localhost:${port}/ws`,
     gossipBootstrapPeers: parseBootstrapPeers(process.env.GOSSIP_BOOTSTRAP_PEERS || ""),

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -184,18 +184,22 @@ export default () => {
     // verifyAndExecute is DEFERRED to increment 2 (needs gossip aggregation across DVT nodes).
     //
     // AUDIT_WATCHLIST: comma-separated operator addresses to monitor.
-    // AUDIT_CREDIT_THRESHOLD_BPS: flag when debt usage ≥ this fraction of the credit limit
-    //   (10000 bps = 100% = availableCredit exhausted / debt exceeds limit).
-    // Registry defaults to the Sepolia SuperPaymaster registry; SuperPaymaster / DVTValidator /
-    // GTokenStaking addresses must be supplied per deployment.
+    // AUDIT_CREDIT_THRESHOLD_BPS: additional margin ON TOP of strict over-limit — flag only
+    //   when debt STRICTLY exceeds the limit AND debt*10000/limit ≥ this (10000 bps = 100%).
+    // FAIL-CLOSED: when AUDIT_ENABLED=true, ALL of AUDIT_REGISTRY_ADDRESS /
+    //   AUDIT_SUPER_PAYMASTER_ADDRESS / AUDIT_DVT_VALIDATOR_ADDRESS must be set explicitly
+    //   (no silent default), and each must have on-chain code (getCode != "0x") at bootstrap
+    //   or the audit self-disables. GTokenStaking is optional (auxiliary evidence only).
+    // AUDIT_COOLDOWN_MS: min gap between proposals for the same operator+rule so an ongoing
+    //   violation is not re-proposed every tick (default 1h).
     auditEnabled: process.env.AUDIT_ENABLED === "true",
     auditIntervalMs: parseInt(process.env.AUDIT_INTERVAL_MS || "60000", 10),
+    auditCooldownMs: parseInt(process.env.AUDIT_COOLDOWN_MS || "3600000", 10),
     auditWatchlist: parseAllowlist(process.env.AUDIT_WATCHLIST || ""),
     auditCreditThresholdBps: parseInt(process.env.AUDIT_CREDIT_THRESHOLD_BPS || "10000", 10),
     auditProofDir: process.env.AUDIT_PROOF_DIR || "./audit-proofs",
     auditChainId: parseInt(process.env.AUDIT_CHAIN_ID || "11155111", 10),
-    auditRegistryAddress:
-      process.env.AUDIT_REGISTRY_ADDRESS || "0xf5Bf37ca83AfdAab73691bA7eCcDfA69b8708E71",
+    auditRegistryAddress: process.env.AUDIT_REGISTRY_ADDRESS || undefined,
     auditSuperPaymasterAddress: process.env.AUDIT_SUPER_PAYMASTER_ADDRESS || undefined,
     auditDvtValidatorAddress: process.env.AUDIT_DVT_VALIDATOR_ADDRESS || undefined,
     auditGtokenStakingAddress: process.env.AUDIT_GTOKEN_STAKING_ADDRESS || undefined,

--- a/src/modules/audit/audit.controller.ts
+++ b/src/modules/audit/audit.controller.ts
@@ -1,0 +1,30 @@
+import { Controller, Get } from "@nestjs/common";
+import { ApiOperation, ApiTags } from "@nestjs/swagger";
+import { AuditService, AuditDetection } from "./audit.service.js";
+
+/**
+ * Read-only status surface for the DVT audit module (Phase 2 / 目标2). Exposes whether
+ * auditing is enabled, its cadence, the watched operators, and the most recent detections
+ * so operators can confirm the auditor is live and see what it has flagged. No secrets and
+ * no write actions — filing/executing slashes happens only from the autonomous poll.
+ */
+@ApiTags("audit")
+@Controller("audit")
+export class AuditController {
+  constructor(private readonly auditService: AuditService) {}
+
+  @Get("status")
+  @ApiOperation({
+    summary: "DVT audit status — enabled flag, cadence, watchlist, recent detections",
+  })
+  async status(): Promise<{
+    enabled: boolean;
+    intervalMs: number;
+    watchlist: string[];
+    lastTickAt: number | null;
+    recentDetections: AuditDetection[];
+    archivedProofCount: number;
+  }> {
+    return this.auditService.getStatus();
+  }
+}

--- a/src/modules/audit/audit.module.ts
+++ b/src/modules/audit/audit.module.ts
@@ -1,0 +1,16 @@
+import { Module } from "@nestjs/common";
+import { AuditService } from "./audit.service.js";
+import { AuditController } from "./audit.controller.js";
+import { BlockchainModule } from "../blockchain/blockchain.module.js";
+
+/**
+ * DVT Phase 2 (目标2) — autonomous operator audit module (increment 1). Reuses the shared
+ * BlockchainService (single provider/wallet) for all chain reads/writes.
+ */
+@Module({
+  imports: [BlockchainModule],
+  controllers: [AuditController],
+  providers: [AuditService],
+  exports: [AuditService],
+})
+export class AuditModule {}

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -569,6 +569,37 @@ describe("AuditService", () => {
     expect(archive.records.every(r => r.proposalTx === undefined)).toBe(true);
   });
 
+  it("Fix (PK): archive.put failure does NOT suppress retry — evidence never lost", async () => {
+    let putCalls = 0;
+    const records: SlashProof[] = [];
+    const flakyArchive: IProofArchive = {
+      async put(proof: SlashProof) {
+        putCalls++;
+        if (putCalls === 1) throw new Error("ENOSPC: disk full");
+        records.push(proof);
+        return { proofHash: proof.proofHash, location: `mem://${proof.proofHash}` };
+      },
+      async has(proofHash: string) {
+        return records.some(r => r.proofHash === proofHash);
+      },
+      async count() {
+        return records.length;
+      },
+    };
+    const blockchain = overLimitBlockchain({
+      createSlashProposal: async () => ({ txHash: "0xABC", proposalId: 1n }),
+    });
+    blockchain.getBlockNumber = async () => 5000; // SAME violation@block both ticks
+    const svc = makeService(blockchain, makeConfig(), flakyArchive);
+
+    await svc.tick(); // put throws → recordStableKey NOT reached
+    expect(records).toHaveLength(0);
+    // The in-memory stableKey must NOT have suppressed the same violation — a later tick retries.
+    await svc.tick();
+    expect(putCalls).toBe(2);
+    expect(records).toHaveLength(1); // evidence eventually persisted (invariant held)
+  });
+
   // ── FIX 4: proof carries the REAL on-chain proposal id (no fabrication) ─────────
   it("Fix 4: the proof carries the REAL on-chain proposal id parsed from the event", async () => {
     const blockchain = overLimitBlockchain({

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -1,4 +1,3 @@
-import { jest } from "@jest/globals";
 import { AuditService } from "./audit.service.js";
 import { IProofArchive, SlashProof, computeProofHash } from "./proof-archive.js";
 
@@ -7,10 +6,12 @@ const REGISTRY = "0xf5Bf37ca83AfdAab73691bA7eCcDfA69b8708E71";
 const SUPER_PAYMASTER = "0x" + "34".repeat(20);
 const DVT_VALIDATOR = "0x" + "56".repeat(20);
 const GTOKEN_STAKING = "0x" + "78".repeat(20);
+const BLOCK = 12_345;
 
 const BASE_CONFIG: Record<string, unknown> = {
   auditEnabled: true,
   auditIntervalMs: 60_000,
+  auditCooldownMs: 3_600_000,
   auditWatchlist: [OPERATOR],
   auditCreditThresholdBps: 10_000,
   auditChainId: 11155111,
@@ -27,22 +28,29 @@ function makeConfig(overrides: Record<string, unknown> = {}) {
 }
 
 /**
- * Blockchain mock. Defaults model a HEALTHY operator (availableCredit == creditLimit →
- * usage 0bps → no violation). Override getAvailableCredit to model exhausted credit.
+ * Blockchain mock. Defaults model a HEALTHY operator: debt (0) ≤ creditLimit (1000) → no
+ * violation. Override getDebt to model a genuine over-limit (debt > creditLimit). getCode
+ * returns real bytecode so the fail-closed bootstrap existence check passes by default.
  */
 function makeBlockchain(
   overrides: Partial<{
-    getCreditLimit: () => Promise<bigint>;
-    getAvailableCredit: () => Promise<bigint>;
-    getGlobalReputation: () => Promise<bigint>;
-    getRoleLockAmount: () => Promise<bigint>;
+    getBlockNumber: () => Promise<number>;
+    getCode: (addr: string) => Promise<string>;
+    getCreditLimit: (addr: string, op: string, bt?: number) => Promise<bigint>;
+    getAvailableCredit: (addr: string, op: string, bt?: number) => Promise<bigint>;
+    getDebt: (addr: string, op: string, bt?: number) => Promise<bigint | null>;
+    getGlobalReputation: (addr: string, op: string, bt?: number) => Promise<bigint>;
+    getRoleLockAmount: (...args: any[]) => Promise<bigint>;
     createSlashProposal: (...args: any[]) => Promise<string>;
     getWalletAddress: () => string | null;
   }> = {}
 ): any {
   return {
+    getBlockNumber: overrides.getBlockNumber ?? (async () => BLOCK),
+    getCode: overrides.getCode ?? (async () => "0x60006000fd"),
     getCreditLimit: overrides.getCreditLimit ?? (async () => 1000n),
     getAvailableCredit: overrides.getAvailableCredit ?? (async () => 1000n),
+    getDebt: overrides.getDebt ?? (async () => 0n),
     getGlobalReputation: overrides.getGlobalReputation ?? (async () => 500n),
     getRoleLockAmount: overrides.getRoleLockAmount ?? (async () => 42n),
     createSlashProposal: overrides.createSlashProposal ?? (async () => "0xPROPOSALTX"),
@@ -61,6 +69,9 @@ function makeArchive(): IProofArchive & { records: SlashProof[] } {
       if (existing >= 0) records[existing] = proof;
       else records.push(proof);
       return { proofHash: proof.proofHash, location: `mem://${proof.proofHash}` };
+    },
+    async has(proofHash: string) {
+      return records.some(r => r.proofHash === proofHash);
     },
     async count() {
       return records.length;
@@ -86,6 +97,16 @@ function makeService(
   return new AuditService(blockchain, config, makeRegistry(), clock, () => 0, archive);
 }
 
+/** A blockchain whose operator is genuinely OVER limit: debt (2000) > creditLimit (1000). */
+function overLimitBlockchain(overrides: Record<string, any> = {}) {
+  return makeBlockchain({
+    getCreditLimit: async () => 1000n,
+    getAvailableCredit: async () => 0n,
+    getDebt: async () => 2000n,
+    ...overrides,
+  });
+}
+
 describe("AuditService", () => {
   it("registers the audit capability (enabled) with the CapabilityRegistry", () => {
     const registry = makeRegistry();
@@ -93,16 +114,16 @@ describe("AuditService", () => {
     expect(registry.registered).toContain("audit");
   });
 
-  it("disabled → onApplicationBootstrap never schedules a tick", () => {
+  it("disabled → onApplicationBootstrap never schedules a tick", async () => {
     const svc = makeService(makeBlockchain(), makeConfig({ auditEnabled: false }), makeArchive());
-    svc.onApplicationBootstrap();
+    await svc.onApplicationBootstrap();
     expect((svc as any).startupTimer).toBeNull();
     expect((svc as any).timer).toBeNull();
   });
 
-  it("enabled → onApplicationBootstrap schedules a phase-jittered first tick", () => {
+  it("enabled → onApplicationBootstrap schedules a phase-jittered first tick", async () => {
     const svc = makeService(makeBlockchain(), makeConfig(), makeArchive());
-    svc.onApplicationBootstrap();
+    await svc.onApplicationBootstrap();
     // First tick is phase-jittered via setTimeout — startupTimer holds it, interval not armed.
     expect((svc as any).startupTimer).not.toBeNull();
     expect((svc as any).timer).toBeNull();
@@ -110,16 +131,43 @@ describe("AuditService", () => {
     expect((svc as any).startupTimer).toBeNull();
   });
 
-  it("enabled but empty watchlist → does not schedule", () => {
+  it("enabled but empty watchlist → does not schedule", async () => {
     const svc = makeService(makeBlockchain(), makeConfig({ auditWatchlist: [] }), makeArchive());
-    svc.onApplicationBootstrap();
+    await svc.onApplicationBootstrap();
     expect((svc as any).startupTimer).toBeNull();
   });
 
-  it("healthy operator (availableCredit == limit) → no detection, no proposal", async () => {
+  // ── MEDIUM 1: config fail-closed ──────────────────────────────────────────────
+  it("fail-closed: a missing required contract address → DISABLED, never schedules", async () => {
+    const svc = makeService(
+      makeBlockchain(),
+      makeConfig({ auditDvtValidatorAddress: undefined }),
+      makeArchive()
+    );
+    await svc.onApplicationBootstrap();
+    expect((svc as any).startupTimer).toBeNull();
+    expect((await svc.getStatus()).enabled).toBe(false);
+  });
+
+  it("fail-closed: an address with no on-chain code (getCode=0x) → DISABLED", async () => {
+    const blockchain = makeBlockchain({ getCode: async () => "0x" });
+    const svc = makeService(blockchain, makeConfig(), makeArchive());
+    await svc.onApplicationBootstrap();
+    expect((svc as any).startupTimer).toBeNull();
+    expect((await svc.getStatus()).enabled).toBe(false);
+  });
+
+  it("fail-closed: an invalid chainId → DISABLED", async () => {
+    const svc = makeService(makeBlockchain(), makeConfig({ auditChainId: 0 }), makeArchive());
+    await svc.onApplicationBootstrap();
+    expect((svc as any).startupTimer).toBeNull();
+    expect((await svc.getStatus()).enabled).toBe(false);
+  });
+
+  // ── CRITICAL 1: at-limit ≠ over-limit ─────────────────────────────────────────
+  it("healthy operator (debt 0 ≤ limit) → no detection, no proposal", async () => {
     const created: any[] = [];
     const blockchain = makeBlockchain({
-      getAvailableCredit: async () => 1000n, // == limit → usage 0bps
       createSlashProposal: async (...args: any[]) => {
         created.push(args);
         return "0xTX";
@@ -132,11 +180,45 @@ describe("AuditService", () => {
     expect(archive.records).toHaveLength(0);
   });
 
-  it("credit-over-limit → files a proposal AND archives a content-addressed proof with evidence", async () => {
+  it("AT exactly the limit (debt == creditLimit) → NOT flagged (at limit, not over)", async () => {
     const created: any[] = [];
     const blockchain = makeBlockchain({
       getCreditLimit: async () => 1000n,
-      getAvailableCredit: async () => 0n, // debt == limit → usage 10000bps ≥ threshold
+      getAvailableCredit: async () => 0n, // fully used, but that is AT the limit
+      getDebt: async () => 1000n, // debt == limit → NOT over
+      createSlashProposal: async (...args: any[]) => {
+        created.push(args);
+        return "0xTX";
+      },
+    });
+    const archive = makeArchive();
+    const svc = makeService(blockchain, makeConfig(), archive);
+    await svc.tick();
+    expect(created).toHaveLength(0);
+    expect(archive.records).toHaveLength(0);
+  });
+
+  it("fail-safe: debt unreadable (getDebt → null) → SKIP even when availableCredit is 0", async () => {
+    const created: any[] = [];
+    const blockchain = makeBlockchain({
+      getCreditLimit: async () => 1000n,
+      getAvailableCredit: async () => 0n,
+      getDebt: async () => null, // BOTH SP and Registry reads revert
+      createSlashProposal: async (...args: any[]) => {
+        created.push(args);
+        return "0xTX";
+      },
+    });
+    const archive = makeArchive();
+    const svc = makeService(blockchain, makeConfig(), archive);
+    await svc.tick();
+    expect(created).toHaveLength(0);
+    expect(archive.records).toHaveLength(0);
+  });
+
+  it("STRICT over-limit (debt > limit) → files a proposal AND archives a content-addressed proof", async () => {
+    const created: any[] = [];
+    const blockchain = overLimitBlockchain({
       createSlashProposal: async (...args: any[]) => {
         created.push(args);
         return "0xPROPOSALTX";
@@ -160,26 +242,26 @@ describe("AuditService", () => {
     expect(proof.version).toBe("dvt-slash-proof/1");
     expect(proof.operator).toBe(OPERATOR);
     expect(proof.slashLevel).toBe(1);
-    expect(proof.executedTx).toBe("0xPROPOSALTX");
+    expect(proof.proposalTx).toBe("0xPROPOSALTX");
 
-    // Evidence captured, with the raw view sources.
+    // Evidence captured, with the raw view sources + the pinned block.
     expect(proof.evidence.rule).toBe("credit-over-limit");
-    expect(proof.evidence.observed).toBe("1000"); // debt
+    expect(proof.evidence.observed).toBe("2000"); // debt
     expect(proof.evidence.threshold).toBe("1000"); // creditLimit
+    expect(proof.evidence.violationBlock).toBe(BLOCK);
     const sourceNames = proof.evidence.sources.map(s => s.name);
     expect(sourceNames).toContain("Registry.getCreditLimit");
+    expect(sourceNames).toContain("SuperPaymaster.getDebt");
     expect(sourceNames).toContain("SuperPaymaster.getAvailableCredit");
 
-    // proofHash is a real content address: recomputing from the immutable core matches.
+    // proofHash is a real content address over ON-CHAIN identity: recomputing matches.
     const recomputed = computeProofHash({
-      version: proof.version,
       chainId: proof.chainId,
       operator: proof.operator,
-      slashLevel: proof.slashLevel,
-      reason: proof.reason,
-      epoch: proof.epoch,
-      messageHash: proof.messageHash,
-      evidence: proof.evidence,
+      rule: proof.evidence.rule,
+      creditLimit: proof.evidence.threshold,
+      debt: proof.evidence.observed,
+      violationBlock: proof.evidence.violationBlock,
     });
     expect(recomputed).toBe(proof.proofHash);
     expect(proof.proofHash).toMatch(/^0x[0-9a-f]{64}$/);
@@ -191,23 +273,142 @@ describe("AuditService", () => {
     expect(status.archivedProofCount).toBe(1);
   });
 
+  // ── CRITICAL 2: block-pinned reads ────────────────────────────────────────────
+  it("pins EVERY rule input to one block (blockTag threaded from a single getBlockNumber)", async () => {
+    const seen: Record<string, number | undefined> = {};
+    const blockchain = overLimitBlockchain();
+    blockchain.getBlockNumber = async () => 999;
+    blockchain.getCreditLimit = async (_a: string, _o: string, bt?: number) => {
+      seen.limit = bt;
+      return 1000n;
+    };
+    blockchain.getAvailableCredit = async (_a: string, _o: string, bt?: number) => {
+      seen.avail = bt;
+      return 0n;
+    };
+    blockchain.getDebt = async (_a: string, _o: string, bt?: number) => {
+      seen.debt = bt;
+      return 2000n;
+    };
+    const archive = makeArchive();
+    const svc = makeService(blockchain, makeConfig(), archive);
+    await svc.tick();
+    expect(seen.limit).toBe(999);
+    expect(seen.avail).toBe(999);
+    expect(seen.debt).toBe(999);
+    expect(archive.records[0].evidence.violationBlock).toBe(999);
+  });
+
+  // ── HIGH 3: proofHash is wall-clock-free (stable across nodes/ticks) ───────────
+  it("same on-chain violation → same proofHash regardless of observedAt (two nodes agree)", async () => {
+    const nodeA = makeService(overLimitBlockchain(), makeConfig(), makeArchive(), clockAt(1_000));
+    await nodeA.tick();
+    const hashA = (await nodeA.getStatus()).recentDetections[0].proofHash;
+
+    // A different node observing the same violation at a very different wall-clock time.
+    const nodeB = makeService(
+      overLimitBlockchain(),
+      makeConfig(),
+      makeArchive(),
+      clockAt(9_999_999_999)
+    );
+    await nodeB.tick();
+    const hashB = (await nodeB.getStatus()).recentDetections[0].proofHash;
+
+    expect(hashA).toBe(hashB);
+  });
+
   it("content-address is deterministic + idempotent: same violation twice → one archived proof", async () => {
-    const blockchain = makeBlockchain({
-      getCreditLimit: async () => 1000n,
-      getAvailableCredit: async () => 0n,
+    const created: any[] = [];
+    const blockchain = overLimitBlockchain({
+      createSlashProposal: async (...args: any[]) => {
+        created.push(args);
+        return "0xTX";
+      },
     });
     const archive = makeArchive();
-    // Fixed clock so epoch (derived from observedAt) is identical across both ticks → same proofHash.
     const svc = makeService(blockchain, makeConfig(), archive, clockAt(1_700_000_000_000));
     await svc.tick();
     await svc.tick();
     expect(archive.records).toHaveLength(1);
   });
 
-  it("proposal write failure → proof still archived (evidence never lost)", async () => {
-    const blockchain = makeBlockchain({
-      getCreditLimit: async () => 1000n,
-      getAvailableCredit: async () => 0n,
+  // ── HIGH 1: dedup prevents re-proposing the same violation ─────────────────────
+  it("dedup: same violation@block over many ticks → exactly ONE proposal", async () => {
+    const created: any[] = [];
+    const blockchain = overLimitBlockchain({
+      createSlashProposal: async (...args: any[]) => {
+        created.push(args);
+        return "0xTX";
+      },
+    });
+    const archive = makeArchive();
+    const svc = makeService(blockchain, makeConfig(), archive, clockAt(1_700_000_000_000));
+    await svc.tick();
+    await svc.tick();
+    await svc.tick();
+    expect(created).toHaveLength(1);
+  });
+
+  it("dedup: an already-archived proof (prior process) → no new proposal", async () => {
+    const created: any[] = [];
+    const blockchain = overLimitBlockchain({
+      createSlashProposal: async (...args: any[]) => {
+        created.push(args);
+        return "0xTX";
+      },
+    });
+    // Pre-seed the archive with the exact proof for this violation@block.
+    const archive = makeArchive();
+    const identityHash = computeProofHash({
+      chainId: 11155111,
+      operator: OPERATOR,
+      rule: "credit-over-limit",
+      creditLimit: "1000",
+      debt: "2000",
+      violationBlock: BLOCK,
+    });
+    (archive.records as SlashProof[]).push({ proofHash: identityHash } as SlashProof);
+    const svc = makeService(blockchain, makeConfig(), archive);
+    await svc.tick();
+    expect(created).toHaveLength(0);
+  });
+
+  it("cooldown: an ongoing violation whose block advances is not re-proposed until cooldown elapses", async () => {
+    const created: any[] = [];
+    let block = 1000;
+    let now = 1_700_000_000_000;
+    const blockchain = overLimitBlockchain({
+      createSlashProposal: async (...args: any[]) => {
+        created.push(args);
+        return "0xTX";
+      },
+    });
+    blockchain.getBlockNumber = async () => block;
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditCooldownMs: 3_600_000 }),
+      makeArchive(),
+      () => now
+    );
+
+    // Tick 1 at block 1000 → proposes, arms cooldown.
+    await svc.tick();
+    // Tick 2 shortly after at a NEW block 1001 (ongoing violation) → within cooldown → skip.
+    block = 1001;
+    now += 60_000;
+    await svc.tick();
+    expect(created).toHaveLength(1);
+
+    // Tick 3 after the cooldown elapses at yet another new block → re-proposes once.
+    block = 1002;
+    now += 3_600_001;
+    await svc.tick();
+    expect(created).toHaveLength(2);
+  });
+
+  it("proposal write failure → proof still archived (evidence never lost), proposalTx null", async () => {
+    const blockchain = overLimitBlockchain({
       createSlashProposal: async () => {
         throw new Error("reverted: not authorized");
       },
@@ -216,7 +417,7 @@ describe("AuditService", () => {
     const svc = makeService(blockchain, makeConfig(), archive);
     await expect(svc.tick()).resolves.toBeUndefined(); // never throws
     expect(archive.records).toHaveLength(1);
-    expect(archive.records[0].executedTx).toBeUndefined();
+    expect(archive.records[0].proposalTx).toBeUndefined();
     const status = await svc.getStatus();
     expect(status.recentDetections[0].proposalTx).toBeNull();
   });
@@ -224,9 +425,7 @@ describe("AuditService", () => {
   it("tick sweeps every operator; one failing operator does not abort the rest", async () => {
     const op2 = "0x" + "ab".repeat(20);
     const created: string[] = [];
-    const blockchain = makeBlockchain({
-      getCreditLimit: async () => 1000n,
-      getAvailableCredit: async () => 0n,
+    const blockchain = overLimitBlockchain({
       createSlashProposal: async (_addr: string, operator: string) => {
         created.push(operator);
         return "0xTX";
@@ -248,6 +447,32 @@ describe("AuditService", () => {
     );
     await svc.tick();
     expect(created).toEqual([op2]);
+  });
+
+  // ── HIGH 2: single-flight ─────────────────────────────────────────────────────
+  it("single-flight: an overlapping tick is skipped while one is in-flight", async () => {
+    let blockCalls = 0;
+    let release!: () => void;
+    const gate = new Promise<void>(res => {
+      release = res;
+    });
+    const blockchain = overLimitBlockchain();
+    blockchain.getBlockNumber = async () => {
+      blockCalls++;
+      await gate; // suspend the first tick mid-flight
+      return BLOCK;
+    };
+    const svc = makeService(blockchain, makeConfig(), makeArchive());
+
+    const p1 = svc.tick(); // enters, sets tickInFlight, suspends on the gate
+    const p2 = svc.tick(); // overlapping → must skip immediately
+    await p2;
+    expect(blockCalls).toBe(1); // second tick never started auditing
+
+    release();
+    await p1;
+    expect(blockCalls).toBe(1);
+    expect((svc as any).tickInFlight).toBe(false);
   });
 
   it("coordinateQuorumCoSign is deferred to increment 2 (throws)", async () => {

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -1,0 +1,272 @@
+import { jest } from "@jest/globals";
+import { AuditService } from "./audit.service.js";
+import { IProofArchive, SlashProof, computeProofHash } from "./proof-archive.js";
+
+const OPERATOR = "0x" + "12".repeat(20);
+const REGISTRY = "0xf5Bf37ca83AfdAab73691bA7eCcDfA69b8708E71";
+const SUPER_PAYMASTER = "0x" + "34".repeat(20);
+const DVT_VALIDATOR = "0x" + "56".repeat(20);
+const GTOKEN_STAKING = "0x" + "78".repeat(20);
+
+const BASE_CONFIG: Record<string, unknown> = {
+  auditEnabled: true,
+  auditIntervalMs: 60_000,
+  auditWatchlist: [OPERATOR],
+  auditCreditThresholdBps: 10_000,
+  auditChainId: 11155111,
+  auditRegistryAddress: REGISTRY,
+  auditSuperPaymasterAddress: SUPER_PAYMASTER,
+  auditDvtValidatorAddress: DVT_VALIDATOR,
+  auditGtokenStakingAddress: GTOKEN_STAKING,
+  auditProofDir: "./audit-proofs-test",
+};
+
+function makeConfig(overrides: Record<string, unknown> = {}) {
+  const cfg = { ...BASE_CONFIG, ...overrides };
+  return { get: (k: string) => cfg[k] } as any;
+}
+
+/**
+ * Blockchain mock. Defaults model a HEALTHY operator (availableCredit == creditLimit →
+ * usage 0bps → no violation). Override getAvailableCredit to model exhausted credit.
+ */
+function makeBlockchain(
+  overrides: Partial<{
+    getCreditLimit: () => Promise<bigint>;
+    getAvailableCredit: () => Promise<bigint>;
+    getGlobalReputation: () => Promise<bigint>;
+    getRoleLockAmount: () => Promise<bigint>;
+    createSlashProposal: (...args: any[]) => Promise<string>;
+    getWalletAddress: () => string | null;
+  }> = {}
+): any {
+  return {
+    getCreditLimit: overrides.getCreditLimit ?? (async () => 1000n),
+    getAvailableCredit: overrides.getAvailableCredit ?? (async () => 1000n),
+    getGlobalReputation: overrides.getGlobalReputation ?? (async () => 500n),
+    getRoleLockAmount: overrides.getRoleLockAmount ?? (async () => 42n),
+    createSlashProposal: overrides.createSlashProposal ?? (async () => "0xPROPOSALTX"),
+    getWalletAddress: overrides.getWalletAddress ?? (() => "0x" + "99".repeat(20)),
+  };
+}
+
+/** In-memory archive so tests never touch the filesystem. */
+function makeArchive(): IProofArchive & { records: SlashProof[] } {
+  const records: SlashProof[] = [];
+  return {
+    records,
+    async put(proof: SlashProof) {
+      // Idempotent on proofHash, like LocalProofArchive.
+      const existing = records.findIndex(r => r.proofHash === proof.proofHash);
+      if (existing >= 0) records[existing] = proof;
+      else records.push(proof);
+      return { proofHash: proof.proofHash, location: `mem://${proof.proofHash}` };
+    },
+    async count() {
+      return records.length;
+    },
+  };
+}
+
+function makeRegistry() {
+  const registered: string[] = [];
+  return { registered, register: (cap: { name: string }) => registered.push(cap.name) } as any;
+}
+
+function clockAt(nowMs: number) {
+  return () => nowMs;
+}
+
+function makeService(
+  blockchain: any,
+  config: any,
+  archive: IProofArchive,
+  clock: () => number = clockAt(1_700_000_000_000)
+) {
+  return new AuditService(blockchain, config, makeRegistry(), clock, () => 0, archive);
+}
+
+describe("AuditService", () => {
+  it("registers the audit capability (enabled) with the CapabilityRegistry", () => {
+    const registry = makeRegistry();
+    new AuditService(makeBlockchain(), makeConfig(), registry, clockAt(0), () => 0, makeArchive());
+    expect(registry.registered).toContain("audit");
+  });
+
+  it("disabled → onApplicationBootstrap never schedules a tick", () => {
+    const svc = makeService(makeBlockchain(), makeConfig({ auditEnabled: false }), makeArchive());
+    svc.onApplicationBootstrap();
+    expect((svc as any).startupTimer).toBeNull();
+    expect((svc as any).timer).toBeNull();
+  });
+
+  it("enabled → onApplicationBootstrap schedules a phase-jittered first tick", () => {
+    const svc = makeService(makeBlockchain(), makeConfig(), makeArchive());
+    svc.onApplicationBootstrap();
+    // First tick is phase-jittered via setTimeout — startupTimer holds it, interval not armed.
+    expect((svc as any).startupTimer).not.toBeNull();
+    expect((svc as any).timer).toBeNull();
+    svc.onApplicationShutdown();
+    expect((svc as any).startupTimer).toBeNull();
+  });
+
+  it("enabled but empty watchlist → does not schedule", () => {
+    const svc = makeService(makeBlockchain(), makeConfig({ auditWatchlist: [] }), makeArchive());
+    svc.onApplicationBootstrap();
+    expect((svc as any).startupTimer).toBeNull();
+  });
+
+  it("healthy operator (availableCredit == limit) → no detection, no proposal", async () => {
+    const created: any[] = [];
+    const blockchain = makeBlockchain({
+      getAvailableCredit: async () => 1000n, // == limit → usage 0bps
+      createSlashProposal: async (...args: any[]) => {
+        created.push(args);
+        return "0xTX";
+      },
+    });
+    const archive = makeArchive();
+    const svc = makeService(blockchain, makeConfig(), archive);
+    await svc.tick();
+    expect(created).toHaveLength(0);
+    expect(archive.records).toHaveLength(0);
+  });
+
+  it("credit-over-limit → files a proposal AND archives a content-addressed proof with evidence", async () => {
+    const created: any[] = [];
+    const blockchain = makeBlockchain({
+      getCreditLimit: async () => 1000n,
+      getAvailableCredit: async () => 0n, // debt == limit → usage 10000bps ≥ threshold
+      createSlashProposal: async (...args: any[]) => {
+        created.push(args);
+        return "0xPROPOSALTX";
+      },
+    });
+    const archive = makeArchive();
+    const now = 1_700_000_000_000;
+    const svc = makeService(blockchain, makeConfig(), archive, clockAt(now));
+    await svc.tick();
+
+    // Proposal-intent filed: createProposal(operator, level=1, reason).
+    expect(created).toHaveLength(1);
+    expect(created[0][0]).toBe(DVT_VALIDATOR);
+    expect(created[0][1]).toBe(OPERATOR);
+    expect(created[0][2]).toBe(1); // SLASH_LEVEL_CREDIT_OVER_LIMIT
+    expect(created[0][3]).toContain("credit-over-limit");
+
+    // Exactly one proof archived.
+    expect(archive.records).toHaveLength(1);
+    const proof = archive.records[0];
+    expect(proof.version).toBe("dvt-slash-proof/1");
+    expect(proof.operator).toBe(OPERATOR);
+    expect(proof.slashLevel).toBe(1);
+    expect(proof.executedTx).toBe("0xPROPOSALTX");
+
+    // Evidence captured, with the raw view sources.
+    expect(proof.evidence.rule).toBe("credit-over-limit");
+    expect(proof.evidence.observed).toBe("1000"); // debt
+    expect(proof.evidence.threshold).toBe("1000"); // creditLimit
+    const sourceNames = proof.evidence.sources.map(s => s.name);
+    expect(sourceNames).toContain("Registry.getCreditLimit");
+    expect(sourceNames).toContain("SuperPaymaster.getAvailableCredit");
+
+    // proofHash is a real content address: recomputing from the immutable core matches.
+    const recomputed = computeProofHash({
+      version: proof.version,
+      chainId: proof.chainId,
+      operator: proof.operator,
+      slashLevel: proof.slashLevel,
+      reason: proof.reason,
+      epoch: proof.epoch,
+      messageHash: proof.messageHash,
+      evidence: proof.evidence,
+    });
+    expect(recomputed).toBe(proof.proofHash);
+    expect(proof.proofHash).toMatch(/^0x[0-9a-f]{64}$/);
+
+    // Detection surfaced in status.
+    const status = await svc.getStatus();
+    expect(status.recentDetections).toHaveLength(1);
+    expect(status.recentDetections[0].proofHash).toBe(proof.proofHash);
+    expect(status.archivedProofCount).toBe(1);
+  });
+
+  it("content-address is deterministic + idempotent: same violation twice → one archived proof", async () => {
+    const blockchain = makeBlockchain({
+      getCreditLimit: async () => 1000n,
+      getAvailableCredit: async () => 0n,
+    });
+    const archive = makeArchive();
+    // Fixed clock so epoch (derived from observedAt) is identical across both ticks → same proofHash.
+    const svc = makeService(blockchain, makeConfig(), archive, clockAt(1_700_000_000_000));
+    await svc.tick();
+    await svc.tick();
+    expect(archive.records).toHaveLength(1);
+  });
+
+  it("proposal write failure → proof still archived (evidence never lost)", async () => {
+    const blockchain = makeBlockchain({
+      getCreditLimit: async () => 1000n,
+      getAvailableCredit: async () => 0n,
+      createSlashProposal: async () => {
+        throw new Error("reverted: not authorized");
+      },
+    });
+    const archive = makeArchive();
+    const svc = makeService(blockchain, makeConfig(), archive);
+    await expect(svc.tick()).resolves.toBeUndefined(); // never throws
+    expect(archive.records).toHaveLength(1);
+    expect(archive.records[0].executedTx).toBeUndefined();
+    const status = await svc.getStatus();
+    expect(status.recentDetections[0].proposalTx).toBeNull();
+  });
+
+  it("tick sweeps every operator; one failing operator does not abort the rest", async () => {
+    const op2 = "0x" + "ab".repeat(20);
+    const created: string[] = [];
+    const blockchain = makeBlockchain({
+      getCreditLimit: async () => 1000n,
+      getAvailableCredit: async () => 0n,
+      createSlashProposal: async (_addr: string, operator: string) => {
+        created.push(operator);
+        return "0xTX";
+      },
+    });
+    // Make the FIRST operator's read throw; the second must still be audited.
+    let firstCall = true;
+    blockchain.getCreditLimit = async () => {
+      if (firstCall) {
+        firstCall = false;
+        throw new Error("rpc error");
+      }
+      return 1000n;
+    };
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditWatchlist: [OPERATOR, op2] }),
+      makeArchive()
+    );
+    await svc.tick();
+    expect(created).toEqual([op2]);
+  });
+
+  it("coordinateQuorumCoSign is deferred to increment 2 (throws)", async () => {
+    const svc = makeService(makeBlockchain(), makeConfig(), makeArchive());
+    await expect(svc.coordinateQuorumCoSign()).rejects.toThrow(/increment 2/);
+  });
+
+  it("computeJitterMs stays within [0, intervalMs)", () => {
+    const mk = (rand: number) =>
+      new AuditService(
+        makeBlockchain(),
+        makeConfig(),
+        makeRegistry(),
+        clockAt(0),
+        () => rand,
+        makeArchive()
+      );
+    expect(mk(0).computeJitterMs()).toBe(0);
+    expect(mk(0.5).computeJitterMs()).toBe(30_000);
+    expect(mk(0.999999).computeJitterMs()).toBeLessThan(60_000);
+  });
+});

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -1,3 +1,4 @@
+import { ethers } from "ethers";
 import { AuditService } from "./audit.service.js";
 import { IProofArchive, SlashProof, computeProofHash } from "./proof-archive.js";
 
@@ -41,7 +42,7 @@ function makeBlockchain(
     getDebt: (addr: string, op: string, bt?: number) => Promise<bigint | null>;
     getGlobalReputation: (addr: string, op: string, bt?: number) => Promise<bigint>;
     getRoleLockAmount: (...args: any[]) => Promise<bigint>;
-    createSlashProposal: (...args: any[]) => Promise<string>;
+    createSlashProposal: (...args: any[]) => Promise<{ txHash: string; proposalId: bigint | null }>;
     getWalletAddress: () => string | null;
   }> = {}
 ): any {
@@ -53,7 +54,8 @@ function makeBlockchain(
     getDebt: overrides.getDebt ?? (async () => 0n),
     getGlobalReputation: overrides.getGlobalReputation ?? (async () => 500n),
     getRoleLockAmount: overrides.getRoleLockAmount ?? (async () => 42n),
-    createSlashProposal: overrides.createSlashProposal ?? (async () => "0xPROPOSALTX"),
+    createSlashProposal:
+      overrides.createSlashProposal ?? (async () => ({ txHash: "0xPROPOSALTX", proposalId: 7n })),
     getWalletAddress: overrides.getWalletAddress ?? (() => "0x" + "99".repeat(20)),
   };
 }
@@ -170,7 +172,7 @@ describe("AuditService", () => {
     const blockchain = makeBlockchain({
       createSlashProposal: async (...args: any[]) => {
         created.push(args);
-        return "0xTX";
+        return { txHash: "0xTX", proposalId: 7n };
       },
     });
     const archive = makeArchive();
@@ -188,7 +190,7 @@ describe("AuditService", () => {
       getDebt: async () => 1000n, // debt == limit → NOT over
       createSlashProposal: async (...args: any[]) => {
         created.push(args);
-        return "0xTX";
+        return { txHash: "0xTX", proposalId: 7n };
       },
     });
     const archive = makeArchive();
@@ -206,7 +208,7 @@ describe("AuditService", () => {
       getDebt: async () => null, // BOTH SP and Registry reads revert
       createSlashProposal: async (...args: any[]) => {
         created.push(args);
-        return "0xTX";
+        return { txHash: "0xTX", proposalId: 7n };
       },
     });
     const archive = makeArchive();
@@ -221,7 +223,7 @@ describe("AuditService", () => {
     const blockchain = overLimitBlockchain({
       createSlashProposal: async (...args: any[]) => {
         created.push(args);
-        return "0xPROPOSALTX";
+        return { txHash: "0xPROPOSALTX", proposalId: 7n };
       },
     });
     const archive = makeArchive();
@@ -323,7 +325,7 @@ describe("AuditService", () => {
     const blockchain = overLimitBlockchain({
       createSlashProposal: async (...args: any[]) => {
         created.push(args);
-        return "0xTX";
+        return { txHash: "0xTX", proposalId: 7n };
       },
     });
     const archive = makeArchive();
@@ -339,7 +341,7 @@ describe("AuditService", () => {
     const blockchain = overLimitBlockchain({
       createSlashProposal: async (...args: any[]) => {
         created.push(args);
-        return "0xTX";
+        return { txHash: "0xTX", proposalId: 7n };
       },
     });
     const archive = makeArchive();
@@ -355,7 +357,7 @@ describe("AuditService", () => {
     const blockchain = overLimitBlockchain({
       createSlashProposal: async (...args: any[]) => {
         created.push(args);
-        return "0xTX";
+        return { txHash: "0xTX", proposalId: 7n };
       },
     });
     // Pre-seed the archive with the exact proof for this violation@block.
@@ -381,7 +383,7 @@ describe("AuditService", () => {
     const blockchain = overLimitBlockchain({
       createSlashProposal: async (...args: any[]) => {
         created.push(args);
-        return "0xTX";
+        return { txHash: "0xTX", proposalId: 7n };
       },
     });
     blockchain.getBlockNumber = async () => block;
@@ -428,7 +430,7 @@ describe("AuditService", () => {
     const blockchain = overLimitBlockchain({
       createSlashProposal: async (_addr: string, operator: string) => {
         created.push(operator);
-        return "0xTX";
+        return { txHash: "0xTX", proposalId: 7n };
       },
     });
     // Make the FIRST operator's read throw; the second must still be audited.
@@ -446,7 +448,9 @@ describe("AuditService", () => {
       makeArchive()
     );
     await svc.tick();
-    expect(created).toEqual([op2]);
+    // The watchlist is canonicalized (checksummed) at ingest, so the operator handed to
+    // createProposal is the checksummed form of op2, not its raw lowercase input.
+    expect(created).toEqual([ethers.getAddress(op2)]);
   });
 
   // ── HIGH 2: single-flight ─────────────────────────────────────────────────────
@@ -473,6 +477,166 @@ describe("AuditService", () => {
     await p1;
     expect(blockCalls).toBe(1);
     expect((svc as any).tickInFlight).toBe(false);
+  });
+
+  // ── FIX 1: operator address checksum-normalized in the proofHash preimage ──────
+  it("Fix 1: same violation, operator lowercase vs checksummed → identical proofHash", async () => {
+    const lower = "0x" + "ab".repeat(20);
+    const checksummed = ethers.getAddress(lower);
+    expect(lower).not.toBe(checksummed); // sanity: the two casings genuinely differ
+
+    const nodeLower = makeService(
+      overLimitBlockchain(),
+      makeConfig({ auditWatchlist: [lower] }),
+      makeArchive()
+    );
+    await nodeLower.tick();
+    const hashLower = (await nodeLower.getStatus()).recentDetections[0].proofHash;
+
+    const nodeChecksum = makeService(
+      overLimitBlockchain(),
+      makeConfig({ auditWatchlist: [checksummed] }),
+      makeArchive()
+    );
+    await nodeChecksum.tick();
+    const hashChecksum = (await nodeChecksum.getStatus()).recentDetections[0].proofHash;
+
+    // Two DVT nodes with differently-cased watchlist entries derive the SAME proofHash.
+    expect(hashLower).toBe(hashChecksum);
+  });
+
+  // ── FIX 2: creditLimit==0 is unconfigured, NOT "over limit" ─────────────────────
+  it("Fix 2: creditLimit==0 with debt>0 → unconfigured/de-registered → NO proposal", async () => {
+    const created: any[] = [];
+    const blockchain = makeBlockchain({
+      getCreditLimit: async () => 0n, // unconfigured / de-registered
+      getAvailableCredit: async () => 0n,
+      getDebt: async () => 5000n, // has debt, but a zero limit must NOT be treated as over-limit
+      createSlashProposal: async (...args: any[]) => {
+        created.push(args);
+        return { txHash: "0xTX", proposalId: 7n };
+      },
+    });
+    const archive = makeArchive();
+    const svc = makeService(blockchain, makeConfig(), archive);
+    await svc.tick();
+    expect(created).toHaveLength(0);
+    expect(archive.records).toHaveLength(0);
+  });
+
+  it("Fix 2: creditLimit>0 with debt>limit (credit exhausted) → proposal filed", async () => {
+    const created: any[] = [];
+    const blockchain = overLimitBlockchain({
+      createSlashProposal: async (...args: any[]) => {
+        created.push(args);
+        return { txHash: "0xTX", proposalId: 7n };
+      },
+    });
+    const svc = makeService(blockchain, makeConfig(), makeArchive());
+    await svc.tick();
+    expect(created).toHaveLength(1);
+  });
+
+  // ── FIX 3: cooldown armed on ATTEMPT, not only on SUCCESS ───────────────────────
+  it("Fix 3: a persistently-reverting proposal is attempted only ONCE within the cooldown window", async () => {
+    let attempts = 0;
+    let block = 5000;
+    let now = 1_700_000_000_000;
+    const blockchain = overLimitBlockchain({
+      createSlashProposal: async () => {
+        attempts++;
+        throw new Error("reverted: proposer not an active validator");
+      },
+    });
+    blockchain.getBlockNumber = async () => block;
+    const archive = makeArchive();
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditCooldownMs: 3_600_000 }),
+      archive,
+      () => now
+    );
+    // Many ticks, each at a NEW head block, each a small time step (< cooldown).
+    for (let i = 0; i < 5; i++) {
+      await svc.tick();
+      block += 1;
+      now += 60_000;
+    }
+    // Armed on ATTEMPT → backs off for cooldownMs despite EVERY attempt failing (no gas/nonce burn).
+    expect(attempts).toBe(1);
+    // Evidence is still archived across ticks (not lost), just not re-attempted on-chain.
+    expect(archive.records.length).toBeGreaterThan(1);
+    expect(archive.records.every(r => r.proposalTx === undefined)).toBe(true);
+  });
+
+  // ── FIX 4: proof carries the REAL on-chain proposal id (no fabrication) ─────────
+  it("Fix 4: the proof carries the REAL on-chain proposal id parsed from the event", async () => {
+    const blockchain = overLimitBlockchain({
+      createSlashProposal: async () => ({ txHash: "0xABC", proposalId: 4242n }),
+    });
+    const archive = makeArchive();
+    const svc = makeService(blockchain, makeConfig(), archive);
+    await svc.tick();
+    expect(archive.records).toHaveLength(1);
+    expect(archive.records[0].proposalId).toBe("4242"); // real uint id, not a keccak
+    expect(archive.records[0].proposalIdNote).toBeUndefined();
+    expect(archive.records[0].proposalTx).toBe("0xABC");
+    const status = await svc.getStatus();
+    expect(status.recentDetections[0].proposalId).toBe("4242");
+  });
+
+  it("Fix 4: an unresolved id (event absent) → proposalId null + note, never fabricated", async () => {
+    const blockchain = overLimitBlockchain({
+      createSlashProposal: async () => ({ txHash: "0xDEF", proposalId: null }),
+    });
+    const archive = makeArchive();
+    const svc = makeService(blockchain, makeConfig(), archive);
+    await svc.tick();
+    expect(archive.records[0].proposalId).toBeNull();
+    expect(archive.records[0].proposalIdNote).toMatch(/id-unresolved/);
+    expect(archive.records[0].proposalTx).toBe("0xDEF"); // tx still recorded
+  });
+
+  // ── FIX 5: cross-contract limit mismatch must not false-positive ────────────────
+  it("Fix 5: availableCredit>0 but registryLimit<debt → within SP ceiling → NO proposal", async () => {
+    const created: any[] = [];
+    const blockchain = makeBlockchain({
+      getCreditLimit: async () => 1000n, // stale/low Registry limit
+      getAvailableCredit: async () => 500n, // SP says the operator is still within its ceiling
+      getDebt: async () => 2000n, // exceeds the Registry limit ONLY
+      createSlashProposal: async (...args: any[]) => {
+        created.push(args);
+        return { txHash: "0xTX", proposalId: 7n };
+      },
+    });
+    const archive = makeArchive();
+    const svc = makeService(blockchain, makeConfig(), archive);
+    await svc.tick();
+    expect(created).toHaveLength(0);
+    expect(archive.records).toHaveLength(0);
+  });
+
+  // ── FIX 7: dedup/cooldown maps stay bounded ─────────────────────────────────────
+  it("Fix 7: dedup/cooldown maps are pruned once entries age past cooldownMs", async () => {
+    let now = 1_700_000_000_000;
+    const blockchain = overLimitBlockchain();
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditCooldownMs: 3_600_000 }),
+      makeArchive(),
+      () => now
+    );
+    await svc.tick(); // over-limit → arms a stableKey + a cooldown entry
+    expect((svc as any).proposedStableKeys.size).toBe(1);
+    expect((svc as any).lastProposalAt.size).toBe(1);
+
+    // Advance well past the cooldown and make the operator healthy so no NEW entries are added.
+    now += 3_600_001;
+    blockchain.getDebt = async () => 0n;
+    blockchain.getAvailableCredit = async () => 1000n;
+    await svc.tick(); // prune runs at tick start → the stale entries are evicted
+    expect((svc as any).proposedStableKeys.size).toBe(0);
+    expect((svc as any).lastProposalAt.size).toBe(0);
   });
 
   it("coordinateQuorumCoSign is deferred to increment 2 (throws)", async () => {

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -1,0 +1,382 @@
+import {
+  Injectable,
+  Logger,
+  Optional,
+  OnApplicationBootstrap,
+  OnApplicationShutdown,
+} from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { ethers } from "ethers";
+import { BlockchainService } from "../blockchain/blockchain.service.js";
+import { CapabilityRegistry } from "../capability/capability-registry.service.js";
+import type { IProofArchive, SlashProof, EvidenceSource } from "./proof-archive.js";
+import { LocalProofArchive, computeProofHash } from "./proof-archive.js";
+
+/**
+ * DVT Phase 2 (目标2) — autonomous audit of SuperPaymaster operators, increment 1.
+ *
+ * Each DVT node independently watches a set of operators and, without any external
+ * trigger, reads their on-chain credit / reputation / stake state every tick. When an
+ * operator breaches a rule, the node archives a content-addressed slash proof and files
+ * a slash proposal on the DVTValidator. That proposal is the seed of the slash consensus
+ * the other DVT nodes converge on.
+ *
+ * Opt-in (AUDIT_ENABLED, default off). When disabled, onApplicationBootstrap logs disabled
+ * and never schedules a tick. Like the price keeper, the first tick is phase-jittered across
+ * [0, intervalMs) so redundant auditors that boot together don't file the same proposal in
+ * the same window.
+ *
+ * INCREMENT-1 SCOPE: only the credit-over-limit rule + LocalProofArchive + proposal-intent.
+ * DEFERRED (see coordinateQuorumCoSign / IpfsProofArchive):
+ *   - increment 2: multi-node BLS quorum co-sign via gossip + BLSAggregator.verifyAndExecute;
+ *     the offline (gossip-heartbeat) / deposit-insufficient / token-over-issue rules.
+ *   - increment 3: IPFS pinning of proofs.
+ */
+
+/** Slash severity for the credit-over-limit rule (uint8 level passed to createProposal). */
+const SLASH_LEVEL_CREDIT_OVER_LIMIT = 1;
+const RULE_CREDIT_OVER_LIMIT = "credit-over-limit";
+/** ROLE_DVT = keccak256("DVT") — the staking role lock the audit inspects. */
+const ROLE_DVT = ethers.id("DVT");
+const ABI = new ethers.AbiCoder();
+
+export interface AuditDetection {
+  operator: string;
+  rule: string;
+  proofHash: string;
+  proposalId: string;
+  reason: string;
+  detectedAt: number;
+  /** Tx hash of the filed proposal, or null if the write failed / no wallet. */
+  proposalTx: string | null;
+}
+
+@Injectable()
+export class AuditService implements OnApplicationBootstrap, OnApplicationShutdown {
+  private readonly logger = new Logger(AuditService.name);
+
+  private readonly enabled: boolean;
+  private readonly intervalMs: number;
+  private readonly watchlist: string[];
+  private readonly creditThresholdBps: bigint;
+  private readonly chainId: number;
+  private readonly registryAddress: string;
+  private readonly superPaymasterAddress: string;
+  private readonly dvtValidatorAddress: string;
+  private readonly gtokenStakingAddress: string;
+  private readonly archive: IProofArchive;
+  private readonly clock: () => number;
+  private readonly random: () => number;
+
+  private startupTimer: ReturnType<typeof setTimeout> | null = null;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private lastTickAt: number | null = null;
+  /** Bounded ring of the most recent detections, newest first (for GET /audit/status). */
+  private readonly recentDetections: AuditDetection[] = [];
+  private static readonly MAX_RECENT = 20;
+
+  constructor(
+    private readonly blockchainService: BlockchainService,
+    private readonly config: ConfigService,
+    @Optional() capabilityRegistry?: CapabilityRegistry,
+    /** Test seam: controls `Date.now()` so time-based logic is deterministic. */
+    @Optional() clock?: () => number,
+    /** Test seam: controls the startup phase jitter (default Math.random). */
+    @Optional() random?: () => number,
+    /** Test seam: injectable archive; defaults to a LocalProofArchive at auditProofDir. */
+    @Optional() archive?: IProofArchive
+  ) {
+    this.enabled = config.get<boolean>("auditEnabled") === true;
+    this.intervalMs = config.get<number>("auditIntervalMs") ?? 60_000;
+    this.watchlist = (config.get<string[]>("auditWatchlist") ?? []).map(a => a.trim()).filter(Boolean);
+    this.creditThresholdBps = BigInt(config.get<number>("auditCreditThresholdBps") ?? 10_000);
+    this.chainId = config.get<number>("auditChainId") ?? 11155111;
+    this.registryAddress = config.get<string>("auditRegistryAddress") ?? "";
+    this.superPaymasterAddress = config.get<string>("auditSuperPaymasterAddress") ?? "";
+    this.dvtValidatorAddress = config.get<string>("auditDvtValidatorAddress") ?? "";
+    this.gtokenStakingAddress = config.get<string>("auditGtokenStakingAddress") ?? "";
+    this.clock = clock ?? (() => Date.now());
+    this.random = random ?? (() => Math.random());
+    this.archive =
+      archive ?? new LocalProofArchive(config.get<string>("auditProofDir") ?? "./audit-proofs");
+
+    capabilityRegistry?.register({
+      name: "audit",
+      class: "infra-core",
+      description:
+        "DVT Phase 2 (目标2) — autonomous audit of SuperPaymaster operators → slash consensus (increment 1)",
+      enabled: this.enabled,
+    });
+  }
+
+  onApplicationBootstrap(): void {
+    if (!this.enabled) {
+      this.logger.log("DVT audit DISABLED (AUDIT_ENABLED!=true) — no operators watched");
+      return;
+    }
+    if (this.watchlist.length === 0) {
+      this.logger.warn("Audit: AUDIT_ENABLED=true but AUDIT_WATCHLIST is empty — nothing to watch");
+      return;
+    }
+    if (!this.registryAddress || !this.superPaymasterAddress) {
+      this.logger.warn(
+        "Audit: AUDIT_ENABLED=true but AUDIT_REGISTRY_ADDRESS / AUDIT_SUPER_PAYMASTER_ADDRESS " +
+          "not set — cannot read operator credit state, disabled"
+      );
+      return;
+    }
+    // Phase-jitter the first tick across [0, intervalMs) so redundant auditors that boot
+    // together don't all file the same proposal in the same window.
+    const jitterMs = this.computeJitterMs();
+    this.startupTimer = setTimeout(() => {
+      this.startupTimer = null;
+      void this.tick().catch(e => this.logger.error(`Audit tick error: ${String(e)}`));
+      this.timer = setInterval(
+        () => void this.tick().catch(e => this.logger.error(`Audit tick error: ${String(e)}`)),
+        this.intervalMs
+      );
+    }, jitterMs);
+    this.logger.log(
+      `DVT audit ENABLED — interval=${this.intervalMs}ms jitter=${jitterMs}ms ` +
+        `watchlist=[${this.watchlist.join(", ")}] creditThreshold=${this.creditThresholdBps}bps ` +
+        `registry=${this.registryAddress} superPaymaster=${this.superPaymasterAddress}`
+    );
+  }
+
+  onApplicationShutdown(): void {
+    if (this.startupTimer !== null) {
+      clearTimeout(this.startupTimer);
+      this.startupTimer = null;
+    }
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** Startup phase offset in [0, intervalMs). Visible for testing. */
+  computeJitterMs(): number {
+    return Math.floor(this.random() * this.intervalMs);
+  }
+
+  /**
+   * One audit cycle. Called on every interval tick. Never throws; per-operator errors
+   * are logged and do not abort the sweep of the remaining operators.
+   */
+  async tick(): Promise<void> {
+    this.lastTickAt = this.clock();
+    for (const operator of this.watchlist) {
+      try {
+        await this.auditOperator(operator);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.logger.error(`Audit: ${operator} audit failed — ${msg}`);
+      }
+    }
+  }
+
+  /**
+   * Audit a single operator: read its credit / reputation / stake state and evaluate the
+   * credit-over-limit rule. On a confirmed violation, archive a proof and file a proposal.
+   */
+  async auditOperator(operator: string): Promise<void> {
+    const creditLimit = await this.blockchainService.getCreditLimit(this.registryAddress, operator);
+    const availableCredit = await this.blockchainService.getAvailableCredit(
+      this.superPaymasterAddress,
+      operator
+    );
+    // Auxiliary evidence (not part of the credit rule): reputation + DVT stake lock.
+    const reputation = await this.blockchainService
+      .getGlobalReputation(this.registryAddress, operator)
+      .catch(() => -1n);
+    const dvtStake = this.gtokenStakingAddress
+      ? await this.blockchainService.getRoleLockAmount(this.gtokenStakingAddress, operator, ROLE_DVT)
+      : 0n;
+
+    // Credit-over-limit rule: debt = creditLimit − availableCredit. usageBps = debt/limit.
+    // Flag when usage ≥ threshold (default 10000 bps = availableCredit exhausted).
+    const debt = creditLimit > availableCredit ? creditLimit - availableCredit : 0n;
+    const usageBps =
+      creditLimit > 0n ? (debt * 10_000n) / creditLimit : debt > 0n ? 10_001n : 0n;
+
+    if (usageBps < this.creditThresholdBps) {
+      this.logger.debug(
+        `Audit: ${operator} within credit (usage=${usageBps}bps < ${this.creditThresholdBps}bps)`
+      );
+      return;
+    }
+
+    const observedAt = this.clock();
+    const reason =
+      `${RULE_CREDIT_OVER_LIMIT}: debt ${debt} of limit ${creditLimit} ` +
+      `(usage ${usageBps}bps ≥ ${this.creditThresholdBps}bps, availableCredit ${availableCredit})`;
+    const sources: EvidenceSource[] = [
+      { type: "view", name: "Registry.getCreditLimit", value: creditLimit.toString() },
+      {
+        type: "view",
+        name: "SuperPaymaster.getAvailableCredit",
+        value: availableCredit.toString(),
+      },
+      { type: "view", name: "Registry.globalReputation", value: reputation.toString() },
+      { type: "view", name: "GTokenStaking.roleLocks(DVT)", value: dvtStake.toString() },
+    ];
+
+    await this.handleViolation({
+      operator,
+      slashLevel: SLASH_LEVEL_CREDIT_OVER_LIMIT,
+      reason,
+      rule: RULE_CREDIT_OVER_LIMIT,
+      observed: debt.toString(),
+      threshold: creditLimit.toString(),
+      sources,
+      observedAt,
+    });
+  }
+
+  /**
+   * On a confirmed violation: build the evidence proof, content-address it, file the slash
+   * proposal on the DVTValidator (proposal-intent), and archive the proof. The proof is
+   * archived even if the on-chain write fails, so the evidence is never lost.
+   */
+  private async handleViolation(v: {
+    operator: string;
+    slashLevel: number;
+    reason: string;
+    rule: string;
+    observed: string;
+    threshold: string;
+    sources: EvidenceSource[];
+    observedAt: number;
+  }): Promise<AuditDetection> {
+    const epoch = Math.floor(v.observedAt / 1000);
+    const proposer = this.blockchainService.getWalletAddress() ?? ethers.ZeroAddress;
+    // Deterministic proposal id — the same operator+epoch+rule maps to one proposal.
+    const proposalId = ethers.keccak256(
+      ABI.encode(
+        ["address", "uint256", "uint256", "string"],
+        [v.operator, this.chainId, epoch, v.rule]
+      )
+    );
+    // The message a DVT quorum would BLS-sign over the proposal (co-sign is increment 2).
+    const messageHash = ethers.keccak256(
+      ABI.encode(
+        ["bytes32", "address", "uint8", "uint256"],
+        [proposalId, v.operator, v.slashLevel, 0]
+      )
+    );
+
+    const core = {
+      version: "dvt-slash-proof/1" as const,
+      chainId: this.chainId,
+      operator: v.operator,
+      slashLevel: v.slashLevel,
+      reason: v.reason,
+      epoch,
+      messageHash,
+      evidence: {
+        rule: v.rule,
+        observed: v.observed,
+        threshold: v.threshold,
+        sources: v.sources,
+        observedAt: v.observedAt,
+      },
+    };
+    const proofHash = computeProofHash(core);
+
+    // File the slash proposal (proposal-INTENT). Best-effort: on failure (no wallet / revert)
+    // the proof is still archived so the evidence survives for a later retry.
+    let proposalTx: string | null = null;
+    if (this.dvtValidatorAddress) {
+      try {
+        proposalTx = await this.blockchainService.createSlashProposal(
+          this.dvtValidatorAddress,
+          v.operator,
+          v.slashLevel,
+          v.reason
+        );
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.logger.error(`Audit: ${v.operator} createProposal failed — ${msg}`);
+      }
+    } else {
+      this.logger.warn(
+        `Audit: ${v.operator} violated ${v.rule} but AUDIT_DVT_VALIDATOR_ADDRESS unset — proposal not filed`
+      );
+    }
+
+    const proof: SlashProof = {
+      ...core,
+      proposalId,
+      // Quorum co-sign fields are placeholders until increment 2.
+      signerMask: "0x",
+      sigG2: "0x",
+      proofHash,
+      participants: [],
+      proposer,
+      penaltyAmount: "0",
+      attestations: {},
+      createdAt: this.clock(),
+      ...(proposalTx ? { executedTx: proposalTx } : {}),
+    };
+
+    const { location } = await this.archive.put(proof);
+    this.logger.warn(
+      `Audit: ${v.operator} VIOLATION ${v.rule} — proof ${proofHash} archived at ${location}` +
+        (proposalTx ? ` (proposal ${proposalTx})` : " (proposal NOT filed)")
+    );
+
+    // TODO(increment-2): coordinateQuorumCoSign() — gossip the proposal to the other DVT
+    // nodes, collect their BLS co-signatures into an aggregate, then submit through
+    // BLSAggregator.verifyAndExecute to actually execute the slash. Deferred: needs the
+    // gossip aggregation layer across DVT nodes.
+
+    const detection: AuditDetection = {
+      operator: v.operator,
+      rule: v.rule,
+      proofHash,
+      proposalId,
+      reason: v.reason,
+      detectedAt: v.observedAt,
+      proposalTx,
+    };
+    this.recentDetections.unshift(detection);
+    if (this.recentDetections.length > AuditService.MAX_RECENT) {
+      this.recentDetections.length = AuditService.MAX_RECENT;
+    }
+    return detection;
+  }
+
+  /**
+   * TODO(increment-2): coordinate the multi-node BLS quorum co-sign over a filed proposal
+   * and submit BLSAggregator.verifyAndExecute. Deferred — requires gossip aggregation across
+   * DVT nodes. Kept as a named seam so the increment-1 flow already points at where it lands.
+   */
+  async coordinateQuorumCoSign(): Promise<never> {
+    throw new Error("coordinateQuorumCoSign deferred to increment 2 (gossip BLS aggregation)");
+  }
+
+  /** Read-only status for GET /audit/status. No secrets. */
+  async getStatus(): Promise<{
+    enabled: boolean;
+    intervalMs: number;
+    watchlist: string[];
+    lastTickAt: number | null;
+    recentDetections: AuditDetection[];
+    archivedProofCount: number;
+  }> {
+    let archivedProofCount = 0;
+    try {
+      archivedProofCount = await this.archive.count();
+    } catch {
+      archivedProofCount = -1;
+    }
+    return {
+      enabled: this.enabled,
+      intervalMs: this.intervalMs,
+      watchlist: this.watchlist,
+      lastTickAt: this.lastTickAt,
+      recentDetections: this.recentDetections,
+      archivedProofCount,
+    };
+  }
+}

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -544,11 +544,13 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       ...(proposalIdNote ? { proposalIdNote } : {}),
     };
 
-    // Mark this exact violation@block handled BEFORE archiving so a same-block re-tick can't
-    // double-file. (The cooldown was already armed on ATTEMPT above.)
-    this.recordStableKey(stableKey);
-
+    // Archive the evidence FIRST, then mark the violation@block handled. If archive.put throws
+    // (disk full / IO error), recordStableKey is NOT reached, so a later tick re-attempts the
+    // archive rather than the in-memory stableKey silently suppressing it for cooldownMs — the
+    // "evidence never lost" invariant. (The on-chain tx is still cooldown-gated above, so a retry
+    // re-archives without re-sending a proposal.)
     const { location } = await this.archive.put(proof);
+    this.recordStableKey(stableKey);
     this.logger.warn(
       `Audit: ${v.operator} VIOLATION ${v.rule} — proof ${proofHash} archived at ${location}` +
         (proposalTx ? ` (proposal ${proposalTx})` : " (proposal NOT filed)")

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -9,7 +9,7 @@ import { ConfigService } from "@nestjs/config";
 import { ethers } from "ethers";
 import { BlockchainService } from "../blockchain/blockchain.service.js";
 import { CapabilityRegistry } from "../capability/capability-registry.service.js";
-import type { IProofArchive, SlashProof, EvidenceSource } from "./proof-archive.js";
+import type { IProofArchive, SlashProof, EvidenceSource, ProofIdentity } from "./proof-archive.js";
 import { LocalProofArchive, computeProofHash } from "./proof-archive.js";
 
 /**
@@ -55,8 +55,9 @@ export interface AuditDetection {
 export class AuditService implements OnApplicationBootstrap, OnApplicationShutdown {
   private readonly logger = new Logger(AuditService.name);
 
-  private readonly enabled: boolean;
+  private enabled: boolean;
   private readonly intervalMs: number;
+  private readonly cooldownMs: number;
   private readonly watchlist: string[];
   private readonly creditThresholdBps: bigint;
   private readonly chainId: number;
@@ -71,6 +72,19 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
   private startupTimer: ReturnType<typeof setTimeout> | null = null;
   private timer: ReturnType<typeof setInterval> | null = null;
   private lastTickAt: number | null = null;
+  /** Single-flight guard: a tick is skipped while a previous one is still running. */
+  private tickInFlight = false;
+  /**
+   * Stable-key dedup for the SAME on-chain violation@block: `chainId|operator|rule|block`.
+   * Prevents re-proposing/re-archiving the identical block's violation within a process.
+   */
+  private readonly proposedStableKeys = new Set<string>();
+  /**
+   * Cooldown clock, keyed on the COARSE `chainId|operator|rule` (block-independent), holding
+   * the wall-clock of the last SUCCESSFUL proposal — an ongoing violation whose block advances
+   * every tick is not re-proposed until cooldownMs elapses.
+   */
+  private readonly lastProposalAt = new Map<string, number>();
   /** Bounded ring of the most recent detections, newest first (for GET /audit/status). */
   private readonly recentDetections: AuditDetection[] = [];
   private static readonly MAX_RECENT = 20;
@@ -88,6 +102,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
   ) {
     this.enabled = config.get<boolean>("auditEnabled") === true;
     this.intervalMs = config.get<number>("auditIntervalMs") ?? 60_000;
+    this.cooldownMs = config.get<number>("auditCooldownMs") ?? 3_600_000;
     this.watchlist = (config.get<string[]>("auditWatchlist") ?? []).map(a => a.trim()).filter(Boolean);
     this.creditThresholdBps = BigInt(config.get<number>("auditCreditThresholdBps") ?? 10_000);
     this.chainId = config.get<number>("auditChainId") ?? 11155111;
@@ -109,7 +124,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     });
   }
 
-  onApplicationBootstrap(): void {
+  async onApplicationBootstrap(): Promise<void> {
     if (!this.enabled) {
       this.logger.log("DVT audit DISABLED (AUDIT_ENABLED!=true) — no operators watched");
       return;
@@ -118,12 +133,51 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       this.logger.warn("Audit: AUDIT_ENABLED=true but AUDIT_WATCHLIST is empty — nothing to watch");
       return;
     }
-    if (!this.registryAddress || !this.superPaymasterAddress) {
-      this.logger.warn(
-        "Audit: AUDIT_ENABLED=true but AUDIT_REGISTRY_ADDRESS / AUDIT_SUPER_PAYMASTER_ADDRESS " +
-          "not set — cannot read operator credit state, disabled"
+    // FAIL-CLOSED config validation. Every required contract address must be set explicitly
+    // (no silent default → no cross-chain garbage) AND must exist on-chain. Any failure
+    // DISABLES the audit rather than polling wrong/empty addresses and filing false slashes.
+    const missing: string[] = [];
+    if (!this.registryAddress) missing.push("AUDIT_REGISTRY_ADDRESS");
+    if (!this.superPaymasterAddress) missing.push("AUDIT_SUPER_PAYMASTER_ADDRESS");
+    if (!this.dvtValidatorAddress) missing.push("AUDIT_DVT_VALIDATOR_ADDRESS");
+    if (missing.length > 0) {
+      this.enabled = false;
+      this.logger.error(
+        `Audit: AUDIT_ENABLED=true but ${missing.join(", ")} not set — DISABLED (fail-closed)`
       );
       return;
+    }
+    if (!Number.isInteger(this.chainId) || this.chainId <= 0) {
+      this.enabled = false;
+      this.logger.error(`Audit: invalid AUDIT_CHAIN_ID=${this.chainId} — DISABLED (fail-closed)`);
+      return;
+    }
+    // On-chain existence check: reject any address with no deployed code (wrong chain / typo).
+    const toCheck: Array<[string, string]> = [
+      ["AUDIT_REGISTRY_ADDRESS", this.registryAddress],
+      ["AUDIT_SUPER_PAYMASTER_ADDRESS", this.superPaymasterAddress],
+      ["AUDIT_DVT_VALIDATOR_ADDRESS", this.dvtValidatorAddress],
+    ];
+    if (this.gtokenStakingAddress) {
+      toCheck.push(["AUDIT_GTOKEN_STAKING_ADDRESS", this.gtokenStakingAddress]);
+    }
+    for (const [name, addr] of toCheck) {
+      let code = "0x";
+      try {
+        code = await this.blockchainService.getCode(addr);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.enabled = false;
+        this.logger.error(`Audit: getCode(${name}=${addr}) failed (${msg}) — DISABLED (fail-closed)`);
+        return;
+      }
+      if (!code || code === "0x") {
+        this.enabled = false;
+        this.logger.error(
+          `Audit: ${name}=${addr} has no on-chain code on chainId ${this.chainId} — DISABLED (fail-closed)`
+        );
+        return;
+      }
     }
     // Phase-jitter the first tick across [0, intervalMs) so redundant auditors that boot
     // together don't all file the same proposal in the same window.
@@ -164,14 +218,25 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
    * are logged and do not abort the sweep of the remaining operators.
    */
   async tick(): Promise<void> {
+    // Single-flight: if a previous tick is still running (slow RPC), skip this one rather
+    // than overlapping sweeps that would double-read and race the dedup bookkeeping.
+    if (this.tickInFlight) {
+      this.logger.debug("Audit: tick already in-flight — skipping this interval");
+      return;
+    }
+    this.tickInFlight = true;
     this.lastTickAt = this.clock();
-    for (const operator of this.watchlist) {
-      try {
-        await this.auditOperator(operator);
-      } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
-        this.logger.error(`Audit: ${operator} audit failed — ${msg}`);
+    try {
+      for (const operator of this.watchlist) {
+        try {
+          await this.auditOperator(operator);
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err);
+          this.logger.error(`Audit: ${operator} audit failed — ${msg}`);
+        }
       }
+    } finally {
+      this.tickInFlight = false;
     }
   }
 
@@ -180,45 +245,83 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
    * credit-over-limit rule. On a confirmed violation, archive a proof and file a proposal.
    */
   async auditOperator(operator: string): Promise<void> {
-    const creditLimit = await this.blockchainService.getCreditLimit(this.registryAddress, operator);
+    // Pin EVERY rule input to ONE block so creditLimit, availableCredit and debt can never
+    // be mixed across blocks (no phantom over-limit from a mid-read state change).
+    const violationBlock = await this.blockchainService.getBlockNumber();
+
+    const creditLimit = await this.blockchainService.getCreditLimit(
+      this.registryAddress,
+      operator,
+      violationBlock
+    );
     const availableCredit = await this.blockchainService.getAvailableCredit(
       this.superPaymasterAddress,
-      operator
+      operator,
+      violationBlock
     );
+    // GENUINE over-limit needs the operator's ACTUAL debt, read directly (block-pinned).
+    // getDebt is best-effort: null = getter absent / reverted → we CANNOT prove over-limit,
+    // so we SKIP (fail-safe, no proposal) rather than inferring it from availableCredit==0.
+    const debt = await this.readOperatorDebt(operator, violationBlock);
+    if (debt === null) {
+      this.logger.debug(
+        `Audit: ${operator} debt unreadable (getDebt reverted/absent) — SKIP (fail-safe)`
+      );
+      return;
+    }
+
     // Auxiliary evidence (not part of the credit rule): reputation + DVT stake lock.
     const reputation = await this.blockchainService
-      .getGlobalReputation(this.registryAddress, operator)
+      .getGlobalReputation(this.registryAddress, operator, violationBlock)
       .catch(() => -1n);
     const dvtStake = this.gtokenStakingAddress
-      ? await this.blockchainService.getRoleLockAmount(this.gtokenStakingAddress, operator, ROLE_DVT)
+      ? await this.blockchainService.getRoleLockAmount(
+          this.gtokenStakingAddress,
+          operator,
+          ROLE_DVT,
+          violationBlock
+        )
       : 0n;
 
-    // Credit-over-limit rule: debt = creditLimit − availableCredit. usageBps = debt/limit.
-    // Flag when usage ≥ threshold (default 10000 bps = availableCredit exhausted).
-    const debt = creditLimit > availableCredit ? creditLimit - availableCredit : 0n;
+    // STRICT credit-over-limit rule: flag ONLY a genuine breach where debt EXCEEDS the limit
+    // (debt == creditLimit is AT the limit, not over → NOT a violation). creditThresholdBps is
+    // an OPTIONAL additional margin on top: debt*10000/limit must also reach it (default 10000).
+    const overLimit = debt > creditLimit;
     const usageBps =
-      creditLimit > 0n ? (debt * 10_000n) / creditLimit : debt > 0n ? 10_001n : 0n;
+      creditLimit > 0n
+        ? (debt * 10_000n) / creditLimit
+        : debt > 0n
+          ? this.creditThresholdBps // no limit but has debt → treat as over the margin
+          : 0n;
 
+    if (!overLimit) {
+      this.logger.debug(
+        `Audit: ${operator} not over limit (debt=${debt} ≤ limit=${creditLimit}, usage=${usageBps}bps)`
+      );
+      return;
+    }
     if (usageBps < this.creditThresholdBps) {
       this.logger.debug(
-        `Audit: ${operator} within credit (usage=${usageBps}bps < ${this.creditThresholdBps}bps)`
+        `Audit: ${operator} over limit but under margin (usage=${usageBps}bps < ${this.creditThresholdBps}bps)`
       );
       return;
     }
 
     const observedAt = this.clock();
     const reason =
-      `${RULE_CREDIT_OVER_LIMIT}: debt ${debt} of limit ${creditLimit} ` +
-      `(usage ${usageBps}bps ≥ ${this.creditThresholdBps}bps, availableCredit ${availableCredit})`;
+      `${RULE_CREDIT_OVER_LIMIT}: debt ${debt} EXCEEDS limit ${creditLimit} ` +
+      `(usage ${usageBps}bps ≥ ${this.creditThresholdBps}bps, availableCredit ${availableCredit}, block ${violationBlock})`;
     const sources: EvidenceSource[] = [
-      { type: "view", name: "Registry.getCreditLimit", value: creditLimit.toString() },
+      { type: "view", name: "Registry.getCreditLimit", value: creditLimit.toString(), block: violationBlock },
+      { type: "view", name: "SuperPaymaster.getDebt", value: debt.toString(), block: violationBlock },
       {
         type: "view",
         name: "SuperPaymaster.getAvailableCredit",
         value: availableCredit.toString(),
+        block: violationBlock,
       },
-      { type: "view", name: "Registry.globalReputation", value: reputation.toString() },
-      { type: "view", name: "GTokenStaking.roleLocks(DVT)", value: dvtStake.toString() },
+      { type: "view", name: "Registry.globalReputation", value: reputation.toString(), block: violationBlock },
+      { type: "view", name: "GTokenStaking.roleLocks(DVT)", value: dvtStake.toString(), block: violationBlock },
     ];
 
     await this.handleViolation({
@@ -226,11 +329,23 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       slashLevel: SLASH_LEVEL_CREDIT_OVER_LIMIT,
       reason,
       rule: RULE_CREDIT_OVER_LIMIT,
-      observed: debt.toString(),
-      threshold: creditLimit.toString(),
+      creditLimit,
+      debt,
+      violationBlock,
       sources,
       observedAt,
     });
+  }
+
+  /**
+   * Best-effort operator debt read (block-pinned). Tries the SuperPaymaster credit-debt
+   * system first, then the Registry. Returns null only when NEITHER exposes a readable
+   * getDebt — the caller treats null as "unknown" and skips (never guesses an over-limit).
+   */
+  private async readOperatorDebt(operator: string, blockTag: number): Promise<bigint | null> {
+    const fromSp = await this.blockchainService.getDebt(this.superPaymasterAddress, operator, blockTag);
+    if (fromSp !== null) return fromSp;
+    return this.blockchainService.getDebt(this.registryAddress, operator, blockTag);
   }
 
   /**
@@ -243,18 +358,31 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     slashLevel: number;
     reason: string;
     rule: string;
-    observed: string;
-    threshold: string;
+    creditLimit: bigint;
+    debt: bigint;
+    violationBlock: number;
     sources: EvidenceSource[];
     observedAt: number;
-  }): Promise<AuditDetection> {
-    const epoch = Math.floor(v.observedAt / 1000);
+  }): Promise<AuditDetection | null> {
+    const epoch = Math.floor(v.observedAt / 1000); // human field only — NOT hashed.
     const proposer = this.blockchainService.getWalletAddress() ?? ethers.ZeroAddress;
-    // Deterministic proposal id — the same operator+epoch+rule maps to one proposal.
+
+    // Content-address IDENTITY = ON-CHAIN facts only (no wall-clock). Two DVT nodes seeing
+    // the same violation at the same block derive the same proofHash + proposalId.
+    const identity: ProofIdentity = {
+      chainId: this.chainId,
+      operator: v.operator,
+      rule: v.rule,
+      creditLimit: v.creditLimit.toString(),
+      debt: v.debt.toString(),
+      violationBlock: v.violationBlock,
+    };
+    const proofHash = computeProofHash(identity);
+    // Deterministic proposal id from the same stable dedup key: chainId|operator|rule|block.
     const proposalId = ethers.keccak256(
       ABI.encode(
-        ["address", "uint256", "uint256", "string"],
-        [v.operator, this.chainId, epoch, v.rule]
+        ["uint256", "address", "string", "uint256"],
+        [this.chainId, v.operator, v.rule, v.violationBlock]
       )
     );
     // The message a DVT quorum would BLS-sign over the proposal (co-sign is increment 2).
@@ -265,8 +393,43 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       )
     );
 
-    const core = {
-      version: "dvt-slash-proof/1" as const,
+    // ── DEDUP ─────────────────────────────────────────────────────────────────────
+    const stableKey = `${this.chainId}|${v.operator}|${v.rule}|${v.violationBlock}`;
+    const coarseKey = `${this.chainId}|${v.operator}|${v.rule}`;
+    // (a) exact same violation@block already handled (this process, or on disk from a prior run).
+    if (this.proposedStableKeys.has(stableKey) || (await this.archive.has(proofHash))) {
+      this.logger.debug(
+        `Audit: ${v.operator} ${v.rule}@${v.violationBlock} already proposed (proof ${proofHash}) — skip`
+      );
+      return null;
+    }
+    // (b) cooldown: an ongoing violation whose block advances each tick must not re-propose
+    //     every interval. Only a SUCCESSFUL proposal arms the cooldown (see below).
+    const last = this.lastProposalAt.get(coarseKey);
+    if (last !== undefined && this.clock() - last < this.cooldownMs) {
+      this.logger.debug(
+        `Audit: ${v.operator} ${v.rule} within cooldown (${this.clock() - last}ms < ${this.cooldownMs}ms) — skip`
+      );
+      return null;
+    }
+
+    // File the slash proposal (proposal-INTENT). Best-effort: on failure (no wallet / revert)
+    // the proof is still archived so the evidence survives for a later retry.
+    let proposalTx: string | null = null;
+    try {
+      proposalTx = await this.blockchainService.createSlashProposal(
+        this.dvtValidatorAddress,
+        v.operator,
+        v.slashLevel,
+        v.reason
+      );
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(`Audit: ${v.operator} createProposal failed — ${msg}`);
+    }
+
+    const proof: SlashProof = {
+      version: "dvt-slash-proof/1",
       chainId: this.chainId,
       operator: v.operator,
       slashLevel: v.slashLevel,
@@ -275,37 +438,12 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       messageHash,
       evidence: {
         rule: v.rule,
-        observed: v.observed,
-        threshold: v.threshold,
+        observed: v.debt.toString(),
+        threshold: v.creditLimit.toString(),
         sources: v.sources,
+        violationBlock: v.violationBlock,
         observedAt: v.observedAt,
       },
-    };
-    const proofHash = computeProofHash(core);
-
-    // File the slash proposal (proposal-INTENT). Best-effort: on failure (no wallet / revert)
-    // the proof is still archived so the evidence survives for a later retry.
-    let proposalTx: string | null = null;
-    if (this.dvtValidatorAddress) {
-      try {
-        proposalTx = await this.blockchainService.createSlashProposal(
-          this.dvtValidatorAddress,
-          v.operator,
-          v.slashLevel,
-          v.reason
-        );
-      } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
-        this.logger.error(`Audit: ${v.operator} createProposal failed — ${msg}`);
-      }
-    } else {
-      this.logger.warn(
-        `Audit: ${v.operator} violated ${v.rule} but AUDIT_DVT_VALIDATOR_ADDRESS unset — proposal not filed`
-      );
-    }
-
-    const proof: SlashProof = {
-      ...core,
       proposalId,
       // Quorum co-sign fields are placeholders until increment 2.
       signerMask: "0x",
@@ -316,8 +454,13 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       penaltyAmount: "0",
       attestations: {},
       createdAt: this.clock(),
-      ...(proposalTx ? { executedTx: proposalTx } : {}),
+      ...(proposalTx ? { proposalTx } : {}),
     };
+
+    // Mark this exact violation@block handled BEFORE archiving so a same-block re-tick can't
+    // double-file; arm the coarse cooldown only when the proposal actually landed.
+    this.proposedStableKeys.add(stableKey);
+    if (proposalTx) this.lastProposalAt.set(coarseKey, this.clock());
 
     const { location } = await this.archive.put(proof);
     this.logger.warn(

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -44,10 +44,11 @@ export interface AuditDetection {
   operator: string;
   rule: string;
   proofHash: string;
-  proposalId: string;
+  /** Real on-chain proposal id (decimal string), or null when unresolved (not filed / event absent). */
+  proposalId: string | null;
   reason: string;
   detectedAt: number;
-  /** Tx hash of the filed proposal, or null if the write failed / no wallet. */
+  /** Tx hash of the filed proposal, or null if the write failed / no wallet / cooldown-suppressed. */
   proposalTx: string | null;
 }
 
@@ -77,14 +78,18 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
   /**
    * Stable-key dedup for the SAME on-chain violation@block: `chainId|operator|rule|block`.
    * Prevents re-proposing/re-archiving the identical block's violation within a process.
+   * Maps stableKey → wall-clock of first handling so stale entries can be pruned (bounded).
    */
-  private readonly proposedStableKeys = new Set<string>();
+  private readonly proposedStableKeys = new Map<string, number>();
   /**
    * Cooldown clock, keyed on the COARSE `chainId|operator|rule` (block-independent), holding
-   * the wall-clock of the last SUCCESSFUL proposal — an ongoing violation whose block advances
-   * every tick is not re-proposed until cooldownMs elapses.
+   * the wall-clock of the last proposal ATTEMPT — an ongoing violation whose block advances
+   * every tick is not re-attempted until cooldownMs elapses, even if every attempt reverts.
+   * Pruned once an entry ages past cooldownMs (the cooldown has expired → entry is dead).
    */
   private readonly lastProposalAt = new Map<string, number>();
+  /** Hard ceiling on either dedup map's size — a defensive LRU-style cap against unbounded growth. */
+  private static readonly MAX_DEDUP_ENTRIES = 10_000;
   /** Bounded ring of the most recent detections, newest first (for GET /audit/status). */
   private readonly recentDetections: AuditDetection[] = [];
   private static readonly MAX_RECENT = 20;
@@ -103,7 +108,23 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     this.enabled = config.get<boolean>("auditEnabled") === true;
     this.intervalMs = config.get<number>("auditIntervalMs") ?? 60_000;
     this.cooldownMs = config.get<number>("auditCooldownMs") ?? 3_600_000;
-    this.watchlist = (config.get<string[]>("auditWatchlist") ?? []).map(a => a.trim()).filter(Boolean);
+    // Canonicalize every watched operator to its checksummed form ONCE at ingest. All downstream
+    // identity/hash/key derivations (proofHash, stableKey, proposalId, proof.operator) then use the
+    // identical canonical string, so two DVT nodes with differently-cased AUDIT_WATCHLIST entries
+    // derive the SAME proofHash for the SAME violation (content-addressed cross-node dedup). Invalid
+    // addresses are dropped with a warning rather than crashing the process.
+    this.watchlist = (config.get<string[]>("auditWatchlist") ?? [])
+      .map(a => a.trim())
+      .filter(Boolean)
+      .map(a => {
+        try {
+          return ethers.getAddress(a);
+        } catch {
+          this.logger.warn(`Audit: dropping invalid AUDIT_WATCHLIST entry "${a}" (not an address)`);
+          return null;
+        }
+      })
+      .filter((a): a is string => a !== null);
     this.creditThresholdBps = BigInt(config.get<number>("auditCreditThresholdBps") ?? 10_000);
     this.chainId = config.get<number>("auditChainId") ?? 11155111;
     this.registryAddress = config.get<string>("auditRegistryAddress") ?? "";
@@ -214,6 +235,34 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
   }
 
   /**
+   * Record a handled violation@block stable-key with the current wall-clock, keeping the map
+   * bounded: entries past cooldownMs are pruned, and a hard LRU-style cap evicts the oldest if
+   * the map somehow still overflows (defensive against pathological churn within one cooldown).
+   */
+  private recordStableKey(stableKey: string): void {
+    this.proposedStableKeys.set(stableKey, this.clock());
+    if (this.proposedStableKeys.size > AuditService.MAX_DEDUP_ENTRIES) {
+      // Map iteration is insertion-ordered → the first key is the oldest inserted.
+      const oldest = this.proposedStableKeys.keys().next().value;
+      if (oldest !== undefined) this.proposedStableKeys.delete(oldest);
+    }
+  }
+
+  /**
+   * Evict dedup/cooldown entries that have aged past cooldownMs (they can no longer suppress
+   * anything, so keeping them only leaks memory in the long-lived daemon). Called once per tick.
+   */
+  private pruneDedupState(): void {
+    const now = this.clock();
+    for (const [key, ts] of this.proposedStableKeys) {
+      if (now - ts > this.cooldownMs) this.proposedStableKeys.delete(key);
+    }
+    for (const [key, ts] of this.lastProposalAt) {
+      if (now - ts > this.cooldownMs) this.lastProposalAt.delete(key);
+    }
+  }
+
+  /**
    * One audit cycle. Called on every interval tick. Never throws; per-operator errors
    * are logged and do not abort the sweep of the remaining operators.
    */
@@ -226,6 +275,9 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     }
     this.tickInFlight = true;
     this.lastTickAt = this.clock();
+    // Bound the dedup/cooldown maps so the long-lived daemon never leaks: drop entries that
+    // have aged past cooldownMs (they can no longer suppress anything) before each sweep.
+    this.pruneDedupState();
     try {
       for (const operator of this.watchlist) {
         try {
@@ -249,20 +301,29 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     // be mixed across blocks (no phantom over-limit from a mid-read state change).
     const violationBlock = await this.blockchainService.getBlockNumber();
 
-    const creditLimit = await this.blockchainService.getCreditLimit(
-      this.registryAddress,
-      operator,
-      violationBlock
-    );
-    const availableCredit = await this.blockchainService.getAvailableCredit(
-      this.superPaymasterAddress,
-      operator,
-      violationBlock
-    );
-    // GENUINE over-limit needs the operator's ACTUAL debt, read directly (block-pinned).
-    // getDebt is best-effort: null = getter absent / reverted → we CANNOT prove over-limit,
-    // so we SKIP (fail-safe, no proposal) rather than inferring it from availableCredit==0.
-    const debt = await this.readOperatorDebt(operator, violationBlock);
+    // All per-operator reads are pinned to the SAME block; issue them concurrently (5-6 reads)
+    // rather than serially. reputation + DVT stake lock are auxiliary evidence (not part of the
+    // rule) → best-effort with a fallback so they never fail the audit.
+    const [creditLimit, availableCredit, debt, reputation, dvtStake] = await Promise.all([
+      this.blockchainService.getCreditLimit(this.registryAddress, operator, violationBlock),
+      this.blockchainService.getAvailableCredit(this.superPaymasterAddress, operator, violationBlock),
+      // GENUINE over-limit needs the operator's ACTUAL debt, read directly (block-pinned).
+      // getDebt is best-effort: null = getter absent / reverted → we CANNOT prove over-limit,
+      // so we SKIP (fail-safe, no proposal) rather than inferring it from availableCredit==0.
+      this.readOperatorDebt(operator, violationBlock),
+      this.blockchainService
+        .getGlobalReputation(this.registryAddress, operator, violationBlock)
+        .catch(() => -1n),
+      this.gtokenStakingAddress
+        ? this.blockchainService.getRoleLockAmount(
+            this.gtokenStakingAddress,
+            operator,
+            ROLE_DVT,
+            violationBlock
+          )
+        : Promise.resolve(0n),
+    ]);
+
     if (debt === null) {
       this.logger.debug(
         `Audit: ${operator} debt unreadable (getDebt reverted/absent) — SKIP (fail-safe)`
@@ -270,29 +331,31 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       return;
     }
 
-    // Auxiliary evidence (not part of the credit rule): reputation + DVT stake lock.
-    const reputation = await this.blockchainService
-      .getGlobalReputation(this.registryAddress, operator, violationBlock)
-      .catch(() => -1n);
-    const dvtStake = this.gtokenStakingAddress
-      ? await this.blockchainService.getRoleLockAmount(
-          this.gtokenStakingAddress,
-          operator,
-          ROLE_DVT,
-          violationBlock
-        )
-      : 0n;
+    // FAIL-SAFE: creditLimit == 0 means UNCONFIGURED / de-registered, NOT "over limit". Flagging
+    // debt>0 against a zero limit would be an unconditional false positive → SKIP (never slash).
+    if (creditLimit === 0n) {
+      this.logger.debug(
+        `Audit: ${operator} creditLimit=0 (unconfigured/de-registered) — SKIP (fail-safe, not over-limit)`
+      );
+      return;
+    }
+    // CROSS-CONTRACT AGREEMENT: both SuperPaymaster signals must agree before flagging. If
+    // availableCredit > 0 the operator is still within SP's ENFORCED ceiling, so a lower/stale
+    // Registry creditLimit must NOT produce a false over-limit → SKIP. Only when SP itself reports
+    // the credit exhausted (availableCredit == 0) do we trust the debt>limit comparison.
+    if (availableCredit > 0n) {
+      this.logger.debug(
+        `Audit: ${operator} availableCredit=${availableCredit}>0 (within SP ceiling) — SKIP (no false over-limit)`
+      );
+      return;
+    }
 
     // STRICT credit-over-limit rule: flag ONLY a genuine breach where debt EXCEEDS the limit
     // (debt == creditLimit is AT the limit, not over → NOT a violation). creditThresholdBps is
     // an OPTIONAL additional margin on top: debt*10000/limit must also reach it (default 10000).
+    // creditLimit > 0 is guaranteed above, so the ratio is always well-defined.
     const overLimit = debt > creditLimit;
-    const usageBps =
-      creditLimit > 0n
-        ? (debt * 10_000n) / creditLimit
-        : debt > 0n
-          ? this.creditThresholdBps // no limit but has debt → treat as over the margin
-          : 0n;
+    const usageBps = (debt * 10_000n) / creditLimit;
 
     if (!overLimit) {
       this.logger.debug(
@@ -378,20 +441,6 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       violationBlock: v.violationBlock,
     };
     const proofHash = computeProofHash(identity);
-    // Deterministic proposal id from the same stable dedup key: chainId|operator|rule|block.
-    const proposalId = ethers.keccak256(
-      ABI.encode(
-        ["uint256", "address", "string", "uint256"],
-        [this.chainId, v.operator, v.rule, v.violationBlock]
-      )
-    );
-    // The message a DVT quorum would BLS-sign over the proposal (co-sign is increment 2).
-    const messageHash = ethers.keccak256(
-      ABI.encode(
-        ["bytes32", "address", "uint8", "uint256"],
-        [proposalId, v.operator, v.slashLevel, 0]
-      )
-    );
 
     // ── DEDUP ─────────────────────────────────────────────────────────────────────
     const stableKey = `${this.chainId}|${v.operator}|${v.rule}|${v.violationBlock}`;
@@ -403,30 +452,67 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       );
       return null;
     }
-    // (b) cooldown: an ongoing violation whose block advances each tick must not re-propose
-    //     every interval. Only a SUCCESSFUL proposal arms the cooldown (see below).
+
+    // (b) COOLDOWN gates the on-chain ATTEMPT only (never the archival). An ongoing violation
+    //     whose block advances each tick must not re-send a tx every interval — otherwise a
+    //     persistently-reverting proposal (e.g. proposer not an active validator) would burn
+    //     admin-wallet gas and churn nonces forever. The cooldown is armed on ATTEMPT (below),
+    //     regardless of the tx result, keyed on the COARSE chainId|operator|rule.
     const last = this.lastProposalAt.get(coarseKey);
-    if (last !== undefined && this.clock() - last < this.cooldownMs) {
+    const withinCooldown = last !== undefined && this.clock() - last < this.cooldownMs;
+
+    // File the slash proposal (proposal-INTENT), unless suppressed by the cooldown. Best-effort:
+    // on failure (no wallet / revert) the proof is still archived so the evidence survives.
+    let proposalTx: string | null = null;
+    let onchainProposalId: bigint | null = null;
+    if (withinCooldown) {
       this.logger.debug(
-        `Audit: ${v.operator} ${v.rule} within cooldown (${this.clock() - last}ms < ${this.cooldownMs}ms) — skip`
+        `Audit: ${v.operator} ${v.rule} within cooldown (${this.clock() - (last as number)}ms < ` +
+          `${this.cooldownMs}ms) — attempt suppressed, archiving evidence only`
       );
-      return null;
+    } else {
+      // Arm the cooldown on ATTEMPT (before the result) so a reverting tx still backs off for
+      // cooldownMs instead of retrying every advancing-block tick.
+      this.lastProposalAt.set(coarseKey, this.clock());
+      try {
+        const res = await this.blockchainService.createSlashProposal(
+          this.dvtValidatorAddress,
+          v.operator,
+          v.slashLevel,
+          v.reason
+        );
+        proposalTx = res.txHash;
+        onchainProposalId = res.proposalId;
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.logger.error(`Audit: ${v.operator} createProposal failed — ${msg}`);
+      }
     }
 
-    // File the slash proposal (proposal-INTENT). Best-effort: on failure (no wallet / revert)
-    // the proof is still archived so the evidence survives for a later retry.
-    let proposalTx: string | null = null;
-    try {
-      proposalTx = await this.blockchainService.createSlashProposal(
-        this.dvtValidatorAddress,
-        v.operator,
-        v.slashLevel,
-        v.reason
-      );
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      this.logger.error(`Audit: ${v.operator} createProposal failed — ${msg}`);
-    }
+    // Use the REAL on-chain proposal id (decimal string). When unresolved — attempt suppressed
+    // by cooldown, write failed, or the ProposalCreated event was absent — store null + a clear
+    // note rather than fabricating an id (a fake id would never match the on-chain proposal and
+    // would break increment-2's quorum co-sign / verifyAndExecute).
+    const proposalId: string | null = onchainProposalId !== null ? onchainProposalId.toString() : null;
+    const proposalIdNote = withinCooldown
+      ? "id-unresolved: proposal attempt suppressed by cooldown"
+      : proposalTx === null
+        ? "id-unresolved: proposal write failed"
+        : onchainProposalId === null
+          ? "id-unresolved: ProposalCreated event not found in receipt"
+          : undefined;
+    // The message a DVT quorum would BLS-sign over the proposal (co-sign is increment 2). Bound to
+    // the REAL id; when the id is unresolved the message is a placeholder ("0x") since there is no
+    // on-chain proposal to sign over yet.
+    const messageHash =
+      onchainProposalId !== null
+        ? ethers.keccak256(
+            ABI.encode(
+              ["uint256", "address", "uint8", "uint256"],
+              [onchainProposalId, v.operator, v.slashLevel, 0]
+            )
+          )
+        : "0x";
 
     const proof: SlashProof = {
       version: "dvt-slash-proof/1",
@@ -455,12 +541,12 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       attestations: {},
       createdAt: this.clock(),
       ...(proposalTx ? { proposalTx } : {}),
+      ...(proposalIdNote ? { proposalIdNote } : {}),
     };
 
     // Mark this exact violation@block handled BEFORE archiving so a same-block re-tick can't
-    // double-file; arm the coarse cooldown only when the proposal actually landed.
-    this.proposedStableKeys.add(stableKey);
-    if (proposalTx) this.lastProposalAt.set(coarseKey, this.clock());
+    // double-file. (The cooldown was already armed on ATTEMPT above.)
+    this.recordStableKey(stableKey);
 
     const { location } = await this.archive.put(proof);
     this.logger.warn(

--- a/src/modules/audit/proof-archive.ts
+++ b/src/modules/audit/proof-archive.ts
@@ -37,7 +37,15 @@ export interface Evidence {
   threshold: string;
   /** Each raw source reading that supports the detection. */
   sources: EvidenceSource[];
-  /** Unix ms when the observation was made. */
+  /**
+   * Block number ALL rule inputs were pinned to (from one provider.getBlockNumber()).
+   * Part of the content-address identity — two nodes reading the same block agree.
+   */
+  violationBlock: number;
+  /**
+   * Unix ms when the observation was made. Kept for humans ONLY — deliberately
+   * EXCLUDED from the content-address identity so wall-clock never perturbs proofHash.
+   */
   observedAt: number;
 }
 
@@ -68,15 +76,32 @@ export interface SlashProof {
   /** Per-node attestations — empty until increment 2. */
   attestations: Record<string, string>;
   createdAt: number;
-  /** Tx hash of the createProposal call, when the proposal-intent was filed. */
-  executedTx?: string;
+  /**
+   * Tx hash of the createProposal SUBMISSION (proposal-intent), when filed. This is the
+   * proposal tx, NOT the slash execution — execution (BLSAggregator.verifyAndExecute) is
+   * the deferred increment-2 step. Undefined when no proposal was filed.
+   */
+  proposalTx?: string;
 }
 
-/** The immutable subset that defines a detection — the content-address preimage. */
-export type ProofCore = Pick<
-  SlashProof,
-  "version" | "chainId" | "operator" | "slashLevel" | "reason" | "epoch" | "messageHash" | "evidence"
->;
+/**
+ * The ON-CHAIN identity that content-addresses a detection. Deliberately excludes all
+ * wall-clock (observedAt / epoch / createdAt) so two DVT nodes observing the SAME on-chain
+ * violation — same operator, same debt/limit, pinned to the same block — derive the SAME
+ * proofHash. This is what makes the archive content-addressed and cross-node de-duplicating.
+ */
+export interface ProofIdentity {
+  chainId: number;
+  operator: string;
+  /** Rule id, e.g. "credit-over-limit". */
+  rule: string;
+  /** On-chain credit limit at violationBlock (stringified). */
+  creditLimit: string;
+  /** On-chain debt at violationBlock (stringified). */
+  debt: string;
+  /** Block all rule inputs were pinned to. */
+  violationBlock: number;
+}
 
 /** Deterministic JSON with recursively sorted keys — a stable content-address preimage. */
 function stableStringify(value: unknown): string {
@@ -93,19 +118,22 @@ function stableStringify(value: unknown): string {
 
 /**
  * Content-address a detection: keccak256 over the canonical (sorted-key) serialization
- * of its immutable core. Deterministic — the same evidence always yields the same hash,
- * which is what makes the archive tamper-evident and de-duplicating.
+ * of its ON-CHAIN identity. Deterministic and wall-clock-free — the same on-chain
+ * violation always yields the same hash, which is what makes the archive tamper-evident,
+ * de-duplicating, and stable across nodes/ticks.
  */
-export function computeProofHash(core: ProofCore): string {
-  return ethers.keccak256(ethers.toUtf8Bytes(stableStringify(core)));
+export function computeProofHash(identity: ProofIdentity): string {
+  return ethers.keccak256(ethers.toUtf8Bytes(stableStringify(identity)));
 }
 
 /**
  * Proof archive backend. `put` is idempotent on `proofHash` (same evidence overwrites
- * the same file), so redundant detections across ticks don't multiply records.
+ * the same file), so redundant detections across ticks don't multiply records. `has`
+ * lets a proposer skip re-proposing a violation whose proof is already archived.
  */
 export interface IProofArchive {
   put(proof: SlashProof): Promise<{ proofHash: string; location: string }>;
+  has(proofHash: string): Promise<boolean>;
   count(): Promise<number>;
 }
 
@@ -118,6 +146,15 @@ export class LocalProofArchive implements IProofArchive {
     const location = path.join(this.dir, `${proof.proofHash}.json`);
     await fs.writeFile(location, JSON.stringify(proof, null, 2), "utf8");
     return { proofHash: proof.proofHash, location };
+  }
+
+  async has(proofHash: string): Promise<boolean> {
+    try {
+      await fs.access(path.join(this.dir, `${proofHash}.json`));
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   async count(): Promise<number> {
@@ -137,6 +174,10 @@ export class LocalProofArchive implements IProofArchive {
  */
 export class IpfsProofArchive implements IProofArchive {
   async put(): Promise<{ proofHash: string; location: string }> {
+    throw new Error("IpfsProofArchive not implemented — increment 3");
+  }
+
+  async has(): Promise<boolean> {
     throw new Error("IpfsProofArchive not implemented — increment 3");
   }
 

--- a/src/modules/audit/proof-archive.ts
+++ b/src/modules/audit/proof-archive.ts
@@ -1,0 +1,146 @@
+import { promises as fs } from "fs";
+import * as path from "path";
+import { ethers } from "ethers";
+
+/**
+ * DVT slash-proof archival (DVT Phase 2 / 目标2, increment 1).
+ *
+ * A detection produces a content-addressed evidence record. The record is the durable,
+ * auditable justification for a slash: any node (or a human reviewer) can re-fetch it by
+ * its `proofHash` and re-derive the same hash from the content, so a proposer cannot
+ * silently alter the evidence after the fact.
+ *
+ * Increment 1 fills only the evidence + proposal-intent fields. The BLS quorum fields
+ * (`signerMask`, `sigG2`, `participants`, `attestations`) are placeholders here — they are
+ * populated in increment 2 when the multi-node co-sign lands (see AuditService).
+ */
+
+export interface EvidenceSource {
+  /** Where the observation came from: an on-chain `view` read or a decoded `event`. */
+  type: "view" | "event";
+  /** Human-readable source name, e.g. "SuperPaymaster.getAvailableCredit". */
+  name: string;
+  /** Stringified observed value (bigints are serialized as decimal strings). */
+  value: string;
+  /** Tx hash, for `event` sources. */
+  tx?: string;
+  /** Block number, for `event` sources. */
+  block?: number;
+}
+
+export interface Evidence {
+  /** Rule id that fired, e.g. "credit-over-limit". */
+  rule: string;
+  /** The observed quantity that breached the rule (stringified). */
+  observed: string;
+  /** The threshold that was breached (stringified). */
+  threshold: string;
+  /** Each raw source reading that supports the detection. */
+  sources: EvidenceSource[];
+  /** Unix ms when the observation was made. */
+  observedAt: number;
+}
+
+/** The durable slash-proof record. Schema version "dvt-slash-proof/1". */
+export interface SlashProof {
+  version: "dvt-slash-proof/1";
+  proposalId: string;
+  chainId: number;
+  operator: string;
+  slashLevel: number;
+  reason: string;
+  epoch: number;
+  /** BLS message the quorum signs over the proposal. */
+  messageHash: string;
+  /** Bitmask of co-signers — empty until increment 2. */
+  signerMask: string;
+  /** Aggregated G2 signature — empty until increment 2. */
+  sigG2: string;
+  /** Content address of this record (keccak256 over the immutable evidence core). */
+  proofHash: string;
+  /** Co-signing node ids — empty until increment 2. */
+  participants: string[];
+  /** Address of the node that filed the proposal. */
+  proposer: string;
+  /** Penalty amount (stringified wei) — 0 in increment 1 (level-driven on-chain). */
+  penaltyAmount: string;
+  evidence: Evidence;
+  /** Per-node attestations — empty until increment 2. */
+  attestations: Record<string, string>;
+  createdAt: number;
+  /** Tx hash of the createProposal call, when the proposal-intent was filed. */
+  executedTx?: string;
+}
+
+/** The immutable subset that defines a detection — the content-address preimage. */
+export type ProofCore = Pick<
+  SlashProof,
+  "version" | "chainId" | "operator" | "slashLevel" | "reason" | "epoch" | "messageHash" | "evidence"
+>;
+
+/** Deterministic JSON with recursively sorted keys — a stable content-address preimage. */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return "[" + value.map(stableStringify).join(",") + "]";
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return "{" + keys.map(k => JSON.stringify(k) + ":" + stableStringify(obj[k])).join(",") + "}";
+}
+
+/**
+ * Content-address a detection: keccak256 over the canonical (sorted-key) serialization
+ * of its immutable core. Deterministic — the same evidence always yields the same hash,
+ * which is what makes the archive tamper-evident and de-duplicating.
+ */
+export function computeProofHash(core: ProofCore): string {
+  return ethers.keccak256(ethers.toUtf8Bytes(stableStringify(core)));
+}
+
+/**
+ * Proof archive backend. `put` is idempotent on `proofHash` (same evidence overwrites
+ * the same file), so redundant detections across ticks don't multiply records.
+ */
+export interface IProofArchive {
+  put(proof: SlashProof): Promise<{ proofHash: string; location: string }>;
+  count(): Promise<number>;
+}
+
+/** Filesystem-backed archive: one `<proofHash>.json` per detection under `dir`. */
+export class LocalProofArchive implements IProofArchive {
+  constructor(private readonly dir: string) {}
+
+  async put(proof: SlashProof): Promise<{ proofHash: string; location: string }> {
+    await fs.mkdir(this.dir, { recursive: true });
+    const location = path.join(this.dir, `${proof.proofHash}.json`);
+    await fs.writeFile(location, JSON.stringify(proof, null, 2), "utf8");
+    return { proofHash: proof.proofHash, location };
+  }
+
+  async count(): Promise<number> {
+    try {
+      const entries = await fs.readdir(this.dir);
+      return entries.filter(e => e.endsWith(".json")).length;
+    } catch {
+      // Directory not created yet → nothing archived.
+      return 0;
+    }
+  }
+}
+
+/**
+ * STUB — IPFS-pinned archive. Deferred to increment 3 (content-address pinning so proofs
+ * survive independent of any single node's disk). The interface is ready; the impl is not.
+ */
+export class IpfsProofArchive implements IProofArchive {
+  async put(): Promise<{ proofHash: string; location: string }> {
+    throw new Error("IpfsProofArchive not implemented — increment 3");
+  }
+
+  async count(): Promise<number> {
+    throw new Error("IpfsProofArchive not implemented — increment 3");
+  }
+}

--- a/src/modules/audit/proof-archive.ts
+++ b/src/modules/audit/proof-archive.ts
@@ -52,7 +52,14 @@ export interface Evidence {
 /** The durable slash-proof record. Schema version "dvt-slash-proof/1". */
 export interface SlashProof {
   version: "dvt-slash-proof/1";
-  proposalId: string;
+  /**
+   * REAL on-chain proposal id (auto-incrementing uint256, as a decimal string) parsed from the
+   * DVTValidator's ProposalCreated event. `null` when unresolved (proposal not filed, write
+   * reverted, or the event was absent) — never a fabricated value; see `proposalIdNote`.
+   */
+  proposalId: string | null;
+  /** Present only when `proposalId` is null: a human-readable reason the id could not be resolved. */
+  proposalIdNote?: string;
   chainId: number;
   operator: string;
   slashLevel: number;

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -423,6 +423,102 @@ export class BlockchainService {
     return BigInt(updatedAt);
   }
 
+  // ── DVT Phase 2 audit (目标2, increment 1) ─────────────────────────────────
+  //
+  // Read-only SuperPaymaster-stack views used by AuditService to evaluate the
+  // credit-over-limit rule, plus the one write (createProposal) that files a
+  // slash proposal. All reads use the shared read-only provider (no wallet
+  // required); the write uses the admin wallet (ETH_PRIVATE_KEY).
+
+  /** Registry.getCreditLimit(operator) — the operator's on-chain credit ceiling (wei-scaled). */
+  async getCreditLimit(registryAddress: string, operator: string): Promise<bigint> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+    const abi = ["function getCreditLimit(address account) view returns (uint256)"];
+    const contract = new ethers.Contract(registryAddress, abi, this.provider);
+    return BigInt(await contract.getCreditLimit(operator));
+  }
+
+  /** Registry.globalReputation(operator) — the operator's global reputation score. */
+  async getGlobalReputation(registryAddress: string, operator: string): Promise<bigint> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+    const abi = ["function globalReputation(address account) view returns (uint256)"];
+    const contract = new ethers.Contract(registryAddress, abi, this.provider);
+    return BigInt(await contract.globalReputation(operator));
+  }
+
+  /** SuperPaymaster.getAvailableCredit(operator) — remaining credit (creditLimit − debt). */
+  async getAvailableCredit(superPaymasterAddress: string, operator: string): Promise<bigint> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+    const abi = ["function getAvailableCredit(address account) view returns (uint256)"];
+    const contract = new ethers.Contract(superPaymasterAddress, abi, this.provider);
+    return BigInt(await contract.getAvailableCredit(operator));
+  }
+
+  /**
+   * GTokenStaking.roleLocks(operator, role) — the operator's staked amount locked
+   * behind a role (role = keccak256("DVT") for ROLE_DVT). The mapping returns a
+   * struct whose exact shape varies across GTokenStaking versions; we only need the
+   * leading `amount` word, so a single-field ABI reads it for either layout. Auxiliary
+   * (informational) evidence — best-effort: reverts/decode errors resolve to 0.
+   */
+  async getRoleLockAmount(
+    gtokenStakingAddress: string,
+    operator: string,
+    role: string
+  ): Promise<bigint> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+    const abi = ["function roleLocks(address account, bytes32 role) view returns (uint256 amount)"];
+    const contract = new ethers.Contract(gtokenStakingAddress, abi, this.provider);
+    try {
+      const amount = await contract.roleLocks(operator, role);
+      return BigInt(amount);
+    } catch (error: any) {
+      this.logger.warn(
+        `roleLocks read failed on ${gtokenStakingAddress} for ${operator}: ${error.message}`
+      );
+      return 0n;
+    }
+  }
+
+  /**
+   * File a slash proposal on the DVTValidator:
+   *   createProposal(address operator, uint8 level, string reason)
+   * Uses the admin wallet (ETH_PRIVATE_KEY). This is the proposal-INTENT only — the
+   * multi-node BLS quorum co-sign + BLSAggregator.verifyAndExecute is deferred to
+   * increment 2 (see AuditService.coordinateQuorumCoSign). Returns the tx hash.
+   */
+  async createSlashProposal(
+    dvtValidatorAddress: string,
+    operator: string,
+    level: number,
+    reason: string
+  ): Promise<string> {
+    if (!this.wallet) {
+      throw new Error("Blockchain not configured. Set ETH_PRIVATE_KEY environment variable.");
+    }
+    const abi = [
+      "function createProposal(address operator, uint8 level, string reason) returns (bytes32)",
+    ];
+    const contract = new ethers.Contract(dvtValidatorAddress, abi, this.wallet);
+    const fees = await bumpedFees(this.provider);
+    const tx: ethers.TransactionResponse = await contract.createProposal(
+      operator,
+      level,
+      reason,
+      fees
+    );
+    this.logger.log(`createProposal(${operator}, ${level}) submitted: ${tx.hash}`);
+    return tx.hash;
+  }
+
   /** Current network base-fee in gwei (0 on chains without EIP-1559). */
   async getBaseFeeGwei(): Promise<bigint> {
     const block = await this.provider.getBlock("latest");

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -545,23 +545,32 @@ export class BlockchainService {
 
   /**
    * File a slash proposal on the DVTValidator:
-   *   createProposal(address operator, uint8 level, string reason)
+   *   createProposal(address operator, uint8 level, string reason) returns (uint256 id)
    * Uses the admin wallet (ETH_PRIVATE_KEY). This is the proposal-INTENT only — the
    * multi-node BLS quorum co-sign + BLSAggregator.verifyAndExecute is deferred to
-   * increment 2 (see AuditService.coordinateQuorumCoSign). Returns the tx hash.
+   * increment 2 (see AuditService.coordinateQuorumCoSign).
+   *
+   * The contract assigns an auto-incrementing `uint256 id` and emits `ProposalCreated`.
+   * A transaction's Solidity return value is NOT recoverable off-chain, so the REAL id is
+   * parsed from the emitted event in the receipt (best-effort). Returns both the tx hash and
+   * the on-chain proposal id (`proposalId` is `null` when the event can't be found — e.g. an
+   * older contract with a different event shape — so the caller never fabricates an id).
    */
   async createSlashProposal(
     dvtValidatorAddress: string,
     operator: string,
     level: number,
     reason: string
-  ): Promise<string> {
+  ): Promise<{ txHash: string; proposalId: bigint | null }> {
     if (!this.wallet) {
       throw new Error("Blockchain not configured. Set ETH_PRIVATE_KEY environment variable.");
     }
+    // Minimal fragment set: the write function plus the event we parse the real id from.
     const abi = [
-      "function createProposal(address operator, uint8 level, string reason) returns (bytes32)",
+      "function createProposal(address operator, uint8 level, string reason) returns (uint256)",
+      "event ProposalCreated(uint256 indexed id, address indexed operator, uint8 level)",
     ];
+    const iface = new ethers.Interface(abi);
     const contract = new ethers.Contract(dvtValidatorAddress, abi, this.wallet);
     const fees = await bumpedFees(this.provider);
     const tx: ethers.TransactionResponse = await contract.createProposal(
@@ -579,8 +588,30 @@ export class BlockchainService {
         `createProposal tx ${tx.hash} failed (status ${receipt?.status ?? "unknown"})`
       );
     }
-    this.logger.log(`createProposal(${operator}, ${level}) confirmed in block ${receipt.blockNumber}`);
-    return tx.hash;
+    // Parse the REAL on-chain proposal id from the emitted ProposalCreated event. Best-effort:
+    // decode by topic, ignore unrelated logs, and fall back to null (never fabricate an id).
+    let proposalId: bigint | null = null;
+    for (const log of receipt.logs) {
+      try {
+        const parsed = iface.parseLog({ topics: [...log.topics], data: log.data });
+        if (parsed && parsed.name === "ProposalCreated") {
+          proposalId = BigInt(parsed.args.id ?? parsed.args[0]);
+          break;
+        }
+      } catch {
+        // Not a ProposalCreated log (or from another contract) — skip.
+      }
+    }
+    if (proposalId === null) {
+      this.logger.warn(
+        `createProposal ${tx.hash} confirmed but no ProposalCreated event found — id unresolved`
+      );
+    }
+    this.logger.log(
+      `createProposal(${operator}, ${level}) confirmed in block ${receipt.blockNumber}` +
+        (proposalId !== null ? ` (proposalId ${proposalId})` : "")
+    );
+    return { txHash: tx.hash, proposalId };
   }
 
   /** Current network base-fee in gwei (0 on chains without EIP-1559). */

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -430,34 +430,88 @@ export class BlockchainService {
   // slash proposal. All reads use the shared read-only provider (no wallet
   // required); the write uses the admin wallet (ETH_PRIVATE_KEY).
 
+  /**
+   * Current chain head block number. AuditService reads it ONCE per operator and pins
+   * every subsequent view read to it (blockTag) so all rule inputs come from one block —
+   * no cross-block / phantom mixing of creditLimit, availableCredit and debt.
+   */
+  async getBlockNumber(): Promise<number> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+    return this.provider.getBlockNumber();
+  }
+
+  /** Runtime bytecode at `address` ("0x" when there's no contract). Used for a fail-closed
+   *  bootstrap existence check before the audit poll trusts an address. */
+  async getCode(address: string, blockTag?: number): Promise<string> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+    return this.provider.getCode(address, blockTag);
+  }
+
   /** Registry.getCreditLimit(operator) — the operator's on-chain credit ceiling (wei-scaled). */
-  async getCreditLimit(registryAddress: string, operator: string): Promise<bigint> {
+  async getCreditLimit(
+    registryAddress: string,
+    operator: string,
+    blockTag?: number
+  ): Promise<bigint> {
     if (!this.provider) {
       throw new Error("Blockchain provider not configured");
     }
     const abi = ["function getCreditLimit(address account) view returns (uint256)"];
     const contract = new ethers.Contract(registryAddress, abi, this.provider);
-    return BigInt(await contract.getCreditLimit(operator));
+    return BigInt(await contract.getCreditLimit(operator, { blockTag }));
+  }
+
+  /**
+   * Best-effort operator debt read: `getDebt(address) view returns (uint256)`, tried on the
+   * SuperPaymaster / Registry credit-debt system (SP v5 recordDebt/getDebt). Returns the debt
+   * as a bigint, or `null` when the read reverts / the getter is absent — the caller MUST treat
+   * `null` as "debt unknown" and SKIP (fail-safe: never guess an over-limit from missing data).
+   */
+  async getDebt(contractAddress: string, operator: string, blockTag?: number): Promise<bigint | null> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+    const abi = ["function getDebt(address account) view returns (uint256)"];
+    const contract = new ethers.Contract(contractAddress, abi, this.provider);
+    try {
+      const debt = await contract.getDebt(operator, { blockTag });
+      return BigInt(debt);
+    } catch (error: any) {
+      this.logger.warn(`getDebt read failed on ${contractAddress} for ${operator}: ${error.message}`);
+      return null;
+    }
   }
 
   /** Registry.globalReputation(operator) — the operator's global reputation score. */
-  async getGlobalReputation(registryAddress: string, operator: string): Promise<bigint> {
+  async getGlobalReputation(
+    registryAddress: string,
+    operator: string,
+    blockTag?: number
+  ): Promise<bigint> {
     if (!this.provider) {
       throw new Error("Blockchain provider not configured");
     }
     const abi = ["function globalReputation(address account) view returns (uint256)"];
     const contract = new ethers.Contract(registryAddress, abi, this.provider);
-    return BigInt(await contract.globalReputation(operator));
+    return BigInt(await contract.globalReputation(operator, { blockTag }));
   }
 
   /** SuperPaymaster.getAvailableCredit(operator) — remaining credit (creditLimit − debt). */
-  async getAvailableCredit(superPaymasterAddress: string, operator: string): Promise<bigint> {
+  async getAvailableCredit(
+    superPaymasterAddress: string,
+    operator: string,
+    blockTag?: number
+  ): Promise<bigint> {
     if (!this.provider) {
       throw new Error("Blockchain provider not configured");
     }
     const abi = ["function getAvailableCredit(address account) view returns (uint256)"];
     const contract = new ethers.Contract(superPaymasterAddress, abi, this.provider);
-    return BigInt(await contract.getAvailableCredit(operator));
+    return BigInt(await contract.getAvailableCredit(operator, { blockTag }));
   }
 
   /**
@@ -470,7 +524,8 @@ export class BlockchainService {
   async getRoleLockAmount(
     gtokenStakingAddress: string,
     operator: string,
-    role: string
+    role: string,
+    blockTag?: number
   ): Promise<bigint> {
     if (!this.provider) {
       throw new Error("Blockchain provider not configured");
@@ -478,7 +533,7 @@ export class BlockchainService {
     const abi = ["function roleLocks(address account, bytes32 role) view returns (uint256 amount)"];
     const contract = new ethers.Contract(gtokenStakingAddress, abi, this.provider);
     try {
-      const amount = await contract.roleLocks(operator, role);
+      const amount = await contract.roleLocks(operator, role, { blockTag });
       return BigInt(amount);
     } catch (error: any) {
       this.logger.warn(
@@ -516,6 +571,15 @@ export class BlockchainService {
       fees
     );
     this.logger.log(`createProposal(${operator}, ${level}) submitted: ${tx.hash}`);
+    // Await the receipt: a dropped/reverted proposal must NOT be recorded as success.
+    // Throw on failure so the caller archives the evidence but records proposalTx=null.
+    const receipt = await tx.wait();
+    if (!receipt || receipt.status !== 1) {
+      throw new Error(
+        `createProposal tx ${tx.hash} failed (status ${receipt?.status ?? "unknown"})`
+      );
+    }
+    this.logger.log(`createProposal(${operator}, ${level}) confirmed in block ${receipt.blockNumber}`);
     return tx.hash;
   }
 


### PR DESCRIPTION
DVT **Phase 2 (目标2)** increment 1: DVT 节点自主审计 SP operator → 违规时提 slash 提案 + 归档证据。让质押有牙齿。

## 内容
- `src/modules/audit/`: 后台轮询(phase-jitter,仿 keeper)+ credit-over-limit 规则 + proof 内容寻址归档 + `GET /audit/status` + capability 注册。默认关闭(AUDIT_ENABLED)。
- blockchain.service: getCreditLimit/getDebt/getAvailableCredit/getGlobalReputation/getRoleLockAmount 读(支持 blockTag)+ `createSlashProposal` 写(await receipt)。
- **只提案不执行 slash**: quorum BLS co-sign + `verifyAndExecute` = increment-2 stub;IPFS = increment-3 stub。

## Codex 审查(2 轮)
Round 1: 2 Critical + 3 High + 2 Medium(全是"误报→误触发 slash"类)全修 —— 严格 debt>creditLimit、块钉读、稳定 dedup+cooldown、single-flight、proofHash 只用链上事实、config fail-closed(getCode)、await receipt+proposalTx。
Round 2: Codex 用量到限未跑成 → 本地 Tier-3 核验 + @copilot 独立复审(本 PR)。

## 测试
22/22 audit(含 at-limit-不触发 / 严格-over-触发 / 同违规-同 proofHash / dedup / single-flight / block-pin / fail-closed 专项)+ 196/196 全量;type-check/build/lint 清。

关联: CC-11(Phase 2)、#163。increment-2 = gossip quorum co-sign + verifyAndExecute。
