### PR TITLE
fix(#163 Phase2): audit rule works against REAL SuperPaymaster ABI (getDebt on token)

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -203,6 +203,11 @@ export default () => {
     auditSuperPaymasterAddress: process.env.AUDIT_SUPER_PAYMASTER_ADDRESS || undefined,
     auditDvtValidatorAddress: process.env.AUDIT_DVT_VALIDATOR_ADDRESS || undefined,
     auditGtokenStakingAddress: process.env.AUDIT_GTOKEN_STAKING_ADDRESS || undefined,
+    // The xPNTs token the credit-over-limit rule reads operator debt from. Debt lives on the
+    // xPNTs TOKEN (IxPNTsToken.getDebt(address)), NOT on SuperPaymaster/Registry. Default is the
+    // Sepolia aPNTs token. FAIL-CLOSED: required + must have on-chain code when AUDIT_ENABLED=true.
+    auditApntsTokenAddress:
+      process.env.AUDIT_APNTS_TOKEN_ADDRESS || "0x696A73701b104c6cCBbAadDD2216788ea08EaB89",
 
     // Gossip Network
     gossipPublicUrl: process.env.GOSSIP_PUBLIC_URL || `ws://localhost:${port}/ws`,

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -7,6 +7,8 @@ const REGISTRY = "0xf5Bf37ca83AfdAab73691bA7eCcDfA69b8708E71";
 const SUPER_PAYMASTER = "0x" + "34".repeat(20);
 const DVT_VALIDATOR = "0x" + "56".repeat(20);
 const GTOKEN_STAKING = "0x" + "78".repeat(20);
+/** aPNTs xPNTs token — where getDebt actually lives (per the real SP ABI). */
+const APNTS_TOKEN = "0x696A73701b104c6cCBbAadDD2216788ea08EaB89";
 const BLOCK = 12_345;
 
 const BASE_CONFIG: Record<string, unknown> = {
@@ -20,6 +22,7 @@ const BASE_CONFIG: Record<string, unknown> = {
   auditSuperPaymasterAddress: SUPER_PAYMASTER,
   auditDvtValidatorAddress: DVT_VALIDATOR,
   auditGtokenStakingAddress: GTOKEN_STAKING,
+  auditApntsTokenAddress: APNTS_TOKEN,
   auditProofDir: "./audit-proofs-test",
 };
 
@@ -38,8 +41,13 @@ function makeBlockchain(
     getBlockNumber: () => Promise<number>;
     getCode: (addr: string) => Promise<string>;
     getCreditLimit: (addr: string, op: string, bt?: number) => Promise<bigint>;
-    getAvailableCredit: (addr: string, op: string, bt?: number) => Promise<bigint>;
-    getDebt: (addr: string, op: string, bt?: number) => Promise<bigint | null>;
+    getAvailableCredit: (
+      addr: string,
+      op: string,
+      token: string,
+      bt?: number
+    ) => Promise<bigint>;
+    getDebt: (tokenAddr: string, op: string, bt?: number) => Promise<bigint | null>;
     getGlobalReputation: (addr: string, op: string, bt?: number) => Promise<bigint>;
     getRoleLockAmount: (...args: any[]) => Promise<bigint>;
     createSlashProposal: (...args: any[]) => Promise<{ txHash: string; proposalId: bigint | null }>;
@@ -284,7 +292,12 @@ describe("AuditService", () => {
       seen.limit = bt;
       return 1000n;
     };
-    blockchain.getAvailableCredit = async (_a: string, _o: string, bt?: number) => {
+    blockchain.getAvailableCredit = async (
+      _a: string,
+      _o: string,
+      _token: string,
+      bt?: number
+    ) => {
       seen.avail = bt;
       return 0n;
     };
@@ -668,6 +681,69 @@ describe("AuditService", () => {
     await svc.tick(); // prune runs at tick start → the stale entries are evicted
     expect((svc as any).proposedStableKeys.size).toBe(0);
     expect((svc as any).lastProposalAt.size).toBe(0);
+  });
+
+  // ── REAL SP ABI: debt lives on the xPNTs TOKEN, credit takes (user, token) ──────
+  it("reads debt from the aPNTs TOKEN and passes the token to getAvailableCredit", async () => {
+    const debtTargets: string[] = [];
+    const creditArgs: Array<{ sp: string; op: string; token: string }> = [];
+    const blockchain = overLimitBlockchain({
+      getDebt: async (tokenAddr: string, _op: string) => {
+        debtTargets.push(tokenAddr);
+        return 2000n;
+      },
+      getAvailableCredit: async (sp: string, op: string, token: string) => {
+        creditArgs.push({ sp, op, token });
+        return 0n;
+      },
+    });
+    const svc = makeService(blockchain, makeConfig(), makeArchive());
+    await svc.tick();
+    // getDebt is called against the TOKEN, never the SuperPaymaster or Registry.
+    expect(debtTargets).toEqual([APNTS_TOKEN]);
+    // getAvailableCredit gets (superPaymaster, operator, token).
+    expect(creditArgs).toEqual([{ sp: SUPER_PAYMASTER, op: OPERATOR, token: APNTS_TOKEN }]);
+  });
+
+  it("fail-closed: a missing aPNTs token address → DISABLED, never schedules", async () => {
+    const svc = makeService(
+      makeBlockchain(),
+      makeConfig({ auditApntsTokenAddress: undefined }),
+      makeArchive()
+    );
+    await svc.onApplicationBootstrap();
+    expect((svc as any).startupTimer).toBeNull();
+    expect((await svc.getStatus()).enabled).toBe(false);
+  });
+
+  it("archives the REAL 7-field messageHash matching BLSAggregator.verifyAndExecute", async () => {
+    const now = 1_700_000_000_000;
+    const blockchain = overLimitBlockchain({
+      createSlashProposal: async () => ({ txHash: "0xTX", proposalId: 7n }),
+    });
+    const archive = makeArchive();
+    const svc = makeService(blockchain, makeConfig(), archive, clockAt(now));
+    await svc.tick();
+
+    const proof = archive.records[0];
+    const epoch = Math.floor(now / 1000);
+    const expected = ethers.keccak256(
+      new ethers.AbiCoder().encode(
+        ["uint256", "address", "uint8", "address[]", "uint256[]", "uint256", "uint256"],
+        [7n, OPERATOR, 1, [], [], epoch, 11155111]
+      )
+    );
+    expect(proof.messageHash).toBe(expected);
+  });
+
+  it("unresolved proposal id → messageHash placeholder '0x' (no on-chain proposal to sign)", async () => {
+    const blockchain = overLimitBlockchain({
+      createSlashProposal: async () => ({ txHash: "0xDEF", proposalId: null }),
+    });
+    const archive = makeArchive();
+    const svc = makeService(blockchain, makeConfig(), archive);
+    await svc.tick();
+    expect(archive.records[0].messageHash).toBe("0x");
   });
 
   it("coordinateQuorumCoSign is deferred to increment 2 (throws)", async () => {

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -261,7 +261,8 @@ describe("AuditService", () => {
     expect(proof.evidence.violationBlock).toBe(BLOCK);
     const sourceNames = proof.evidence.sources.map(s => s.name);
     expect(sourceNames).toContain("Registry.getCreditLimit");
-    expect(sourceNames).toContain("SuperPaymaster.getDebt");
+    // Debt evidence must name the REAL source — the aPNTs xPNTs token, not SuperPaymaster.
+    expect(sourceNames).toContain(`IxPNTsToken(${APNTS_TOKEN}).getDebt`);
     expect(sourceNames).toContain("SuperPaymaster.getAvailableCredit");
 
     // proofHash is a real content address over ON-CHAIN identity: recomputing matches.

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -386,7 +386,12 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       `(usage ${usageBps}bps ≥ ${this.creditThresholdBps}bps, availableCredit ${availableCredit}, block ${violationBlock})`;
     const sources: EvidenceSource[] = [
       { type: "view", name: "Registry.getCreditLimit", value: creditLimit.toString(), block: violationBlock },
-      { type: "view", name: "SuperPaymaster.getDebt", value: debt.toString(), block: violationBlock },
+      {
+        type: "view",
+        name: `IxPNTsToken(${this.apntsTokenAddress}).getDebt`,
+        value: debt.toString(),
+        block: violationBlock,
+      },
       {
         type: "view",
         name: "SuperPaymaster.getAvailableCredit",

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -66,6 +66,8 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
   private readonly superPaymasterAddress: string;
   private readonly dvtValidatorAddress: string;
   private readonly gtokenStakingAddress: string;
+  /** xPNTs token the credit-over-limit rule reads operator debt from (getDebt lives on the token). */
+  private readonly apntsTokenAddress: string;
   private readonly archive: IProofArchive;
   private readonly clock: () => number;
   private readonly random: () => number;
@@ -131,6 +133,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     this.superPaymasterAddress = config.get<string>("auditSuperPaymasterAddress") ?? "";
     this.dvtValidatorAddress = config.get<string>("auditDvtValidatorAddress") ?? "";
     this.gtokenStakingAddress = config.get<string>("auditGtokenStakingAddress") ?? "";
+    this.apntsTokenAddress = config.get<string>("auditApntsTokenAddress") ?? "";
     this.clock = clock ?? (() => Date.now());
     this.random = random ?? (() => Math.random());
     this.archive =
@@ -161,6 +164,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     if (!this.registryAddress) missing.push("AUDIT_REGISTRY_ADDRESS");
     if (!this.superPaymasterAddress) missing.push("AUDIT_SUPER_PAYMASTER_ADDRESS");
     if (!this.dvtValidatorAddress) missing.push("AUDIT_DVT_VALIDATOR_ADDRESS");
+    if (!this.apntsTokenAddress) missing.push("AUDIT_APNTS_TOKEN_ADDRESS");
     if (missing.length > 0) {
       this.enabled = false;
       this.logger.error(
@@ -178,6 +182,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       ["AUDIT_REGISTRY_ADDRESS", this.registryAddress],
       ["AUDIT_SUPER_PAYMASTER_ADDRESS", this.superPaymasterAddress],
       ["AUDIT_DVT_VALIDATOR_ADDRESS", this.dvtValidatorAddress],
+      ["AUDIT_APNTS_TOKEN_ADDRESS", this.apntsTokenAddress],
     ];
     if (this.gtokenStakingAddress) {
       toCheck.push(["AUDIT_GTOKEN_STAKING_ADDRESS", this.gtokenStakingAddress]);
@@ -306,7 +311,12 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     // rule) → best-effort with a fallback so they never fail the audit.
     const [creditLimit, availableCredit, debt, reputation, dvtStake] = await Promise.all([
       this.blockchainService.getCreditLimit(this.registryAddress, operator, violationBlock),
-      this.blockchainService.getAvailableCredit(this.superPaymasterAddress, operator, violationBlock),
+      this.blockchainService.getAvailableCredit(
+        this.superPaymasterAddress,
+        operator,
+        this.apntsTokenAddress,
+        violationBlock
+      ),
       // GENUINE over-limit needs the operator's ACTUAL debt, read directly (block-pinned).
       // getDebt is best-effort: null = getter absent / reverted → we CANNOT prove over-limit,
       // so we SKIP (fail-safe, no proposal) rather than inferring it from availableCredit==0.
@@ -401,14 +411,13 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
   }
 
   /**
-   * Best-effort operator debt read (block-pinned). Tries the SuperPaymaster credit-debt
-   * system first, then the Registry. Returns null only when NEITHER exposes a readable
-   * getDebt — the caller treats null as "unknown" and skips (never guesses an over-limit).
+   * Best-effort operator debt read (block-pinned). Per the verified SP ABI, debt lives on the
+   * xPNTs TOKEN (IxPNTsToken.getDebt(address)), NOT SuperPaymaster/Registry — so this reads the
+   * aPNTs token directly. Returns null when the token's getDebt reverts / is absent — the caller
+   * treats null as "unknown" and skips (never guesses an over-limit from missing data).
    */
   private async readOperatorDebt(operator: string, blockTag: number): Promise<bigint | null> {
-    const fromSp = await this.blockchainService.getDebt(this.superPaymasterAddress, operator, blockTag);
-    if (fromSp !== null) return fromSp;
-    return this.blockchainService.getDebt(this.registryAddress, operator, blockTag);
+    return this.blockchainService.getDebt(this.apntsTokenAddress, operator, blockTag);
   }
 
   /**
@@ -501,15 +510,19 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
         : onchainProposalId === null
           ? "id-unresolved: ProposalCreated event not found in receipt"
           : undefined;
-    // The message a DVT quorum would BLS-sign over the proposal (co-sign is increment 2). Bound to
-    // the REAL id; when the id is unresolved the message is a placeholder ("0x") since there is no
-    // on-chain proposal to sign over yet.
+    // The message a DVT quorum would BLS-sign over the proposal (co-sign is increment 2). This
+    // MUST match BLSAggregator.verifyAndExecute's message-hash preimage (BLSAggregator.sol:406):
+    //   keccak256(abi.encode(proposalId, operator, slashLevel, repUsers[], newScores[], epoch, chainId))
+    // — 7 fields. For a slash-only proposal repUsers/newScores are empty ([]). Bound to the REAL id;
+    // when the id is unresolved the message is a placeholder ("0x") since there is no on-chain
+    // proposal to sign over yet.
+    // TODO(inc-2): epoch must match the value passed to verifyAndExecute at co-sign time.
     const messageHash =
       onchainProposalId !== null
         ? ethers.keccak256(
             ABI.encode(
-              ["uint256", "address", "uint8", "uint256"],
-              [onchainProposalId, v.operator, v.slashLevel, 0]
+              ["uint256", "address", "uint8", "address[]", "uint256[]", "uint256", "uint256"],
+              [onchainProposalId, v.operator, v.slashLevel, [], [], epoch, this.chainId]
             )
           )
         : "0x";

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -466,22 +466,24 @@ export class BlockchainService {
   }
 
   /**
-   * Best-effort operator debt read: `getDebt(address) view returns (uint256)`, tried on the
-   * SuperPaymaster / Registry credit-debt system (SP v5 recordDebt/getDebt). Returns the debt
-   * as a bigint, or `null` when the read reverts / the getter is absent — the caller MUST treat
-   * `null` as "debt unknown" and SKIP (fail-safe: never guess an over-limit from missing data).
+   * Best-effort operator debt read: `getDebt(address user) view returns (uint256)` on the xPNTs
+   * TOKEN contract (`tokenAddress`) — NOT SuperPaymaster/Registry. Per the verified SP ABI, debt
+   * lives on the xPNTs token itself (IxPNTsToken.getDebt), and SuperPaymaster.getAvailableCredit
+   * internally reads `creditLimit - IxPNTsToken(token).getDebt(user)`. Returns the debt as a bigint,
+   * or `null` when the read reverts / the getter is absent — the caller MUST treat `null` as "debt
+   * unknown" and SKIP (fail-safe: never guess an over-limit from missing data).
    */
-  async getDebt(contractAddress: string, operator: string, blockTag?: number): Promise<bigint | null> {
+  async getDebt(tokenAddress: string, operator: string, blockTag?: number): Promise<bigint | null> {
     if (!this.provider) {
       throw new Error("Blockchain provider not configured");
     }
-    const abi = ["function getDebt(address account) view returns (uint256)"];
-    const contract = new ethers.Contract(contractAddress, abi, this.provider);
+    const abi = ["function getDebt(address user) view returns (uint256)"];
+    const contract = new ethers.Contract(tokenAddress, abi, this.provider);
     try {
       const debt = await contract.getDebt(operator, { blockTag });
       return BigInt(debt);
     } catch (error: any) {
-      this.logger.warn(`getDebt read failed on ${contractAddress} for ${operator}: ${error.message}`);
+      this.logger.warn(`getDebt read failed on token ${tokenAddress} for ${operator}: ${error.message}`);
       return null;
     }
   }
@@ -500,18 +502,23 @@ export class BlockchainService {
     return BigInt(await contract.globalReputation(operator, { blockTag }));
   }
 
-  /** SuperPaymaster.getAvailableCredit(operator) — remaining credit (creditLimit − debt). */
+  /**
+   * SuperPaymaster.getAvailableCredit(user, token) — remaining credit for `operator` against a
+   * specific xPNTs `token`. Per the verified SP ABI this takes TWO args (user, token) and returns
+   * `creditLimit - IxPNTsToken(token).getDebt(user)` clamped ≥0.
+   */
   async getAvailableCredit(
     superPaymasterAddress: string,
     operator: string,
+    token: string,
     blockTag?: number
   ): Promise<bigint> {
     if (!this.provider) {
       throw new Error("Blockchain provider not configured");
     }
-    const abi = ["function getAvailableCredit(address account) view returns (uint256)"];
+    const abi = ["function getAvailableCredit(address user, address token) view returns (uint256)"];
     const contract = new ethers.Contract(superPaymasterAddress, abi, this.provider);
-    return BigInt(await contract.getAvailableCredit(operator, { blockTag }));
+    return BigInt(await contract.getAvailableCredit(operator, token, { blockTag }));
   }
 
   /**


### PR DESCRIPTION
Self-read the actual SuperPaymaster source to verify the audit module's SP integration (per the reality-check). Found the inc-1 credit-over-limit rule was **inert** — it read `getDebt` from SuperPaymaster/Registry, but debt lives on the **xPNTs token** (`IxPNTsToken.getDebt(user)`), so the read always reverted → the rule silently SKIP'd every tick.

## Fixed vs verified real ABI
- **getDebt** → `IxPNTsToken(aPNTs 0x696A7370…).getDebt(user)` (was SP→Registry, both wrong). Config `AUDIT_APNTS_TOKEN_ADDRESS`.
- **getAvailableCredit** → real 2-arg `getAvailableCredit(user, token)`.
- **messageHash** → real `keccak256(abi.encode(proposalId, operator, slashLevel, repUsers[], newScores[], epoch, chainId))` (7 fields), so inc-2 quorum co-sign binds the right hash.
- fail-closed now includes the aPNTs token (getCode check).
- `ProposalCreated` event + `createProposal` return were already correct (confirmed vs source).

Now the rule actually fires on a genuine `debt > creditLimit` instead of always skipping.

Tests: 35/35 audit + 209/209 full; type-check/build/lint clean. Related: CC-13, #163.
