### PR TITLE
feat(#163 Phase2 inc2): two-step slash-consensus orchestration (default-off, SP #329)

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -44,16 +44,18 @@ ERC-4337 compliant smart contract wallets with:
 - **Flexible Validation**: Support for both AAStarValidator and standard ECDSA
 - **Modular Design**: Clean separation between account logic and validation
 
-> The account + factory contracts were retired (#163 Phase 1) — see the note below. Account
-> deployment now lives in `airaccount-contract`.
+> The account + factory contracts were retired (#163 Phase 1) — see the note
+> below. Account deployment now lives in `airaccount-contract`.
 
 ## Project Structure
 
-> **Note (#163 Phase 1):** the ERC-4337 account + factory contracts (`AAStarAccountBase`,
-> `AAStarAccountV6/7/8`, `AAStarAccountFactoryV6/7/8`) and their `DeployAAStar*` bundle scripts
-> were **retired**. This repo now ships the DVT **validator only**; the production account line is
-> `airaccount-contract`'s `AAStarAirAccountV7` (EntryPoint v0.7, behind its ValidatorRouter).
-> `AAStarValidator` is router-mountable via `IAAStarAlgorithm.validate()` (algId 0x01).
+> **Note (#163 Phase 1):** the ERC-4337 account + factory contracts
+> (`AAStarAccountBase`, `AAStarAccountV6/7/8`, `AAStarAccountFactoryV6/7/8`) and
+> their `DeployAAStar*` bundle scripts were **retired**. This repo now ships the
+> DVT **validator only**; the production account line is `airaccount-contract`'s
+> `AAStarAirAccountV7` (EntryPoint v0.7, behind its ValidatorRouter).
+> `AAStarValidator` is router-mountable via `IAAStarAlgorithm.validate()` (algId
+> 0x01).
 
 ```
 contracts/

--- a/src/config/configuration.spec.ts
+++ b/src/config/configuration.spec.ts
@@ -1,0 +1,44 @@
+import configuration from "./configuration.js";
+
+/**
+ * Config-floor tests (Codex round-2 LOW): AUDIT_FINALITY_CONFIRMATIONS must be floored to a
+ * POSITIVE value so the finalized-block fallback never resolves to the unconfirmed head (latest − 0).
+ */
+describe("configuration: auditFinalityConfirmations floor", () => {
+  const saved = { ...process.env };
+
+  beforeEach(() => {
+    // Required vars so the config validator doesn't throw.
+    process.env.ETH_RPC_URL = "http://localhost:8545";
+    process.env.VALIDATOR_CONTRACT_ADDRESS = "0x" + "12".repeat(20);
+  });
+
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  it("confirmations=0 → effective confirmations is floored to >= 1 (never the unconfirmed head)", () => {
+    process.env.AUDIT_FINALITY_CONFIRMATIONS = "0";
+    expect(configuration().auditFinalityConfirmations).toBe(1);
+  });
+
+  it("a negative value is floored to 1", () => {
+    process.env.AUDIT_FINALITY_CONFIRMATIONS = "-5";
+    expect(configuration().auditFinalityConfirmations).toBe(1);
+  });
+
+  it("a non-numeric value falls back to the default 12", () => {
+    process.env.AUDIT_FINALITY_CONFIRMATIONS = "not-a-number";
+    expect(configuration().auditFinalityConfirmations).toBe(12);
+  });
+
+  it("unset uses the default 12", () => {
+    delete process.env.AUDIT_FINALITY_CONFIRMATIONS;
+    expect(configuration().auditFinalityConfirmations).toBe(12);
+  });
+
+  it("a valid positive value is preserved", () => {
+    process.env.AUDIT_FINALITY_CONFIRMATIONS = "20";
+    expect(configuration().auditFinalityConfirmations).toBe(20);
+  });
+});

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -231,6 +231,11 @@ export default () => {
     })(),
     // Durable over-slash guard (finding-2): how far back to scan slash-executed events when
     // deciding whether an operator was already slashed (a restart-surviving, on-chain-truth guard).
+    // NOTE (PK finding): on a range-limited RPC, a getLogs span wider than the provider's cap makes
+    // the scan error → the over-slash guard fails CLOSED (the slash is SKIPPED, logged as
+    // "indeterminate"), which is the safe direction but suppresses legitimate slashes. Size this to
+    // your RPC's getLogs block-range limit (e.g. many public endpoints cap ~10k) so the scan stays
+    // determinate. It is only consulted on the armed executeSlash path.
     auditSlashLookbackBlocks: parseInt(process.env.AUDIT_SLASH_LOOKBACK_BLOCKS || "50000", 10),
 
     // Gossip Network

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -201,8 +201,20 @@ export default () => {
     auditChainId: parseInt(process.env.AUDIT_CHAIN_ID || "11155111", 10),
     auditRegistryAddress: process.env.AUDIT_REGISTRY_ADDRESS || undefined,
     auditSuperPaymasterAddress: process.env.AUDIT_SUPER_PAYMASTER_ADDRESS || undefined,
-    auditDvtValidatorAddress: process.env.AUDIT_DVT_VALIDATOR_ADDRESS || undefined,
+    // DVTValidator (SP #329 finalized interface). Default is the Sepolia deployment.
+    auditDvtValidatorAddress:
+      process.env.AUDIT_DVT_VALIDATOR_ADDRESS || "0x568b1486BFE036e603eA11f0D03Dc47fa62c9E0e",
+    // BLSAggregator (SP #329). Currently informational — the on-chain queue/execute writes go
+    // through DVTValidator; the aggregator address is recorded for the future live gossip
+    // co-sign that will aggregate peer BLS signatures by SP-assigned validator slot.
+    auditBlsAggregatorAddress:
+      process.env.AUDIT_BLS_AGGREGATOR_ADDRESS || "0xF51c029879685Ced8fbCfa4b647c2eAe50Cd8B13",
     auditGtokenStakingAddress: process.env.AUDIT_GTOKEN_STAKING_ADDRESS || undefined,
+    // SECOND safety gate (increment 2). AUDIT_ENABLED alone only FILES slash proposals; the
+    // two-step on-chain slash (queueSlashWithProof → executeWithProof, each quorum co-signed)
+    // fires ONLY when this is ALSO "true". Default FALSE so nothing is auto-slashed until an
+    // operator explicitly opts in AND the SP validator slots (registerBLSPublicKey) are ready.
+    auditExecuteSlash: process.env.AUDIT_EXECUTE_SLASH === "true",
     // The xPNTs token the credit-over-limit rule reads operator debt from. Debt lives on the
     // xPNTs TOKEN (IxPNTsToken.getDebt(address)), NOT on SuperPaymaster/Registry. Default is the
     // Sepolia aPNTs token. FAIL-CLOSED: required + must have on-chain code when AUDIT_ENABLED=true.

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -220,6 +220,12 @@ export default () => {
     // Sepolia aPNTs token. FAIL-CLOSED: required + must have on-chain code when AUDIT_ENABLED=true.
     auditApntsTokenAddress:
       process.env.AUDIT_APNTS_TOKEN_ADDRESS || "0x696A73701b104c6cCBbAadDD2216788ea08EaB89",
+    // Reorg-safety (finding-3): the audit reads all rule inputs at a FINALIZED (fallback: safe)
+    // block. On chains that expose neither tag, fall back to latest MINUS this many confirmations.
+    auditFinalityConfirmations: parseInt(process.env.AUDIT_FINALITY_CONFIRMATIONS || "12", 10),
+    // Durable over-slash guard (finding-2): how far back to scan slash-executed events when
+    // deciding whether an operator was already slashed (a restart-surviving, on-chain-truth guard).
+    auditSlashLookbackBlocks: parseInt(process.env.AUDIT_SLASH_LOOKBACK_BLOCKS || "50000", 10),
 
     // Gossip Network
     gossipPublicUrl: process.env.GOSSIP_PUBLIC_URL || `ws://localhost:${port}/ws`,

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -232,10 +232,11 @@ export default () => {
     // Durable over-slash guard (finding-2): how far back to scan slash-executed events when
     // deciding whether an operator was already slashed (a restart-surviving, on-chain-truth guard).
     // NOTE (PK finding): on a range-limited RPC, a getLogs span wider than the provider's cap makes
-    // the scan error → the over-slash guard fails CLOSED (the slash is SKIPPED, logged as
-    // "indeterminate"), which is the safe direction but suppresses legitimate slashes. Size this to
-    // your RPC's getLogs block-range limit (e.g. many public endpoints cap ~10k) so the scan stays
-    // determinate. It is only consulted on the armed executeSlash path.
+    // the scan error → indeterminate. When the pending flag is ALSO indeterminate (as on the current
+    // SP deployment, which has no isSlashPending getter), the over-slash guard then fails CLOSED (the
+    // slash is SKIPPED, logged as "indeterminate") — the safe direction, but it suppresses legitimate
+    // slashes. Size this to your RPC's getLogs block-range limit (many public endpoints cap ~10k) so
+    // the scan stays determinate. It is only consulted on the armed executeSlash path.
     auditSlashLookbackBlocks: parseInt(process.env.AUDIT_SLASH_LOOKBACK_BLOCKS || "50000", 10),
 
     // Gossip Network

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -222,7 +222,13 @@ export default () => {
       process.env.AUDIT_APNTS_TOKEN_ADDRESS || "0x696A73701b104c6cCBbAadDD2216788ea08EaB89",
     // Reorg-safety (finding-3): the audit reads all rule inputs at a FINALIZED (fallback: safe)
     // block. On chains that expose neither tag, fall back to latest MINUS this many confirmations.
-    auditFinalityConfirmations: parseInt(process.env.AUDIT_FINALITY_CONFIRMATIONS || "12", 10),
+    // FLOORED at 1 (never 0): a 0 (or non-numeric) value would make the fallback resolve to the
+    // UNCONFIRMED head (latest − 0), defeating the finality guard. A positive floor guarantees the
+    // fallback is always at least one confirmation behind the head. Default 12.
+    auditFinalityConfirmations: (() => {
+      const parsed = parseInt(process.env.AUDIT_FINALITY_CONFIRMATIONS || "12", 10);
+      return Math.max(1, Number.isFinite(parsed) ? parsed : 12);
+    })(),
     // Durable over-slash guard (finding-2): how far back to scan slash-executed events when
     // deciding whether an operator was already slashed (a restart-surviving, on-chain-truth guard).
     auditSlashLookbackBlocks: parseInt(process.env.AUDIT_SLASH_LOOKBACK_BLOCKS || "50000", 10),

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -48,7 +48,12 @@ function makeBlockchain(
   overrides: Partial<{
     getBlockNumber: () => Promise<number>;
     getViolationBlock: (confirmations?: number) => Promise<{ number: number; hash: string }>;
-    getRecentSlashExecuted: (addr: string, op: string, fromBlock: number) => Promise<boolean>;
+    getRecentSlashExecuted: (
+      addr: string,
+      op: string,
+      slashLevel: number,
+      fromBlock: number
+    ) => Promise<boolean | null>;
     getCode: (addr: string) => Promise<string>;
     getCreditLimit: (addr: string, op: string, bt?: number) => Promise<bigint>;
     getAvailableCredit: (
@@ -1214,7 +1219,12 @@ describe("AuditService", () => {
     let scannedFrom: number | undefined;
     const order: string[] = [];
     const blockchain = recordingBlockchain(order, {
-      getRecentSlashExecuted: async (_addr: string, _op: string, fromBlock: number) => {
+      getRecentSlashExecuted: async (
+        _addr: string,
+        _op: string,
+        _slashLevel: number,
+        fromBlock: number
+      ) => {
         scannedFrom = fromBlock;
         return false;
       },
@@ -1230,6 +1240,125 @@ describe("AuditService", () => {
     await svc.tick();
     // violationBlock 100000 - lookback 40000 = 60000.
     expect(scannedFrom).toBe(60_000);
+  });
+
+  // ── Codex round-2 HIGH: an INDETERMINATE on-chain scan fails CLOSED (no double-slash) ──
+  it("HIGH: getRecentSlashExecuted=null (provider error) → armed path SKIPS the slash (fail-closed)", async () => {
+    const order: string[] = [];
+    // Provider can't confirm slash state (null), and the pending flag is also unknown (null default).
+    const blockchain = recordingBlockchain(order, { getRecentSlashExecuted: async () => null });
+    const archive = makeArchive();
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true }),
+      archive,
+      undefined,
+      makeCoSigner()
+    );
+    await svc.tick();
+    // Indeterminate scan + indeterminate pending + no durable marker → over-slash guard fails CLOSED.
+    expect(order).toEqual([]); // NO queue / create / execute
+    expect(archive.records).toHaveLength(1); // evidence still archived (never lost)
+    expect(archive.records[0].proposalIdNote).toMatch(/over-slash guard/);
+  });
+
+  it("HIGH: getRecentSlashExecuted THROWS → armed path SKIPS the slash (fail-closed)", async () => {
+    const order: string[] = [];
+    const blockchain = recordingBlockchain(order, {
+      getRecentSlashExecuted: async () => {
+        throw new Error("provider down");
+      },
+    });
+    const archive = makeArchive();
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true }),
+      archive,
+      undefined,
+      makeCoSigner()
+    );
+    await svc.tick();
+    expect(order).toEqual([]); // NO on-chain writes when slash state is unconfirmable
+    expect(archive.records).toHaveLength(1);
+    expect(archive.records[0].proposalIdNote).toMatch(/over-slash guard/);
+  });
+
+  it("HIGH: an INDETERMINATE scan but a KNOWN pending flag (false) still lets the slash proceed", async () => {
+    // Only ONE of the two signals is indeterminate → we still have an authoritative signal, so the
+    // fail-closed backstop does NOT fire and the armed path slashes normally.
+    const order: string[] = [];
+    const blockchain = recordingBlockchain(order, {
+      getRecentSlashExecuted: async () => null,
+      isSlashPending: async () => false,
+    });
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true }),
+      makeArchive(),
+      undefined,
+      makeCoSigner()
+    );
+    await svc.tick();
+    expect(order).toEqual(["queue", "create", "execute"]);
+  });
+
+  // ── Codex round-2 MEDIUM: executeTx + submitted messageHash archived TOGETHER (consistent) ──
+  it("MEDIUM: the post-execute re-archive persists executeTx AND the 8-field messageHash together", async () => {
+    const snapshots: Array<{ executeTx?: string; messageHash: string; proofHash: string }> = [];
+    const records: SlashProof[] = [];
+    const snapArchive: IProofArchive & { slashed: Set<string> } = {
+      slashed: new Set<string>(),
+      async put(proof: SlashProof) {
+        snapshots.push({
+          executeTx: proof.executeTx,
+          messageHash: proof.messageHash,
+          proofHash: proof.proofHash,
+        });
+        const i = records.findIndex(r => r.proofHash === proof.proofHash);
+        if (i >= 0) records[i] = proof;
+        else records.push(proof);
+        return { proofHash: proof.proofHash, location: `mem://${proof.proofHash}` };
+      },
+      async has(proofHash: string) {
+        return records.some(r => r.proofHash === proofHash);
+      },
+      async count() {
+        return records.length;
+      },
+      async recordSlashed(k: string) {
+        this.slashed.add(k);
+      },
+      async hasSlashed(k: string) {
+        return this.slashed.has(k);
+      },
+      async removeSlashed(k: string) {
+        this.slashed.delete(k);
+      },
+    };
+    const order: string[] = [];
+    const blockchain = recordingBlockchain(order);
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true }),
+      snapArchive,
+      undefined,
+      makeCoSigner()
+    );
+    await svc.tick();
+
+    // EVERY durable snapshot that carries executeTx must ALSO carry a real (non-"0x") messageHash —
+    // no snapshot may persist executeTx alongside messageHash="0x" (the crash-window inconsistency).
+    const withExec = snapshots.filter(s => s.executeTx !== undefined);
+    expect(withExec.length).toBeGreaterThan(0);
+    for (const s of withExec) {
+      const expected = buildExecuteMessageHash(7n, OPERATOR, 1, BLOCK, 11155111, s.proofHash);
+      expect(s.messageHash).toBe(expected);
+      expect(s.messageHash).not.toBe("0x");
+    }
+    // Final durable state is likewise consistent.
+    expect(records[0].executeTx).toBe("0xEXECUTETX");
+    const finalExpected = buildExecuteMessageHash(7n, OPERATOR, 1, BLOCK, 11155111, records[0].proofHash);
+    expect(records[0].messageHash).toBe(finalExpected);
   });
 
   it("Finding 2: a durable slashed marker (archive) survives a RESTART → the sustained violation is NOT re-slashed", async () => {

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -1536,18 +1536,18 @@ describe("AuditService", () => {
     expect(archive.records).toHaveLength(0);
   });
 
-  it("PK-F3: healthy operator on the default (executeSlash=false) path never calls removeSlashed", async () => {
+  it("B-F3 regression: a healthy read clears a durable slashed marker even when DISARMED", async () => {
+    // Simulate an armed→disarmed restart: a durable marker left by an earlier armed run exists on
+    // disk, but the node now runs with executeSlash=false. A healthy read MUST still clear it — else
+    // hasSlashed short-circuits before the on-chain scan and suppresses a legitimate future slash
+    // indefinitely (Codex R3 B-F3). Default makeBlockchain models a HEALTHY operator (debt 0 ≤ 1000).
     const archive = makeArchive();
-    let removeCalls = 0;
-    const origRemove = archive.removeSlashed.bind(archive);
-    archive.removeSlashed = async (k: string) => {
-      removeCalls++;
-      return origRemove(k);
-    };
-    // Default makeBlockchain models a HEALTHY operator (debt 0 ≤ limit 1000) → clearCoarseSlashed
-    // runs, but executeSlash is off and there is no in-memory marker → durable syscall is skipped.
-    const svc = makeService(makeBlockchain(), makeConfig(), archive);
+    const coarseKey = `11155111|${ethers.getAddress(OPERATOR)}|credit-over-limit`;
+    await archive.recordSlashed(coarseKey);
+    expect(archive.slashed.has(coarseKey)).toBe(true);
+    const svc = makeService(makeBlockchain(), makeConfig({ auditExecuteSlash: false }), archive);
     await svc.tick();
-    expect(removeCalls).toBe(0);
+    // The stale durable marker is gone — a genuine future violation can slash again.
+    expect(archive.slashed.has(coarseKey)).toBe(false);
   });
 });

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -56,12 +56,7 @@ function makeBlockchain(
     ) => Promise<boolean | null>;
     getCode: (addr: string) => Promise<string>;
     getCreditLimit: (addr: string, op: string, bt?: number) => Promise<bigint>;
-    getAvailableCredit: (
-      addr: string,
-      op: string,
-      token: string,
-      bt?: number
-    ) => Promise<bigint>;
+    getAvailableCredit: (addr: string, op: string, token: string, bt?: number) => Promise<bigint>;
     getDebt: (tokenAddr: string, op: string, bt?: number) => Promise<bigint | null>;
     getGlobalReputation: (addr: string, op: string, bt?: number) => Promise<bigint>;
     getRoleLockAmount: (...args: any[]) => Promise<bigint>;
@@ -354,12 +349,7 @@ describe("AuditService", () => {
       seen.limit = bt;
       return 1000n;
     };
-    blockchain.getAvailableCredit = async (
-      _a: string,
-      _o: string,
-      _token: string,
-      bt?: number
-    ) => {
+    blockchain.getAvailableCredit = async (_a: string, _o: string, _token: string, bt?: number) => {
       seen.avail = bt;
       return 0n;
     };
@@ -1357,7 +1347,14 @@ describe("AuditService", () => {
     }
     // Final durable state is likewise consistent.
     expect(records[0].executeTx).toBe("0xEXECUTETX");
-    const finalExpected = buildExecuteMessageHash(7n, OPERATOR, 1, BLOCK, 11155111, records[0].proofHash);
+    const finalExpected = buildExecuteMessageHash(
+      7n,
+      OPERATOR,
+      1,
+      BLOCK,
+      11155111,
+      records[0].proofHash
+    );
     expect(records[0].messageHash).toBe(finalExpected);
   });
 

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -16,6 +16,8 @@ const GTOKEN_STAKING = "0x" + "78".repeat(20);
 /** aPNTs xPNTs token — where getDebt actually lives (per the real SP ABI). */
 const APNTS_TOKEN = "0x696A73701b104c6cCBbAadDD2216788ea08EaB89";
 const BLOCK = 12_345;
+/** Finalized-block hash the mock getViolationBlock returns (finding-3 reorg-safe evidence). */
+const BLOCK_HASH = "0x" + "bb".repeat(32);
 
 const BASE_CONFIG: Record<string, unknown> = {
   auditEnabled: true,
@@ -45,6 +47,8 @@ function makeConfig(overrides: Record<string, unknown> = {}) {
 function makeBlockchain(
   overrides: Partial<{
     getBlockNumber: () => Promise<number>;
+    getViolationBlock: (confirmations?: number) => Promise<{ number: number; hash: string }>;
+    getRecentSlashExecuted: (addr: string, op: string, fromBlock: number) => Promise<boolean>;
     getCode: (addr: string) => Promise<string>;
     getCreditLimit: (addr: string, op: string, bt?: number) => Promise<bigint>;
     getAvailableCredit: (
@@ -67,6 +71,15 @@ function makeBlockchain(
 ): any {
   return {
     getBlockNumber: overrides.getBlockNumber ?? (async () => BLOCK),
+    // getViolationBlock delegates to this.getBlockNumber() (non-arrow so `this` binds to the mock),
+    // so tests that reassign blockchain.getBlockNumber keep controlling the pinned violation block.
+    getViolationBlock:
+      overrides.getViolationBlock ??
+      async function (this: any) {
+        return { number: await this.getBlockNumber(), hash: BLOCK_HASH };
+      },
+    // No prior slash by default → the durable on-chain over-slash guard reports "not slashed".
+    getRecentSlashExecuted: overrides.getRecentSlashExecuted ?? (async () => false),
     getCode: overrides.getCode ?? (async () => "0x60006000fd"),
     getCreditLimit: overrides.getCreditLimit ?? (async () => 1000n),
     getAvailableCredit: overrides.getAvailableCredit ?? (async () => 1000n),
@@ -100,10 +113,12 @@ function makeCoSigner(
 }
 
 /** In-memory archive so tests never touch the filesystem. */
-function makeArchive(): IProofArchive & { records: SlashProof[] } {
+function makeArchive(): IProofArchive & { records: SlashProof[]; slashed: Set<string> } {
   const records: SlashProof[] = [];
+  const slashed = new Set<string>();
   return {
     records,
+    slashed,
     async put(proof: SlashProof) {
       // Idempotent on proofHash, like LocalProofArchive.
       const existing = records.findIndex(r => r.proofHash === proof.proofHash);
@@ -116,6 +131,15 @@ function makeArchive(): IProofArchive & { records: SlashProof[] } {
     },
     async count() {
       return records.length;
+    },
+    async recordSlashed(coarseKey: string) {
+      slashed.add(coarseKey);
+    },
+    async hasSlashed(coarseKey: string) {
+      return slashed.has(coarseKey);
+    },
+    async removeSlashed(coarseKey: string) {
+      slashed.delete(coarseKey);
     },
   };
 }
@@ -634,6 +658,11 @@ describe("AuditService", () => {
       async count() {
         return records.length;
       },
+      async recordSlashed() {},
+      async hasSlashed() {
+        return false;
+      },
+      async removeSlashed() {},
     };
     const blockchain = overLimitBlockchain({
       createProposalWithEvidence: async () => ({ txHash: "0xABC", proposalId: 1n }),
@@ -754,8 +783,8 @@ describe("AuditService", () => {
     expect((await svc.getStatus()).enabled).toBe(false);
   });
 
-  // ── FINDING 1: proof.messageHash == the 8-field EXECUTE preimage actually signed + submitted ──
-  it("Finding 1: archives the 8-field EXECUTE preimage (buildExecuteMessageHash) bound to the real id + proofHash", async () => {
+  // ── FINDING 1 / FINDING 5: submitted vs intended EXECUTE preimage ────────────────
+  it("Finding 5: file-only (executeSlash off) records the intendedExecuteMessageHash, NOT messageHash (nothing submitted)", async () => {
     const now = 1_700_000_000_000;
     const blockchain = overLimitBlockchain({
       createProposalWithEvidence: async () => ({ txHash: "0xTX", proposalId: 7n }),
@@ -768,29 +797,34 @@ describe("AuditService", () => {
     // epoch is the violationBlock (deterministic), NOT Math.floor(now/1000).
     const epoch = BLOCK;
     const expected = buildExecuteMessageHash(7n, OPERATOR, 1, epoch, 11155111, proof.proofHash);
-    expect(proof.messageHash).toBe(expected);
-    // Sanity: it is NOT the retired 7-field inc-1 preimage.
+    // finding-5: nothing was submitted (file-only) → messageHash stays "0x"; the computed preimage
+    // is kept, unambiguously, as INTENDED — never conflated with a submitted one.
+    expect(proof.messageHash).toBe("0x");
+    expect(proof.intendedExecuteMessageHash).toBe(expected);
+    expect(proof.messageHashNote).toBeDefined();
+    expect(proof.executeTx).toBeUndefined();
+    // Sanity: the intended preimage is the 8-field one, NOT the retired 7-field inc-1 preimage.
     const retired7field = ethers.keccak256(
       new ethers.AbiCoder().encode(
         ["uint256", "address", "uint8", "address[]", "uint256[]", "uint256", "uint256"],
         [7n, OPERATOR, 1, [], [], epoch, 11155111]
       )
     );
-    expect(proof.messageHash).not.toBe(retired7field);
-    expect(proof.messageHashNote).toBeUndefined();
+    expect(proof.intendedExecuteMessageHash).not.toBe(retired7field);
   });
 
-  it("Finding 1: the file-only (executeSlash off) path ALSO archives the 8-field execute preimage", async () => {
+  it("Finding 5: file-only path binds the execute preimage as INTENT only (proposalId 9)", async () => {
     const blockchain = overLimitBlockchain({
       createProposalWithEvidence: async () => ({ txHash: "0xTX", proposalId: 9n }),
     });
     const archive = makeArchive();
-    // Default config → executeSlash OFF; no queue/execute, but the proof still binds the execute preimage.
+    // Default config → executeSlash OFF; no queue/execute → intended preimage, not a submitted one.
     const svc = makeService(blockchain, makeConfig(), archive);
     await svc.tick();
     const proof = archive.records[0];
     const expected = buildExecuteMessageHash(9n, OPERATOR, 1, BLOCK, 11155111, proof.proofHash);
-    expect(proof.messageHash).toBe(expected);
+    expect(proof.messageHash).toBe("0x");
+    expect(proof.intendedExecuteMessageHash).toBe(expected);
   });
 
   it("unresolved proposal id → messageHash placeholder '0x' + a note (no on-chain proposal to sign)", async () => {
@@ -962,12 +996,19 @@ describe("AuditService", () => {
     expect(archive.records[0].proposalTx).toBe("0xPROPOSALTX");
   });
 
-  it("executeSlash=true: a queue tx failure is caught; proposal + execute still proceed, evidence archived", async () => {
+  it("Finding 1 (CRITICAL): a queue tx failure ABORTS the slash — execute is NOT called (two-step safety)", async () => {
     const order: string[] = [];
+    let executeCalls = 0;
     const blockchain = recordingBlockchain(order, {
       queueSlashWithProof: async () => {
         order.push("queue-fail");
         throw new Error("reverted: queue not authorized");
+      },
+      executeSlashWithProof: async (...args: any[]) => {
+        executeCalls++;
+        order.push("execute");
+        (recordingBlockchain as any).lastExecuteArgs = args;
+        return "0xEXECUTETX";
       },
     });
     const archive = makeArchive();
@@ -979,9 +1020,20 @@ describe("AuditService", () => {
       makeCoSigner()
     );
     await expect(svc.tick()).resolves.toBeUndefined();
-    // queue reverted but was swallowed; create + execute still ran; evidence archived.
-    expect(order).toEqual(["queue-fail", "create", "execute"]);
+    // finding-1: queue reverted (queueTx null) → execute must NOT run even though the proposal
+    // filed and resolved a real id. A slash never executes without a confirmed queue pre-flag.
+    expect(order).toEqual(["queue-fail", "create"]);
+    expect(executeCalls).toBe(0);
     expect(archive.records).toHaveLength(1);
+    const proof = archive.records[0];
+    // No execute tx recorded, and the (resolvable) execute preimage is kept as INTENT only.
+    expect(proof.executeTx).toBeUndefined();
+    expect(proof.messageHash).toBe("0x");
+    expect(proof.intendedExecuteMessageHash).toBeDefined();
+    // The over-slash guard was NOT armed durably (no slash executed).
+    expect((archive as any).slashed.size).toBe(0);
+    const status = await svc.getStatus();
+    expect(status.recentDetections[0].executeTx).toBeNull();
   });
 
   // ── FINDING 3: epoch is the deterministic violationBlock (cross-node agreement) ──
@@ -1114,6 +1166,11 @@ describe("AuditService", () => {
       async count() {
         return records.length;
       },
+      async recordSlashed() {},
+      async hasSlashed() {
+        return false;
+      },
+      async removeSlashed() {},
     };
     const svc = makeService(
       blockchain,
@@ -1130,6 +1187,177 @@ describe("AuditService", () => {
     // And a post-execute update records the executeTx on the proof (finding-2).
     expect(records[0].executeTx).toBe("0xE");
     expect(records[0].queueTx).toBe("0xQ");
+  });
+
+  // ── FINDING 2: durable, restart-surviving over-slash guard ──────────────────────
+  it("Finding 2: getRecentSlashExecuted=true short-circuits queue/create/execute (on-chain durable guard)", async () => {
+    const order: string[] = [];
+    const blockchain = recordingBlockchain(order, { getRecentSlashExecuted: async () => true });
+    const archive = makeArchive();
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true }),
+      archive,
+      undefined,
+      makeCoSigner()
+    );
+    await svc.tick();
+    // An on-chain SlashExecuted(WithProof) hit → NO on-chain writes this tick; evidence archived.
+    expect(order).toEqual([]);
+    expect(archive.records).toHaveLength(1);
+    expect(archive.records[0].proposalIdNote).toMatch(/over-slash guard/);
+    // The on-chain hit is cached into the DURABLE journal so later ticks/restarts short-circuit.
+    expect(archive.slashed.size).toBe(1);
+  });
+
+  it("Finding 2: getRecentSlashExecuted scans within [violationBlock - lookback, latest]", async () => {
+    let scannedFrom: number | undefined;
+    const order: string[] = [];
+    const blockchain = recordingBlockchain(order, {
+      getRecentSlashExecuted: async (_addr: string, _op: string, fromBlock: number) => {
+        scannedFrom = fromBlock;
+        return false;
+      },
+    });
+    blockchain.getBlockNumber = async () => 100_000;
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true, auditSlashLookbackBlocks: 40_000 }),
+      makeArchive(),
+      undefined,
+      makeCoSigner()
+    );
+    await svc.tick();
+    // violationBlock 100000 - lookback 40000 = 60000.
+    expect(scannedFrom).toBe(60_000);
+  });
+
+  it("Finding 2: a durable slashed marker (archive) survives a RESTART → the sustained violation is NOT re-slashed", async () => {
+    const archive = makeArchive();
+    let block = 4000;
+    const now = 1_700_000_000_000;
+
+    // Node instance #1 slashes the operator and persists the durable marker.
+    const order1: string[] = [];
+    const bc1 = recordingBlockchain(order1);
+    bc1.getBlockNumber = async () => block;
+    const svc1 = makeService(
+      bc1,
+      makeConfig({ auditExecuteSlash: true, auditCooldownMs: 1 }),
+      archive,
+      () => now,
+      makeCoSigner()
+    );
+    await svc1.tick();
+    expect(order1.filter(o => o === "execute")).toHaveLength(1);
+    expect(archive.slashed.size).toBe(1); // durable marker persisted to the (shared) archive
+
+    // Simulate a process RESTART: a BRAND-NEW service with FRESH in-memory guards but the SAME
+    // archive (disk). The block ADVANCES so this is not per-block-deduped (a fresh proofHash).
+    block = 4001;
+    const order2: string[] = [];
+    const bc2 = recordingBlockchain(order2);
+    bc2.getBlockNumber = async () => block;
+    const svc2 = makeService(
+      bc2,
+      makeConfig({ auditExecuteSlash: true, auditCooldownMs: 1 }),
+      archive,
+      () => now + 10_000,
+      makeCoSigner()
+    );
+    await svc2.tick();
+    // The durable marker (reloaded from the archive) blocks the re-slash across the restart.
+    expect(order2.filter(o => o === "execute")).toHaveLength(0);
+    // Evidence for the new block is still archived (never lost).
+    expect(archive.records.some(r => r.evidence.violationBlock === 4001)).toBe(true);
+  });
+
+  // ── FINDING 3: evidence pinned to a FINALIZED block + its hash (reorg-safe) ──────
+  it("Finding 3: rule inputs are read at a FINALIZED block and its hash is stored in the evidence", async () => {
+    let confirmationsSeen: number | undefined;
+    const finalizedHash = "0x" + "cc".repeat(32);
+    const seen: Record<string, number | undefined> = {};
+    const blockchain = overLimitBlockchain({
+      getViolationBlock: async (confirmations?: number) => {
+        confirmationsSeen = confirmations;
+        return { number: 777, hash: finalizedHash };
+      },
+    });
+    blockchain.getCreditLimit = async (_a: string, _o: string, bt?: number) => {
+      seen.limit = bt;
+      return 1000n;
+    };
+    blockchain.getAvailableCredit = async (_a: string, _o: string, _t: string, bt?: number) => {
+      seen.avail = bt;
+      return 0n;
+    };
+    blockchain.getDebt = async (_a: string, _o: string, bt?: number) => {
+      seen.debt = bt;
+      return 2000n;
+    };
+    const archive = makeArchive();
+    const svc = makeService(blockchain, makeConfig({ auditFinalityConfirmations: 5 }), archive);
+    await svc.tick();
+    // The configured confirmation depth is threaded to getViolationBlock (finalized-tag fallback).
+    expect(confirmationsSeen).toBe(5);
+    // ALL rule inputs are block-pinned to the finalized number, not a live head.
+    expect(seen.limit).toBe(777);
+    expect(seen.avail).toBe(777);
+    expect(seen.debt).toBe(777);
+    // The evidence records both the finalized number AND its hash (reorg-safe justification).
+    expect(archive.records[0].evidence.violationBlock).toBe(777);
+    expect(archive.records[0].evidence.violationBlockHash).toBe(finalizedHash);
+    // epoch (the co-sign preimage input) is the finalized block too.
+    expect(archive.records[0].epoch).toBe(777);
+  });
+
+  // ── FINDING 4: per-step re-archive (durable after EACH confirmed on-chain step) ──
+  it("Finding 4: the proof is RE-ARCHIVED after each confirmed on-chain step (queue then execute)", async () => {
+    const snapshots: Array<{ queueTx?: string; executeTx?: string }> = [];
+    const records: SlashProof[] = [];
+    const snapArchive: IProofArchive & { slashed: Set<string> } = {
+      slashed: new Set<string>(),
+      async put(proof: SlashProof) {
+        // Snapshot the tx fields AT put time so intermediate durable states are observable.
+        snapshots.push({ queueTx: proof.queueTx, executeTx: proof.executeTx });
+        const i = records.findIndex(r => r.proofHash === proof.proofHash);
+        if (i >= 0) records[i] = proof;
+        else records.push(proof);
+        return { proofHash: proof.proofHash, location: `mem://${proof.proofHash}` };
+      },
+      async has(proofHash: string) {
+        return records.some(r => r.proofHash === proofHash);
+      },
+      async count() {
+        return records.length;
+      },
+      async recordSlashed(k: string) {
+        this.slashed.add(k);
+      },
+      async hasSlashed(k: string) {
+        return this.slashed.has(k);
+      },
+      async removeSlashed(k: string) {
+        this.slashed.delete(k);
+      },
+    };
+    const order: string[] = [];
+    const blockchain = recordingBlockchain(order);
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true }),
+      snapArchive,
+      undefined,
+      makeCoSigner()
+    );
+    await svc.tick();
+    // A durable snapshot exists AFTER the queue confirmed (queueTx set, executeTx not yet)…
+    expect(snapshots.some(s => s.queueTx !== undefined && s.executeTx === undefined)).toBe(true);
+    // …and one AFTER the execute confirmed (both txs present).
+    expect(snapshots.some(s => s.queueTx !== undefined && s.executeTx !== undefined)).toBe(true);
+    // Final durable state carries both txs.
+    expect(records[0].queueTx).toBeDefined();
+    expect(records[0].executeTx).toBe("0xEXECUTETX");
   });
 
   it("computeJitterMs stays within [0, intervalMs)", () => {

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -1503,4 +1503,51 @@ describe("AuditService", () => {
     expect(mk(0.5).computeJitterMs()).toBe(30_000);
     expect(mk(0.999999).computeJitterMs()).toBeLessThan(60_000);
   });
+
+  // ── PK perf findings ─────────────────────────────────────────────────────────
+  it("PK-F2: the finalized evidence block is resolved ONCE per tick, shared across operators", async () => {
+    let violationBlockCalls = 0;
+    const opB = "0x" + "ab".repeat(20);
+    const blockchain = makeBlockchain({
+      getViolationBlock: async function (this: any) {
+        violationBlockCalls++;
+        return { number: await this.getBlockNumber(), hash: BLOCK_HASH };
+      },
+    });
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditWatchlist: [OPERATOR, opB] }),
+      makeArchive()
+    );
+    await svc.tick();
+    // Two operators, but only ONE getViolationBlock RPC (shared snapshot), not one per operator.
+    expect(violationBlockCalls).toBe(1);
+  });
+
+  it("PK-F2: a getViolationBlock failure skips the whole tick without throwing", async () => {
+    const blockchain = makeBlockchain({
+      getViolationBlock: async () => {
+        throw new Error("RPC down");
+      },
+    });
+    const archive = makeArchive();
+    const svc = makeService(blockchain, makeConfig(), archive);
+    await expect(svc.tick()).resolves.toBeUndefined();
+    expect(archive.records).toHaveLength(0);
+  });
+
+  it("PK-F3: healthy operator on the default (executeSlash=false) path never calls removeSlashed", async () => {
+    const archive = makeArchive();
+    let removeCalls = 0;
+    const origRemove = archive.removeSlashed.bind(archive);
+    archive.removeSlashed = async (k: string) => {
+      removeCalls++;
+      return origRemove(k);
+    };
+    // Default makeBlockchain models a HEALTHY operator (debt 0 ≤ limit 1000) → clearCoarseSlashed
+    // runs, but executeSlash is off and there is no in-memory marker → durable syscall is skipped.
+    const svc = makeService(makeBlockchain(), makeConfig(), archive);
+    await svc.tick();
+    expect(removeCalls).toBe(0);
+  });
 });

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -1,6 +1,12 @@
 import { ethers } from "ethers";
 import { AuditService } from "./audit.service.js";
 import { IProofArchive, SlashProof, computeProofHash } from "./proof-archive.js";
+import {
+  IQuorumCoSigner,
+  buildQueueMessageHash,
+  buildExecuteMessageHash,
+  encodeProof,
+} from "./slash-consensus.js";
 
 const OPERATOR = "0x" + "12".repeat(20);
 const REGISTRY = "0xf5Bf37ca83AfdAab73691bA7eCcDfA69b8708E71";
@@ -50,7 +56,11 @@ function makeBlockchain(
     getDebt: (tokenAddr: string, op: string, bt?: number) => Promise<bigint | null>;
     getGlobalReputation: (addr: string, op: string, bt?: number) => Promise<bigint>;
     getRoleLockAmount: (...args: any[]) => Promise<bigint>;
-    createSlashProposal: (...args: any[]) => Promise<{ txHash: string; proposalId: bigint | null }>;
+    createProposalWithEvidence: (
+      ...args: any[]
+    ) => Promise<{ txHash: string; proposalId: bigint | null }>;
+    queueSlashWithProof: (...args: any[]) => Promise<string>;
+    executeSlashWithProof: (...args: any[]) => Promise<string>;
     getWalletAddress: () => string | null;
   }> = {}
 ): any {
@@ -62,9 +72,27 @@ function makeBlockchain(
     getDebt: overrides.getDebt ?? (async () => 0n),
     getGlobalReputation: overrides.getGlobalReputation ?? (async () => 500n),
     getRoleLockAmount: overrides.getRoleLockAmount ?? (async () => 42n),
-    createSlashProposal:
-      overrides.createSlashProposal ?? (async () => ({ txHash: "0xPROPOSALTX", proposalId: 7n })),
+    createProposalWithEvidence:
+      overrides.createProposalWithEvidence ??
+      (async () => ({ txHash: "0xPROPOSALTX", proposalId: 7n })),
+    queueSlashWithProof: overrides.queueSlashWithProof ?? (async () => "0xQUEUETX"),
+    executeSlashWithProof: overrides.executeSlashWithProof ?? (async () => "0xEXECUTETX"),
     getWalletAddress: overrides.getWalletAddress ?? (() => "0x" + "99".repeat(20)),
+  };
+}
+
+/** A deterministic mock quorum co-signer that always succeeds (fixed mask + sig). */
+function makeCoSigner(
+  signerMask = 0b111n,
+  sigG2 = "0x" + "ab".repeat(64)
+): IQuorumCoSigner & { calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    async coSign(messageHash: string) {
+      calls.push(messageHash);
+      return { signerMask, sigG2 };
+    },
   };
 }
 
@@ -102,9 +130,10 @@ function makeService(
   blockchain: any,
   config: any,
   archive: IProofArchive,
-  clock: () => number = clockAt(1_700_000_000_000)
+  clock: () => number = clockAt(1_700_000_000_000),
+  coSigner?: IQuorumCoSigner
 ) {
-  return new AuditService(blockchain, config, makeRegistry(), clock, () => 0, archive);
+  return new AuditService(blockchain, config, makeRegistry(), clock, () => 0, archive, coSigner);
 }
 
 /** A blockchain whose operator is genuinely OVER limit: debt (2000) > creditLimit (1000). */
@@ -178,7 +207,7 @@ describe("AuditService", () => {
   it("healthy operator (debt 0 ≤ limit) → no detection, no proposal", async () => {
     const created: any[] = [];
     const blockchain = makeBlockchain({
-      createSlashProposal: async (...args: any[]) => {
+      createProposalWithEvidence: async (...args: any[]) => {
         created.push(args);
         return { txHash: "0xTX", proposalId: 7n };
       },
@@ -196,7 +225,7 @@ describe("AuditService", () => {
       getCreditLimit: async () => 1000n,
       getAvailableCredit: async () => 0n, // fully used, but that is AT the limit
       getDebt: async () => 1000n, // debt == limit → NOT over
-      createSlashProposal: async (...args: any[]) => {
+      createProposalWithEvidence: async (...args: any[]) => {
         created.push(args);
         return { txHash: "0xTX", proposalId: 7n };
       },
@@ -214,7 +243,7 @@ describe("AuditService", () => {
       getCreditLimit: async () => 1000n,
       getAvailableCredit: async () => 0n,
       getDebt: async () => null, // BOTH SP and Registry reads revert
-      createSlashProposal: async (...args: any[]) => {
+      createProposalWithEvidence: async (...args: any[]) => {
         created.push(args);
         return { txHash: "0xTX", proposalId: 7n };
       },
@@ -229,7 +258,7 @@ describe("AuditService", () => {
   it("STRICT over-limit (debt > limit) → files a proposal AND archives a content-addressed proof", async () => {
     const created: any[] = [];
     const blockchain = overLimitBlockchain({
-      createSlashProposal: async (...args: any[]) => {
+      createProposalWithEvidence: async (...args: any[]) => {
         created.push(args);
         return { txHash: "0xPROPOSALTX", proposalId: 7n };
       },
@@ -337,7 +366,7 @@ describe("AuditService", () => {
   it("content-address is deterministic + idempotent: same violation twice → one archived proof", async () => {
     const created: any[] = [];
     const blockchain = overLimitBlockchain({
-      createSlashProposal: async (...args: any[]) => {
+      createProposalWithEvidence: async (...args: any[]) => {
         created.push(args);
         return { txHash: "0xTX", proposalId: 7n };
       },
@@ -353,7 +382,7 @@ describe("AuditService", () => {
   it("dedup: same violation@block over many ticks → exactly ONE proposal", async () => {
     const created: any[] = [];
     const blockchain = overLimitBlockchain({
-      createSlashProposal: async (...args: any[]) => {
+      createProposalWithEvidence: async (...args: any[]) => {
         created.push(args);
         return { txHash: "0xTX", proposalId: 7n };
       },
@@ -369,7 +398,7 @@ describe("AuditService", () => {
   it("dedup: an already-archived proof (prior process) → no new proposal", async () => {
     const created: any[] = [];
     const blockchain = overLimitBlockchain({
-      createSlashProposal: async (...args: any[]) => {
+      createProposalWithEvidence: async (...args: any[]) => {
         created.push(args);
         return { txHash: "0xTX", proposalId: 7n };
       },
@@ -395,7 +424,7 @@ describe("AuditService", () => {
     let block = 1000;
     let now = 1_700_000_000_000;
     const blockchain = overLimitBlockchain({
-      createSlashProposal: async (...args: any[]) => {
+      createProposalWithEvidence: async (...args: any[]) => {
         created.push(args);
         return { txHash: "0xTX", proposalId: 7n };
       },
@@ -425,7 +454,7 @@ describe("AuditService", () => {
 
   it("proposal write failure → proof still archived (evidence never lost), proposalTx null", async () => {
     const blockchain = overLimitBlockchain({
-      createSlashProposal: async () => {
+      createProposalWithEvidence: async () => {
         throw new Error("reverted: not authorized");
       },
     });
@@ -442,7 +471,7 @@ describe("AuditService", () => {
     const op2 = "0x" + "ab".repeat(20);
     const created: string[] = [];
     const blockchain = overLimitBlockchain({
-      createSlashProposal: async (_addr: string, operator: string) => {
+      createProposalWithEvidence: async (_addr: string, operator: string) => {
         created.push(operator);
         return { txHash: "0xTX", proposalId: 7n };
       },
@@ -526,7 +555,7 @@ describe("AuditService", () => {
       getCreditLimit: async () => 0n, // unconfigured / de-registered
       getAvailableCredit: async () => 0n,
       getDebt: async () => 5000n, // has debt, but a zero limit must NOT be treated as over-limit
-      createSlashProposal: async (...args: any[]) => {
+      createProposalWithEvidence: async (...args: any[]) => {
         created.push(args);
         return { txHash: "0xTX", proposalId: 7n };
       },
@@ -541,7 +570,7 @@ describe("AuditService", () => {
   it("Fix 2: creditLimit>0 with debt>limit (credit exhausted) → proposal filed", async () => {
     const created: any[] = [];
     const blockchain = overLimitBlockchain({
-      createSlashProposal: async (...args: any[]) => {
+      createProposalWithEvidence: async (...args: any[]) => {
         created.push(args);
         return { txHash: "0xTX", proposalId: 7n };
       },
@@ -557,7 +586,7 @@ describe("AuditService", () => {
     let block = 5000;
     let now = 1_700_000_000_000;
     const blockchain = overLimitBlockchain({
-      createSlashProposal: async () => {
+      createProposalWithEvidence: async () => {
         attempts++;
         throw new Error("reverted: proposer not an active validator");
       },
@@ -601,7 +630,7 @@ describe("AuditService", () => {
       },
     };
     const blockchain = overLimitBlockchain({
-      createSlashProposal: async () => ({ txHash: "0xABC", proposalId: 1n }),
+      createProposalWithEvidence: async () => ({ txHash: "0xABC", proposalId: 1n }),
     });
     blockchain.getBlockNumber = async () => 5000; // SAME violation@block both ticks
     const svc = makeService(blockchain, makeConfig(), flakyArchive);
@@ -617,7 +646,7 @@ describe("AuditService", () => {
   // ── FIX 4: proof carries the REAL on-chain proposal id (no fabrication) ─────────
   it("Fix 4: the proof carries the REAL on-chain proposal id parsed from the event", async () => {
     const blockchain = overLimitBlockchain({
-      createSlashProposal: async () => ({ txHash: "0xABC", proposalId: 4242n }),
+      createProposalWithEvidence: async () => ({ txHash: "0xABC", proposalId: 4242n }),
     });
     const archive = makeArchive();
     const svc = makeService(blockchain, makeConfig(), archive);
@@ -632,7 +661,7 @@ describe("AuditService", () => {
 
   it("Fix 4: an unresolved id (event absent) → proposalId null + note, never fabricated", async () => {
     const blockchain = overLimitBlockchain({
-      createSlashProposal: async () => ({ txHash: "0xDEF", proposalId: null }),
+      createProposalWithEvidence: async () => ({ txHash: "0xDEF", proposalId: null }),
     });
     const archive = makeArchive();
     const svc = makeService(blockchain, makeConfig(), archive);
@@ -649,7 +678,7 @@ describe("AuditService", () => {
       getCreditLimit: async () => 1000n, // stale/low Registry limit
       getAvailableCredit: async () => 500n, // SP says the operator is still within its ceiling
       getDebt: async () => 2000n, // exceeds the Registry limit ONLY
-      createSlashProposal: async (...args: any[]) => {
+      createProposalWithEvidence: async (...args: any[]) => {
         created.push(args);
         return { txHash: "0xTX", proposalId: 7n };
       },
@@ -720,7 +749,7 @@ describe("AuditService", () => {
   it("archives the REAL 7-field messageHash matching BLSAggregator.verifyAndExecute", async () => {
     const now = 1_700_000_000_000;
     const blockchain = overLimitBlockchain({
-      createSlashProposal: async () => ({ txHash: "0xTX", proposalId: 7n }),
+      createProposalWithEvidence: async () => ({ txHash: "0xTX", proposalId: 7n }),
     });
     const archive = makeArchive();
     const svc = makeService(blockchain, makeConfig(), archive, clockAt(now));
@@ -739,7 +768,7 @@ describe("AuditService", () => {
 
   it("unresolved proposal id → messageHash placeholder '0x' (no on-chain proposal to sign)", async () => {
     const blockchain = overLimitBlockchain({
-      createSlashProposal: async () => ({ txHash: "0xDEF", proposalId: null }),
+      createProposalWithEvidence: async () => ({ txHash: "0xDEF", proposalId: null }),
     });
     const archive = makeArchive();
     const svc = makeService(blockchain, makeConfig(), archive);
@@ -747,9 +776,169 @@ describe("AuditService", () => {
     expect(archive.records[0].messageHash).toBe("0x");
   });
 
-  it("coordinateQuorumCoSign is deferred to increment 2 (throws)", async () => {
-    const svc = makeService(makeBlockchain(), makeConfig(), makeArchive());
-    await expect(svc.coordinateQuorumCoSign()).rejects.toThrow(/increment 2/);
+  // ── INCREMENT 2: two-step slash-consensus orchestration ─────────────────────────
+
+  /** A blockchain whose write calls are recorded in a shared, ordered log. */
+  function recordingBlockchain(order: string[], overrides: Record<string, any> = {}) {
+    return overLimitBlockchain({
+      queueSlashWithProof: async (...args: any[]) => {
+        order.push("queue");
+        return `0xQUEUE:${JSON.stringify(args.slice(1, 4))}`;
+      },
+      createProposalWithEvidence: async (...args: any[]) => {
+        order.push("create");
+        (recordingBlockchain as any).lastCreateArgs = args;
+        return { txHash: "0xPROPOSALTX", proposalId: 7n };
+      },
+      executeSlashWithProof: async (...args: any[]) => {
+        order.push("execute");
+        (recordingBlockchain as any).lastExecuteArgs = args;
+        return "0xEXECUTETX";
+      },
+      ...overrides,
+    });
+  }
+
+  it("default (executeSlash off): files the proposal but NEVER queues/executes a slash", async () => {
+    const order: string[] = [];
+    const blockchain = recordingBlockchain(order);
+    const archive = makeArchive();
+    // Default config has no auditExecuteSlash → the second safety gate is closed.
+    const svc = makeService(blockchain, makeConfig(), archive, undefined, makeCoSigner());
+    await svc.tick();
+    expect(order).toEqual(["create"]); // proposal filed, no queue/execute
+    expect(archive.records).toHaveLength(1);
+    // The filed proposal binds the archived evidence: evidenceHash === proofHash.
+    const createArgs = (recordingBlockchain as any).lastCreateArgs;
+    expect(createArgs[4]).toBe(archive.records[0].proofHash);
+  });
+
+  it("executeSlash=true: calls queue → createProposalWithEvidence → execute in that order", async () => {
+    const order: string[] = [];
+    const blockchain = recordingBlockchain(order);
+    const archive = makeArchive();
+    const coSigner = makeCoSigner();
+    const now = 1_700_000_000_000;
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true }),
+      archive,
+      clockAt(now),
+      coSigner
+    );
+    await svc.tick();
+
+    // Exact on-chain call order.
+    expect(order).toEqual(["queue", "create", "execute"]);
+    expect(archive.records).toHaveLength(1);
+    const proof = archive.records[0];
+    const epoch = Math.floor(now / 1000);
+
+    // createProposalWithEvidence bound the archived evidence: (dvt, op, level, reason, proofHash).
+    const createArgs = (recordingBlockchain as any).lastCreateArgs;
+    expect(createArgs[0]).toBe(DVT_VALIDATOR);
+    expect(createArgs[1]).toBe(OPERATOR);
+    expect(createArgs[2]).toBe(1); // SlashLevel.MINOR
+    expect(createArgs[4]).toBe(proof.proofHash);
+
+    // execute used the REAL proposal id (7) with empty rep arrays + the same epoch.
+    const execArgs = (recordingBlockchain as any).lastExecuteArgs;
+    expect(execArgs[0]).toBe(DVT_VALIDATOR);
+    expect(execArgs[1]).toBe(7n);
+    expect(execArgs[2]).toEqual([]);
+    expect(execArgs[3]).toEqual([]);
+    expect(execArgs[4]).toBe(epoch);
+
+    // The quorum co-signer was invoked exactly twice — over the queue then the execute preimage.
+    expect(coSigner.calls).toHaveLength(2);
+    const expectedQueue = buildQueueMessageHash(OPERATOR, 1, epoch, 11155111);
+    const expectedExec = buildExecuteMessageHash(7n, OPERATOR, 1, epoch, 11155111, proof.proofHash);
+    expect(coSigner.calls[0]).toBe(expectedQueue);
+    expect(coSigner.calls[1]).toBe(expectedExec);
+
+    // The execute step carried the abi-encoded proof (uint256 signerMask, bytes sigG2).
+    const expectedProof = encodeProof(0b111n, "0x" + "ab".repeat(64));
+    expect(execArgs[5]).toBe(expectedProof);
+  });
+
+  it("executeSlash=true + real proposalId: execute is bound to that exact id", async () => {
+    const order: string[] = [];
+    const blockchain = recordingBlockchain(order, {
+      createProposalWithEvidence: async () => ({ txHash: "0xABC", proposalId: 4242n }),
+      executeSlashWithProof: async (...args: any[]) => {
+        order.push("execute");
+        (recordingBlockchain as any).lastExecuteArgs = args;
+        return "0xEXECUTETX";
+      },
+    });
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true }),
+      makeArchive(),
+      undefined,
+      makeCoSigner()
+    );
+    await svc.tick();
+    expect((recordingBlockchain as any).lastExecuteArgs[1]).toBe(4242n);
+  });
+
+  it("executeSlash=true but proposalId unresolved (event absent) → execute is SKIPPED", async () => {
+    const order: string[] = [];
+    const blockchain = recordingBlockchain(order, {
+      createProposalWithEvidence: async () => {
+        order.push("create");
+        return { txHash: "0xDEF", proposalId: null };
+      },
+    });
+    const archive = makeArchive();
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true }),
+      archive,
+      undefined,
+      makeCoSigner()
+    );
+    await svc.tick();
+    // A fabricated id would revert on-chain, so execute must not run; queue + proposal still did.
+    expect(order).toEqual(["queue", "create"]);
+    expect(archive.records).toHaveLength(1);
+  });
+
+  it("executeSlash=true with the default PendingSlotCoSigner stub → co-sign throws, caught, evidence archived", async () => {
+    const order: string[] = [];
+    const blockchain = recordingBlockchain(order);
+    const archive = makeArchive();
+    // No coSigner injected → defaults to PendingSlotCoSigner, whose coSign throws.
+    const svc = makeService(blockchain, makeConfig({ auditExecuteSlash: true }), archive);
+    // The tick must survive the stub's throw (loop never crashes).
+    await expect(svc.tick()).resolves.toBeUndefined();
+    // queue co-sign threw (queue skipped) but the proposal was still filed; execute co-sign
+    // also threw (execute skipped) — yet the evidence is archived regardless.
+    expect(order).toEqual(["create"]);
+    expect(archive.records).toHaveLength(1);
+    expect(archive.records[0].proposalTx).toBe("0xPROPOSALTX");
+  });
+
+  it("executeSlash=true: a queue tx failure is caught; proposal + execute still proceed, evidence archived", async () => {
+    const order: string[] = [];
+    const blockchain = recordingBlockchain(order, {
+      queueSlashWithProof: async () => {
+        order.push("queue-fail");
+        throw new Error("reverted: queue not authorized");
+      },
+    });
+    const archive = makeArchive();
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true }),
+      archive,
+      undefined,
+      makeCoSigner()
+    );
+    await expect(svc.tick()).resolves.toBeUndefined();
+    // queue reverted but was swallowed; create + execute still ran; evidence archived.
+    expect(order).toEqual(["queue-fail", "create", "execute"]);
+    expect(archive.records).toHaveLength(1);
   });
 
   it("computeJitterMs stays within [0, intervalMs)", () => {

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -61,6 +61,7 @@ function makeBlockchain(
     ) => Promise<{ txHash: string; proposalId: bigint | null }>;
     queueSlashWithProof: (...args: any[]) => Promise<string>;
     executeSlashWithProof: (...args: any[]) => Promise<string>;
+    isSlashPending: (...args: any[]) => Promise<boolean | null>;
     getWalletAddress: () => string | null;
   }> = {}
 ): any {
@@ -77,6 +78,8 @@ function makeBlockchain(
       (async () => ({ txHash: "0xPROPOSALTX", proposalId: 7n })),
     queueSlashWithProof: overrides.queueSlashWithProof ?? (async () => "0xQUEUETX"),
     executeSlashWithProof: overrides.executeSlashWithProof ?? (async () => "0xEXECUTETX"),
+    // Current SP keeps _pendingSlash private → no getter → null ("unknown") by default.
+    isSlashPending: overrides.isSlashPending ?? (async () => null),
     getWalletAddress: overrides.getWalletAddress ?? (() => "0x" + "99".repeat(20)),
   };
 }
@@ -619,7 +622,10 @@ describe("AuditService", () => {
       async put(proof: SlashProof) {
         putCalls++;
         if (putCalls === 1) throw new Error("ENOSPC: disk full");
-        records.push(proof);
+        // Idempotent on proofHash, like LocalProofArchive (same file overwritten).
+        const existing = records.findIndex(r => r.proofHash === proof.proofHash);
+        if (existing >= 0) records[existing] = proof;
+        else records.push(proof);
         return { proofHash: proof.proofHash, location: `mem://${proof.proofHash}` };
       },
       async has(proofHash: string) {
@@ -635,11 +641,13 @@ describe("AuditService", () => {
     blockchain.getBlockNumber = async () => 5000; // SAME violation@block both ticks
     const svc = makeService(blockchain, makeConfig(), flakyArchive);
 
-    await svc.tick(); // put throws → recordStableKey NOT reached
+    await svc.tick(); // pre-execute archive put throws → recordStableKey NOT reached
     expect(records).toHaveLength(0);
     // The in-memory stableKey must NOT have suppressed the same violation — a later tick retries.
     await svc.tick();
-    expect(putCalls).toBe(2);
+    // Archive-before-execute writes the proof TWICE per successful tick (v0 intent BEFORE the
+    // on-chain slash, then an idempotent update WITH the tx hashes after): 1 failed + 2 on retry.
+    expect(putCalls).toBe(3);
     expect(records).toHaveLength(1); // evidence eventually persisted (invariant held)
   });
 
@@ -746,7 +754,8 @@ describe("AuditService", () => {
     expect((await svc.getStatus()).enabled).toBe(false);
   });
 
-  it("archives the REAL 7-field messageHash matching BLSAggregator.verifyAndExecute", async () => {
+  // ── FINDING 1: proof.messageHash == the 8-field EXECUTE preimage actually signed + submitted ──
+  it("Finding 1: archives the 8-field EXECUTE preimage (buildExecuteMessageHash) bound to the real id + proofHash", async () => {
     const now = 1_700_000_000_000;
     const blockchain = overLimitBlockchain({
       createProposalWithEvidence: async () => ({ txHash: "0xTX", proposalId: 7n }),
@@ -756,17 +765,35 @@ describe("AuditService", () => {
     await svc.tick();
 
     const proof = archive.records[0];
-    const epoch = Math.floor(now / 1000);
-    const expected = ethers.keccak256(
+    // epoch is the violationBlock (deterministic), NOT Math.floor(now/1000).
+    const epoch = BLOCK;
+    const expected = buildExecuteMessageHash(7n, OPERATOR, 1, epoch, 11155111, proof.proofHash);
+    expect(proof.messageHash).toBe(expected);
+    // Sanity: it is NOT the retired 7-field inc-1 preimage.
+    const retired7field = ethers.keccak256(
       new ethers.AbiCoder().encode(
         ["uint256", "address", "uint8", "address[]", "uint256[]", "uint256", "uint256"],
         [7n, OPERATOR, 1, [], [], epoch, 11155111]
       )
     );
+    expect(proof.messageHash).not.toBe(retired7field);
+    expect(proof.messageHashNote).toBeUndefined();
+  });
+
+  it("Finding 1: the file-only (executeSlash off) path ALSO archives the 8-field execute preimage", async () => {
+    const blockchain = overLimitBlockchain({
+      createProposalWithEvidence: async () => ({ txHash: "0xTX", proposalId: 9n }),
+    });
+    const archive = makeArchive();
+    // Default config → executeSlash OFF; no queue/execute, but the proof still binds the execute preimage.
+    const svc = makeService(blockchain, makeConfig(), archive);
+    await svc.tick();
+    const proof = archive.records[0];
+    const expected = buildExecuteMessageHash(9n, OPERATOR, 1, BLOCK, 11155111, proof.proofHash);
     expect(proof.messageHash).toBe(expected);
   });
 
-  it("unresolved proposal id → messageHash placeholder '0x' (no on-chain proposal to sign)", async () => {
+  it("unresolved proposal id → messageHash placeholder '0x' + a note (no on-chain proposal to sign)", async () => {
     const blockchain = overLimitBlockchain({
       createProposalWithEvidence: async () => ({ txHash: "0xDEF", proposalId: null }),
     });
@@ -774,6 +801,7 @@ describe("AuditService", () => {
     const svc = makeService(blockchain, makeConfig(), archive);
     await svc.tick();
     expect(archive.records[0].messageHash).toBe("0x");
+    expect(archive.records[0].messageHashNote).toMatch(/id-unresolved/);
   });
 
   // ── INCREMENT 2: two-step slash-consensus orchestration ─────────────────────────
@@ -832,7 +860,8 @@ describe("AuditService", () => {
     expect(order).toEqual(["queue", "create", "execute"]);
     expect(archive.records).toHaveLength(1);
     const proof = archive.records[0];
-    const epoch = Math.floor(now / 1000);
+    // epoch is the DETERMINISTIC violationBlock, not a wall-clock value.
+    const epoch = BLOCK;
 
     // createProposalWithEvidence bound the archived evidence: (dvt, op, level, reason, proofHash).
     const createArgs = (recordingBlockchain as any).lastCreateArgs;
@@ -841,7 +870,7 @@ describe("AuditService", () => {
     expect(createArgs[2]).toBe(1); // SlashLevel.MINOR
     expect(createArgs[4]).toBe(proof.proofHash);
 
-    // execute used the REAL proposal id (7) with empty rep arrays + the same epoch.
+    // execute used the REAL proposal id (7) with empty rep arrays + the same deterministic epoch.
     const execArgs = (recordingBlockchain as any).lastExecuteArgs;
     expect(execArgs[0]).toBe(DVT_VALIDATOR);
     expect(execArgs[1]).toBe(7n);
@@ -855,6 +884,20 @@ describe("AuditService", () => {
     const expectedExec = buildExecuteMessageHash(7n, OPERATOR, 1, epoch, 11155111, proof.proofHash);
     expect(coSigner.calls[0]).toBe(expectedQueue);
     expect(coSigner.calls[1]).toBe(expectedExec);
+
+    // The archived proof records BOTH signed preimages, the queue/execute tx hashes, and the
+    // real co-sign material (finding-1 + finding-2).
+    expect(proof.queueMessageHash).toBe(expectedQueue);
+    expect(proof.messageHash).toBe(expectedExec);
+    expect(proof.queueTx).not.toBeUndefined();
+    expect(proof.executeTx).toBe("0xEXECUTETX");
+    expect(proof.signerMask).toBe(ethers.toBeHex(0b111n));
+    expect(proof.sigG2).toBe("0x" + "ab".repeat(64));
+
+    // The detection surfaces the queue/execute txs too.
+    const status = await svc.getStatus();
+    expect(status.recentDetections[0].queueTx).not.toBeNull();
+    expect(status.recentDetections[0].executeTx).toBe("0xEXECUTETX");
 
     // The execute step carried the abi-encoded proof (uint256 signerMask, bytes sigG2).
     const expectedProof = encodeProof(0b111n, "0x" + "ab".repeat(64));
@@ -939,6 +982,154 @@ describe("AuditService", () => {
     // queue reverted but was swallowed; create + execute still ran; evidence archived.
     expect(order).toEqual(["queue-fail", "create", "execute"]);
     expect(archive.records).toHaveLength(1);
+  });
+
+  // ── FINDING 3: epoch is the deterministic violationBlock (cross-node agreement) ──
+  it("Finding 3: epoch == violationBlock — identical across two wildly different observedAt values", async () => {
+    const mkNode = (nowMs: number) => {
+      const blockchain = overLimitBlockchain();
+      blockchain.getBlockNumber = async () => 8_888_888;
+      const archive = makeArchive();
+      const svc = makeService(blockchain, makeConfig(), archive, clockAt(nowMs));
+      return { svc, archive };
+    };
+    const a = mkNode(1_000);
+    const b = mkNode(9_999_999_999_000);
+    await a.svc.tick();
+    await b.svc.tick();
+    // Both nodes derive epoch = violationBlock, regardless of their wall-clocks.
+    expect(a.archive.records[0].epoch).toBe(8_888_888);
+    expect(b.archive.records[0].epoch).toBe(8_888_888);
+    // observedAt stays the ONLY wall-clock field and DOES differ between the nodes.
+    expect(a.archive.records[0].evidence.observedAt).toBe(1_000);
+    expect(b.archive.records[0].evidence.observedAt).toBe(9_999_999_999_000);
+  });
+
+  // ── FINDING 4: coarse operator|rule guard prevents over-slashing a sustained violation ──
+  it("Finding 4: a sustained violation across ticks (advancing block, past cooldown) EXECUTES the slash only ONCE", async () => {
+    const order: string[] = [];
+    let block = 4000;
+    let now = 1_700_000_000_000;
+    const blockchain = recordingBlockchain(order);
+    blockchain.getBlockNumber = async () => block;
+    const archive = makeArchive();
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true, auditCooldownMs: 3_600_000 }),
+      archive,
+      () => now,
+      makeCoSigner()
+    );
+    // Tick 1 → queue + create + execute (slash executes).
+    await svc.tick();
+    // More ticks, each a NEW block AND past cooldown — the coarse guard still blocks a 2nd execute.
+    for (let i = 0; i < 3; i++) {
+      block += 1;
+      now += 3_600_001;
+      await svc.tick();
+    }
+    expect(order.filter(o => o === "execute")).toHaveLength(1);
+    // Evidence is still archived for each new block — just never re-slashed.
+    expect(archive.records.length).toBeGreaterThan(1);
+  });
+
+  it("Finding 4: the over-slash guard CLEARS when the operator becomes healthy, so a NEW violation slashes again", async () => {
+    const order: string[] = [];
+    let block = 4000;
+    let now = 1_700_000_000_000;
+    let over = true;
+    const blockchain = recordingBlockchain(order, {
+      getDebt: async () => (over ? 2000n : 0n),
+      getAvailableCredit: async () => (over ? 0n : 1000n),
+    });
+    blockchain.getBlockNumber = async () => block;
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true, auditCooldownMs: 1 }),
+      makeArchive(),
+      () => now,
+      makeCoSigner()
+    );
+    await svc.tick(); // slash #1
+    // Operator recovers → a healthy tick clears the coarse guard.
+    over = false;
+    block += 1;
+    now += 10;
+    await svc.tick();
+    // Operator breaches again at a NEW block, past the (1ms) cooldown → slash #2 allowed.
+    over = true;
+    block += 1;
+    now += 10;
+    await svc.tick();
+    expect(order.filter(o => o === "execute")).toHaveLength(2);
+  });
+
+  it("Finding 4: an on-chain isSlashPending=true short-circuits queue/create/execute (durable cross-restart guard)", async () => {
+    const order: string[] = [];
+    const blockchain = recordingBlockchain(order, { isSlashPending: async () => true });
+    const archive = makeArchive();
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true }),
+      archive,
+      undefined,
+      makeCoSigner()
+    );
+    await svc.tick();
+    // Already pending on-chain → NO on-chain writes this tick; evidence still archived.
+    expect(order).toEqual([]);
+    expect(archive.records).toHaveLength(1);
+    expect(archive.records[0].proposalIdNote).toMatch(/over-slash guard/);
+  });
+
+  // ── FINDING 5: archive-before-execute ordering (durable intent precedes the slash) ──
+  it("Finding 5: the proof is archived (durable intent) BEFORE the irreversible on-chain execute, then updated after", async () => {
+    const order: string[] = [];
+    const blockchain = overLimitBlockchain({
+      queueSlashWithProof: async () => {
+        order.push("queue");
+        return "0xQ";
+      },
+      createProposalWithEvidence: async () => {
+        order.push("create");
+        return { txHash: "0xP", proposalId: 7n };
+      },
+      executeSlashWithProof: async () => {
+        order.push("execute");
+        return "0xE";
+      },
+    });
+    const records: SlashProof[] = [];
+    const orderingArchive: IProofArchive = {
+      async put(proof: SlashProof) {
+        order.push("archive-put");
+        const i = records.findIndex(r => r.proofHash === proof.proofHash);
+        if (i >= 0) records[i] = proof;
+        else records.push(proof);
+        return { proofHash: proof.proofHash, location: `mem://${proof.proofHash}` };
+      },
+      async has(proofHash: string) {
+        return records.some(r => r.proofHash === proofHash);
+      },
+      async count() {
+        return records.length;
+      },
+    };
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true }),
+      orderingArchive,
+      undefined,
+      makeCoSigner()
+    );
+    await svc.tick();
+    // The FIRST durable write must land before the slash executes.
+    const firstArchive = order.indexOf("archive-put");
+    expect(firstArchive).toBeGreaterThanOrEqual(0);
+    expect(order.indexOf("execute")).toBeGreaterThan(firstArchive);
+    // And a post-execute update records the executeTx on the proof (finding-2).
+    expect(records[0].executeTx).toBe("0xE");
+    expect(records[0].queueTx).toBe("0xQ");
   });
 
   it("computeJitterMs stays within [0, intervalMs)", () => {

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -639,7 +639,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       proposalIdNote = "id-unresolved: proposal attempt suppressed by cooldown";
     } else if (
       this.executeSlash &&
-      (await this.isCoarseAlreadySlashed(coarseKey, v.operator, v.violationBlock))
+      (await this.isCoarseAlreadySlashed(coarseKey, v.operator, v.slashLevel, v.violationBlock))
     ) {
       // ARMED path OVER-SLASH GUARD (finding-4/5): a slash already executed (in-memory) or is
       // pending on-chain for this operator+rule → do NOT queue/execute the same ongoing condition
@@ -774,13 +774,20 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
    *      local journal was lost. A hit is persisted to BOTH the durable journal and the memory guard.
    *   4. Best-effort on-chain PENDING flag (isSlashPending) — null ("unknown") on the current SP
    *      (private `_pendingSlash`), so it only helps a future deployment that exposes a getter.
+   *   5. CONSERVATIVE fail-closed backstop — if the on-chain event scan was INDETERMINATE (provider
+   *      error → null), there is no durable marker, AND the pending flag is ALSO indeterminate, we
+   *      cannot positively confirm "not slashed". For an IRREVERSIBLE slash we then treat it as
+   *      already-slashed and SKIP: better to miss a legitimate slash than risk a DOUBLE-slash when
+   *      the chain state can't be read.
    *
-   * `violationBlock` bounds the event scan window (`violationBlock - slashLookbackBlocks`). Every
-   * remote read is best-effort: an error is swallowed and treated as "no signal", never "not slashed".
+   * `violationBlock` bounds the event scan window (`violationBlock - slashLookbackBlocks`); the scan
+   * is narrowed to operator + `slashLevel`. A determinate remote read of "not slashed" lets the slash
+   * proceed; an indeterminate read (provider error) fails CLOSED per (5) — never "safe to slash".
    */
   private async isCoarseAlreadySlashed(
     coarseKey: string,
     operator: string,
+    slashLevel: number,
     violationBlock: number
   ): Promise<boolean> {
     if (this.slashedCoarseKeys.has(coarseKey)) return true;
@@ -795,29 +802,55 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       // best-effort: journal read error → fall through to the on-chain scan.
     }
 
-    // (3) ON-CHAIN slash-executed events — the authoritative cross-restart guard.
+    // (3) ON-CHAIN slash-executed events — the authoritative cross-restart guard. A `null` from any
+    // target means that scan was INDETERMINATE (provider error), tracked so (5) can fail closed.
+    let scanIndeterminate = false;
     try {
       const fromBlock = Math.max(0, violationBlock - this.slashLookbackBlocks);
       const scanTargets = [this.blsAggregatorAddress, this.superPaymasterAddress].filter(Boolean);
       for (const target of scanTargets) {
-        if (await this.blockchainService.getRecentSlashExecuted(target, operator, fromBlock)) {
+        const hit = await this.blockchainService.getRecentSlashExecuted(
+          target,
+          operator,
+          slashLevel,
+          fromBlock
+        );
+        if (hit === true) {
           await this.recordCoarseSlashed(coarseKey); // persist durable + memory
           return true;
         }
+        if (hit === null) scanIndeterminate = true; // provider error on this target — unconfirmable
       }
     } catch {
-      // best-effort: RPC/range error → fall through to the pending flag.
+      // getRecentSlashExecuted threw (unexpected) → treat the whole scan as indeterminate.
+      scanIndeterminate = true;
     }
 
     // (4) Best-effort on-chain pending flag (null/unknown on the current SP).
+    let pendingIndeterminate = false;
     try {
       const pending = await this.blockchainService.isSlashPending(this.superPaymasterAddress, operator);
       if (pending === true) {
         this.markCoarseSlashed(coarseKey);
         return true;
       }
+      if (pending === null) pendingIndeterminate = true; // no getter on this deployment → unknown
     } catch {
-      // best-effort: getter absent / RPC error → unknown, rely on the guards above.
+      pendingIndeterminate = true; // getter absent / RPC error → unknown
+    }
+
+    // (5) CONSERVATIVE fail-closed backstop. Reaching here means NO guard positively confirmed an
+    // existing slash. If BOTH the on-chain event scan and the pending flag were indeterminate (and
+    // there is no durable marker — else we'd have returned above), we have zero authoritative signal
+    // that the operator is un-slashed. Fail CLOSED: skip the irreversible slash rather than risk a
+    // double-slash on unreadable chain state. A determinate on-chain "not slashed" leaves
+    // scanIndeterminate=false, so the normal armed path still slashes.
+    if (scanIndeterminate && pendingIndeterminate) {
+      this.logger.warn(
+        `Audit: ${operator} slash-state INDETERMINATE (on-chain scan + pending flag both ` +
+          `unavailable, no durable marker) — over-slash guard fails CLOSED, on-chain slash SKIPPED`
+      );
+      return true;
     }
     return false;
   }
@@ -978,11 +1011,19 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
           this.logger.warn(
             `Audit: ${operator} slash EXECUTED (proposal ${proposalId}, tx ${executeTx})`
           );
-          // Durable immediately after the irreversible slash confirms (finding-4).
+          // Durable immediately after the irreversible slash confirms (finding-4). Set the SUBMITTED
+          // execute preimage as messageHash TOGETHER with executeTx in this same write, so every
+          // durable snapshot is internally consistent: a crash before the caller's final re-archive
+          // can no longer persist executeTx with messageHash="0x". `execMsgHash` is the exact 8-field
+          // preimage the quorum co-signed and executeWithProof carried (MEDIUM: executeTx+messageHash
+          // archived together). The caller's final pass recomputes the identical value (idempotent).
           if (proof) {
             proof.executeTx = executeTx;
             proof.signerMask = signerMask;
             proof.sigG2 = sigG2;
+            proof.messageHash = execMsgHash;
+            delete proof.messageHashNote;
+            delete proof.intendedExecuteMessageHash;
             await persistStep();
           }
         } catch (err: unknown) {

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -343,7 +343,12 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
    */
   private async clearCoarseSlashed(operator: string, rule: string): Promise<void> {
     const coarseKey = this.coarseKey(operator, rule);
-    this.slashedCoarseKeys.delete(coarseKey);
+    const hadInMemory = this.slashedCoarseKeys.delete(coarseKey);
+    // Durable slashed markers are ONLY ever written on the armed (executeSlash) execute path. On the
+    // default file-only path none can exist, so the removeSlashed syscall on every healthy tick is
+    // pure waste (PK finding). Skip it unless execution is armed or we actually had an in-memory
+    // marker to mirror durably — correctness is unchanged (a stale marker is re-checked on-chain).
+    if (!hadInMemory && !this.executeSlash) return;
     try {
       await this.archive.removeSlashed(coarseKey);
     } catch {
@@ -382,9 +387,22 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     // have aged past cooldownMs (they can no longer suppress anything) before each sweep.
     this.pruneDedupState();
     try {
+      // Resolve the finalized evidence block ONCE per tick and share it across every operator in
+      // this sweep (PK perf finding): a healthy watchlist otherwise pays getViolationBlock's 1-4
+      // RPC per operator. One finalized snapshot is also MORE consistent (all operators evaluated
+      // against the same chain state) and cannot reorg. A failure here is a global RPC problem, not
+      // per-operator, so skip the whole tick rather than hammering each operator into the same error.
+      let pinnedBlock: { number: number; hash: string };
+      try {
+        pinnedBlock = await this.blockchainService.getViolationBlock(this.finalityConfirmations);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.logger.error(`Audit: could not resolve finalized block — skipping tick (${msg})`);
+        return;
+      }
       for (const operator of this.watchlist) {
         try {
-          await this.auditOperator(operator);
+          await this.auditOperator(operator, pinnedBlock);
         } catch (err: unknown) {
           const msg = err instanceof Error ? err.message : String(err);
           this.logger.error(`Audit: ${operator} audit failed — ${msg}`);
@@ -399,13 +417,18 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
    * Audit a single operator: read its credit / reputation / stake state and evaluate the
    * credit-over-limit rule. On a confirmed violation, archive a proof and file a proposal.
    */
-  async auditOperator(operator: string): Promise<void> {
+  async auditOperator(
+    operator: string,
+    pinnedBlock?: { number: number; hash: string }
+  ): Promise<void> {
     // Pin EVERY rule input to ONE FINALIZED block (finding-3) so creditLimit, availableCredit and
     // debt can never be mixed across blocks (no phantom over-limit from a mid-read state change)
     // AND the block the irreversible slash is justified by cannot be undone by a reorg. The block
     // HASH is recorded in the evidence so the justification is pinned to a specific finalized block.
+    // tick() resolves this ONCE and shares it across the sweep; a direct caller (tests) may omit it.
     const { number: violationBlock, hash: violationBlockHash } =
-      await this.blockchainService.getViolationBlock(this.finalityConfirmations);
+      pinnedBlock ??
+      (await this.blockchainService.getViolationBlock(this.finalityConfirmations));
 
     // All per-operator reads are pinned to the SAME block; issue them concurrently (5-6 reads)
     // rather than serially. reputation + DVT stake lock are auxiliary evidence (not part of the

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -11,6 +11,14 @@ import { BlockchainService } from "../blockchain/blockchain.service.js";
 import { CapabilityRegistry } from "../capability/capability-registry.service.js";
 import type { IProofArchive, SlashProof, EvidenceSource, ProofIdentity } from "./proof-archive.js";
 import { LocalProofArchive, computeProofHash } from "./proof-archive.js";
+import type { IQuorumCoSigner } from "./slash-consensus.js";
+import {
+  SlashLevel,
+  PendingSlotCoSigner,
+  buildQueueMessageHash,
+  buildExecuteMessageHash,
+  encodeProof,
+} from "./slash-consensus.js";
 
 /**
  * DVT Phase 2 (目标2) — autonomous audit of SuperPaymaster operators, increment 1.
@@ -33,8 +41,12 @@ import { LocalProofArchive, computeProofHash } from "./proof-archive.js";
  *   - increment 3: IPFS pinning of proofs.
  */
 
-/** Slash severity for the credit-over-limit rule (uint8 level passed to createProposal). */
-const SLASH_LEVEL_CREDIT_OVER_LIMIT = 1;
+/**
+ * Slash severity for the credit-over-limit rule. Maps to the SP #329 SlashLevel enum: MINOR (=1),
+ * which is 3-of-3 quorum in the N=3 bootstrap. This uint8 is the `level` passed to createProposal
+ * AND the slashLevel bound into both the queue and execute co-sign preimages — they must agree.
+ */
+const SLASH_LEVEL_CREDIT_OVER_LIMIT = SlashLevel.MINOR;
 const RULE_CREDIT_OVER_LIMIT = "credit-over-limit";
 /** ROLE_DVT = keccak256("DVT") — the staking role lock the audit inspects. */
 const ROLE_DVT = ethers.id("DVT");
@@ -65,10 +77,19 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
   private readonly registryAddress: string;
   private readonly superPaymasterAddress: string;
   private readonly dvtValidatorAddress: string;
+  private readonly blsAggregatorAddress: string;
   private readonly gtokenStakingAddress: string;
   /** xPNTs token the credit-over-limit rule reads operator debt from (getDebt lives on the token). */
   private readonly apntsTokenAddress: string;
+  /**
+   * SECOND safety gate (increment 2). When false (default) a violation only FILES + ARCHIVES a
+   * slash proposal; the two-step on-chain slash (queue → execute, quorum co-signed) fires only
+   * when both auditEnabled AND this are true — so nothing is auto-slashed until explicitly enabled.
+   */
+  private readonly executeSlash: boolean;
   private readonly archive: IProofArchive;
+  /** Quorum co-sign seam — default PendingSlotCoSigner (fails closed until SP assigns BLS slots). */
+  private readonly coSigner: IQuorumCoSigner;
   private readonly clock: () => number;
   private readonly random: () => number;
 
@@ -105,7 +126,9 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     /** Test seam: controls the startup phase jitter (default Math.random). */
     @Optional() random?: () => number,
     /** Test seam: injectable archive; defaults to a LocalProofArchive at auditProofDir. */
-    @Optional() archive?: IProofArchive
+    @Optional() archive?: IProofArchive,
+    /** Injected quorum co-signer; defaults to the deferred PendingSlotCoSigner (fails closed). */
+    @Optional() coSigner?: IQuorumCoSigner
   ) {
     this.enabled = config.get<boolean>("auditEnabled") === true;
     this.intervalMs = config.get<number>("auditIntervalMs") ?? 60_000;
@@ -132,12 +155,15 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     this.registryAddress = config.get<string>("auditRegistryAddress") ?? "";
     this.superPaymasterAddress = config.get<string>("auditSuperPaymasterAddress") ?? "";
     this.dvtValidatorAddress = config.get<string>("auditDvtValidatorAddress") ?? "";
+    this.blsAggregatorAddress = config.get<string>("auditBlsAggregatorAddress") ?? "";
     this.gtokenStakingAddress = config.get<string>("auditGtokenStakingAddress") ?? "";
     this.apntsTokenAddress = config.get<string>("auditApntsTokenAddress") ?? "";
+    this.executeSlash = config.get<boolean>("auditExecuteSlash") === true;
     this.clock = clock ?? (() => Date.now());
     this.random = random ?? (() => Math.random());
     this.archive =
       archive ?? new LocalProofArchive(config.get<string>("auditProofDir") ?? "./audit-proofs");
+    this.coSigner = coSigner ?? new PendingSlotCoSigner();
 
     capabilityRegistry?.register({
       name: "audit",
@@ -219,7 +245,9 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     this.logger.log(
       `DVT audit ENABLED — interval=${this.intervalMs}ms jitter=${jitterMs}ms ` +
         `watchlist=[${this.watchlist.join(", ")}] creditThreshold=${this.creditThresholdBps}bps ` +
-        `registry=${this.registryAddress} superPaymaster=${this.superPaymasterAddress}`
+        `registry=${this.registryAddress} superPaymaster=${this.superPaymasterAddress} ` +
+        `dvtValidator=${this.dvtValidatorAddress} blsAggregator=${this.blsAggregatorAddress} ` +
+        `executeSlash=${this.executeSlash} (${this.executeSlash ? "two-step on-chain slash ARMED" : "file+archive ONLY"})`
     );
   }
 
@@ -488,18 +516,38 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       // Arm the cooldown on ATTEMPT (before the result) so a reverting tx still backs off for
       // cooldownMs instead of retrying every advancing-block tick.
       this.lastProposalAt.set(coarseKey, this.clock());
-      try {
-        const res = await this.blockchainService.createSlashProposal(
-          this.dvtValidatorAddress,
-          v.operator,
-          v.slashLevel,
-          v.reason
-        );
-        proposalTx = res.txHash;
+      if (this.executeSlash) {
+        // INCREMENT 2 (execute-slash ARMED): the FULL two-step on-chain slash orchestration —
+        // queue (co-signed) → createProposal(evidenceHash=proofHash) → execute (co-signed). Each
+        // step is wrapped so a co-sign/tx failure is logged but the evidence is still archived
+        // below (evidence never lost) and the poll loop never crashes.
+        const res = await this.coordinateQuorumCoSign({
+          operator: v.operator,
+          slashLevel: v.slashLevel,
+          reason: v.reason,
+          epoch,
+          evidenceHash: proofHash,
+        });
+        proposalTx = res.proposalTx;
         onchainProposalId = res.proposalId;
-      } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
-        this.logger.error(`Audit: ${v.operator} createProposal failed — ${msg}`);
+      } else {
+        // DEFAULT (execute-slash OFF): only FILE the proposal (proposal-INTENT), binding the
+        // archived evidence via evidenceHash=proofHash. No queue/execute → nothing is slashed.
+        // Best-effort: on failure (no wallet / revert) the proof is still archived below.
+        try {
+          const res = await this.blockchainService.createProposalWithEvidence(
+            this.dvtValidatorAddress,
+            v.operator,
+            v.slashLevel,
+            v.reason,
+            proofHash
+          );
+          proposalTx = res.txHash;
+          onchainProposalId = res.proposalId;
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err);
+          this.logger.error(`Audit: ${v.operator} createProposal failed — ${msg}`);
+        }
       }
     }
 
@@ -574,10 +622,9 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
         (proposalTx ? ` (proposal ${proposalTx})` : " (proposal NOT filed)")
     );
 
-    // TODO(increment-2): coordinateQuorumCoSign() — gossip the proposal to the other DVT
-    // nodes, collect their BLS co-signatures into an aggregate, then submit through
-    // BLSAggregator.verifyAndExecute to actually execute the slash. Deferred: needs the
-    // gossip aggregation layer across DVT nodes.
+    // NOTE: the on-chain two-step slash (queue → createProposal → execute) already ran ABOVE
+    // via coordinateQuorumCoSign when executeSlash is armed. It runs BEFORE this archival on
+    // purpose but catches all of its own failures, so the evidence is archived regardless.
 
     const detection: AuditDetection = {
       operator: v.operator,
@@ -596,12 +643,117 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
   }
 
   /**
-   * TODO(increment-2): coordinate the multi-node BLS quorum co-sign over a filed proposal
-   * and submit BLSAggregator.verifyAndExecute. Deferred — requires gossip aggregation across
-   * DVT nodes. Kept as a named seam so the increment-1 flow already points at where it lands.
+   * INCREMENT 2 — the two-step slash-consensus orchestration that turns a filed audit violation
+   * into a real on-chain slash (SP #329). Two INDEPENDENT quorum-co-signed steps bracket the
+   * proposal, run in this exact order:
+   *
+   *   1. QUEUE    — co-sign the 5-field queue preimage → queueSlashWithProof (slash intent).
+   *   2. PROPOSAL — createProposalWithEvidence(evidenceHash=proofHash) → the REAL proposal id,
+   *                 binding the on-chain slash to the archived evidence.
+   *   3. EXECUTE  — co-sign the 8-field execute preimage (bound to that real id + evidenceHash)
+   *                 → executeWithProof (slash-only ⇒ repUsers/newScores empty). Skipped when the
+   *                 proposal id is unresolved (a fabricated id would revert on-chain).
+   *
+   * Each step is wrapped: a co-sign or tx failure is logged and swallowed so the caller still
+   * archives the evidence (evidence never lost) and the poll loop never crashes. With the default
+   * PendingSlotCoSigner every co-sign throws (SP validator slots pending the 24h timelock), so
+   * this reduces to: nothing queued, proposal filed, nothing executed.
+   *
+   * TODO(inc-2 live): the real multi-node gossip BLS aggregation behind coSigner — collect peer
+   * signatures over the messageHash, build the signerMask bitmap by SP-assigned validator slot,
+   * aggregate into sigG2 — lands once SP hands out slots via registerBLSPublicKey.
    */
-  async coordinateQuorumCoSign(): Promise<never> {
-    throw new Error("coordinateQuorumCoSign deferred to increment 2 (gossip BLS aggregation)");
+  async coordinateQuorumCoSign(args: {
+    operator: string;
+    slashLevel: number;
+    reason: string;
+    epoch: number;
+    evidenceHash: string;
+  }): Promise<{
+    proposalTx: string | null;
+    proposalId: bigint | null;
+    queueTx: string | null;
+    executeTx: string | null;
+  }> {
+    const { operator, slashLevel, reason, epoch, evidenceHash } = args;
+    let queueTx: string | null = null;
+    let proposalTx: string | null = null;
+    let proposalId: bigint | null = null;
+    let executeTx: string | null = null;
+
+    // ── Step 1: QUEUE (quorum co-signed) ──────────────────────────────────────────
+    try {
+      const queueMsgHash = buildQueueMessageHash(operator, slashLevel, epoch, this.chainId);
+      const { signerMask, sigG2 } = await this.coSigner.coSign(queueMsgHash);
+      const proof = encodeProof(signerMask, sigG2);
+      queueTx = await this.blockchainService.queueSlashWithProof(
+        this.dvtValidatorAddress,
+        operator,
+        slashLevel,
+        epoch,
+        proof
+      );
+      this.logger.warn(`Audit: ${operator} slash QUEUED (tx ${queueTx})`);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Audit: ${operator} slash queue step failed — ${msg} (evidence archived; slash not queued)`
+      );
+    }
+
+    // ── Step 2: file the proposal (binds evidenceHash=proofHash) ───────────────────
+    try {
+      const res = await this.blockchainService.createProposalWithEvidence(
+        this.dvtValidatorAddress,
+        operator,
+        slashLevel,
+        reason,
+        evidenceHash
+      );
+      proposalTx = res.txHash;
+      proposalId = res.proposalId;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(`Audit: ${operator} createProposal failed — ${msg}`);
+    }
+
+    // ── Step 3: EXECUTE (quorum co-signed) — only with a REAL proposal id ───────────
+    if (proposalId === null) {
+      this.logger.error(
+        `Audit: ${operator} slash execute SKIPPED — no real proposalId ` +
+          `(createProposal failed or ProposalCreated absent); a fabricated id would revert`
+      );
+      return { proposalTx, proposalId, queueTx, executeTx };
+    }
+    try {
+      const execMsgHash = buildExecuteMessageHash(
+        proposalId,
+        operator,
+        slashLevel,
+        epoch,
+        this.chainId,
+        evidenceHash
+      );
+      const { signerMask, sigG2 } = await this.coSigner.coSign(execMsgHash);
+      const proof = encodeProof(signerMask, sigG2);
+      executeTx = await this.blockchainService.executeSlashWithProof(
+        this.dvtValidatorAddress,
+        proposalId,
+        [], // slash-only ⇒ no reputation users
+        [], // slash-only ⇒ no reputation scores
+        epoch,
+        proof
+      );
+      this.logger.warn(
+        `Audit: ${operator} slash EXECUTED (proposal ${proposalId}, tx ${executeTx})`
+      );
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Audit: ${operator} slash execute step failed — ${msg} (evidence archived; slash not executed)`
+      );
+    }
+    return { proposalTx, proposalId, queueTx, executeTx };
   }
 
   /** Read-only status for GET /audit/status. No secrets. */

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -343,12 +343,12 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
    */
   private async clearCoarseSlashed(operator: string, rule: string): Promise<void> {
     const coarseKey = this.coarseKey(operator, rule);
-    const hadInMemory = this.slashedCoarseKeys.delete(coarseKey);
-    // Durable slashed markers are ONLY ever written on the armed (executeSlash) execute path. On the
-    // default file-only path none can exist, so the removeSlashed syscall on every healthy tick is
-    // pure waste (PK finding). Skip it unless execution is armed or we actually had an in-memory
-    // marker to mirror durably — correctness is unchanged (a stale marker is re-checked on-chain).
-    if (!hadInMemory && !this.executeSlash) return;
+    this.slashedCoarseKeys.delete(coarseKey);
+    // A healthy read ALWAYS attempts the durable removal, regardless of the current executeSlash
+    // setting. A durable marker written by an EARLIER armed run must be cleared even if the node is
+    // now running disarmed — otherwise it would survive an armed→disarmed→armed restart cycle and,
+    // since hasSlashed short-circuits before the on-chain scan, suppress a legitimate future slash
+    // indefinitely (Codex R3 B-F3). removeSlashed on an absent key is a cheap best-effort no-op.
     try {
       await this.archive.removeSlashed(coarseKey);
     } catch {

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -240,7 +240,9 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
         this.enabled = false;
-        this.logger.error(`Audit: getCode(${name}=${addr}) failed (${msg}) — DISABLED (fail-closed)`);
+        this.logger.error(
+          `Audit: getCode(${name}=${addr}) failed (${msg}) — DISABLED (fail-closed)`
+        );
         return;
       }
       if (!code || code === "0x") {
@@ -427,8 +429,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     // HASH is recorded in the evidence so the justification is pinned to a specific finalized block.
     // tick() resolves this ONCE and shares it across the sweep; a direct caller (tests) may omit it.
     const { number: violationBlock, hash: violationBlockHash } =
-      pinnedBlock ??
-      (await this.blockchainService.getViolationBlock(this.finalityConfirmations));
+      pinnedBlock ?? (await this.blockchainService.getViolationBlock(this.finalityConfirmations));
 
     // All per-operator reads are pinned to the SAME block; issue them concurrently (5-6 reads)
     // rather than serially. reputation + DVT stake lock are auxiliary evidence (not part of the
@@ -513,7 +514,12 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       `${RULE_CREDIT_OVER_LIMIT}: debt ${debt} EXCEEDS limit ${creditLimit} ` +
       `(usage ${usageBps}bps ≥ ${this.creditThresholdBps}bps, availableCredit ${availableCredit}, block ${violationBlock})`;
     const sources: EvidenceSource[] = [
-      { type: "view", name: "Registry.getCreditLimit", value: creditLimit.toString(), block: violationBlock },
+      {
+        type: "view",
+        name: "Registry.getCreditLimit",
+        value: creditLimit.toString(),
+        block: violationBlock,
+      },
       {
         type: "view",
         name: `IxPNTsToken(${this.apntsTokenAddress}).getDebt`,
@@ -526,8 +532,18 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
         value: availableCredit.toString(),
         block: violationBlock,
       },
-      { type: "view", name: "Registry.globalReputation", value: reputation.toString(), block: violationBlock },
-      { type: "view", name: "GTokenStaking.roleLocks(DVT)", value: dvtStake.toString(), block: violationBlock },
+      {
+        type: "view",
+        name: "Registry.globalReputation",
+        value: reputation.toString(),
+        block: violationBlock,
+      },
+      {
+        type: "view",
+        name: "GTokenStaking.roleLocks(DVT)",
+        value: dvtStake.toString(),
+        block: violationBlock,
+      },
     ];
 
     await this.handleViolation({
@@ -720,7 +736,8 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     // resolved but NO execute was submitted (file-only path, or execute skipped/failed), the
     // computed-but-unsubmitted preimage is kept under intendedExecuteMessageHash — never conflated
     // with a submitted one. When the id is unresolved there is no preimage to compute at all → "0x".
-    const proposalId: string | null = onchainProposalId !== null ? onchainProposalId.toString() : null;
+    const proposalId: string | null =
+      onchainProposalId !== null ? onchainProposalId.toString() : null;
     if (onchainProposalId !== null) {
       const executePreimage = buildExecuteMessageHash(
         onchainProposalId,
@@ -852,7 +869,10 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     // (4) Best-effort on-chain pending flag (null/unknown on the current SP).
     let pendingIndeterminate = false;
     try {
-      const pending = await this.blockchainService.isSlashPending(this.superPaymasterAddress, operator);
+      const pending = await this.blockchainService.isSlashPending(
+        this.superPaymasterAddress,
+        operator
+      );
       if (pending === true) {
         this.markCoarseSlashed(coarseKey);
         return true;

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -50,7 +50,6 @@ const SLASH_LEVEL_CREDIT_OVER_LIMIT = SlashLevel.MINOR;
 const RULE_CREDIT_OVER_LIMIT = "credit-over-limit";
 /** ROLE_DVT = keccak256("DVT") — the staking role lock the audit inspects. */
 const ROLE_DVT = ethers.id("DVT");
-const ABI = new ethers.AbiCoder();
 
 export interface AuditDetection {
   operator: string;
@@ -62,6 +61,10 @@ export interface AuditDetection {
   detectedAt: number;
   /** Tx hash of the filed proposal, or null if the write failed / no wallet / cooldown-suppressed. */
   proposalTx: string | null;
+  /** Tx hash of the STEP-1 queueSlashWithProof (armed executeSlash path), or null. */
+  queueTx: string | null;
+  /** Tx hash of the STEP-2 executeWithProof — the on-chain slash (armed path), or null. */
+  executeTx: string | null;
 }
 
 @Injectable()
@@ -111,6 +114,17 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
    * Pruned once an entry ages past cooldownMs (the cooldown has expired → entry is dead).
    */
   private readonly lastProposalAt = new Map<string, number>();
+  /**
+   * DURABLE (within-process) over-slash guard for the ARMED execute path, keyed on the COARSE
+   * `chainId|operator|rule` (block-INDEPENDENT). Once a slash EXECUTES for an operator+rule, the
+   * coarse key is recorded here and the on-chain queue+execute is NOT re-run for the same ongoing
+   * condition — even after cooldownMs elapses and the violationBlock advances (which would mint a
+   * fresh stableKey/proofHash/epoch every tick). The key is cleared when the operator is next
+   * observed HEALTHY for that rule (condition resolved), so a genuinely NEW violation can slash
+   * again. Complements the best-effort on-chain isSlashPending() (the cross-restart guard) and the
+   * archive-before-execute ordering. The file-only proposal path is unaffected (keeps per-block dedup).
+   */
+  private readonly slashedCoarseKeys = new Set<string>();
   /** Hard ceiling on either dedup map's size — a defensive LRU-style cap against unbounded growth. */
   private static readonly MAX_DEDUP_ENTRIES = 10_000;
   /** Bounded ring of the most recent detections, newest first (for GET /audit/status). */
@@ -281,6 +295,30 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     }
   }
 
+  private coarseKey(operator: string, rule: string): string {
+    return `${this.chainId}|${operator}|${rule}`;
+  }
+
+  /**
+   * Record that an on-chain slash EXECUTED for this operator+rule so the armed execute path does
+   * not re-slash the same ongoing condition on later ticks. Bounded by a defensive LRU-style cap.
+   */
+  private markCoarseSlashed(coarseKey: string): void {
+    this.slashedCoarseKeys.add(coarseKey);
+    if (this.slashedCoarseKeys.size > AuditService.MAX_DEDUP_ENTRIES) {
+      const oldest = this.slashedCoarseKeys.values().next().value;
+      if (oldest !== undefined) this.slashedCoarseKeys.delete(oldest);
+    }
+  }
+
+  /**
+   * Clear the coarse over-slash guard once the operator is observed HEALTHY for a rule — the
+   * violation has resolved, so a genuinely new future violation is allowed to slash again.
+   */
+  private clearCoarseSlashed(operator: string, rule: string): void {
+    this.slashedCoarseKeys.delete(this.coarseKey(operator, rule));
+  }
+
   /**
    * Evict dedup/cooldown entries that have aged past cooldownMs (they can no longer suppress
    * anything, so keeping them only leaks memory in the long-lived daemon). Called once per tick.
@@ -375,6 +413,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       this.logger.debug(
         `Audit: ${operator} creditLimit=0 (unconfigured/de-registered) — SKIP (fail-safe, not over-limit)`
       );
+      this.clearCoarseSlashed(operator, RULE_CREDIT_OVER_LIMIT);
       return;
     }
     // CROSS-CONTRACT AGREEMENT: both SuperPaymaster signals must agree before flagging. If
@@ -385,6 +424,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       this.logger.debug(
         `Audit: ${operator} availableCredit=${availableCredit}>0 (within SP ceiling) — SKIP (no false over-limit)`
       );
+      this.clearCoarseSlashed(operator, RULE_CREDIT_OVER_LIMIT);
       return;
     }
 
@@ -399,12 +439,14 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       this.logger.debug(
         `Audit: ${operator} not over limit (debt=${debt} ≤ limit=${creditLimit}, usage=${usageBps}bps)`
       );
+      this.clearCoarseSlashed(operator, RULE_CREDIT_OVER_LIMIT);
       return;
     }
     if (usageBps < this.creditThresholdBps) {
       this.logger.debug(
         `Audit: ${operator} over limit but under margin (usage=${usageBps}bps < ${this.creditThresholdBps}bps)`
       );
+      this.clearCoarseSlashed(operator, RULE_CREDIT_OVER_LIMIT);
       return;
     }
 
@@ -469,7 +511,12 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     sources: EvidenceSource[];
     observedAt: number;
   }): Promise<AuditDetection | null> {
-    const epoch = Math.floor(v.observedAt / 1000); // human field only — NOT hashed.
+    // DETERMINISTIC slash epoch = the violationBlock (an on-chain fact). Two DVT nodes observing
+    // the SAME violation derive the SAME epoch, so their queue/execute co-sign preimages match and
+    // the gossip BLS aggregate verifies. A wall-clock epoch (Math.floor(observedAt/1000)) would
+    // diverge across nodes → divergent messageHashes → the aggregate would never verify on-chain.
+    // observedAt stays a HUMAN-only field (already excluded from the content-address identity).
+    const epoch = v.violationBlock;
     const proposer = this.blockchainService.getWalletAddress() ?? ethers.ZeroAddress;
 
     // Content-address IDENTITY = ON-CHAIN facts only (no wall-clock). Two DVT nodes seeing
@@ -486,8 +533,8 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
 
     // ── DEDUP ─────────────────────────────────────────────────────────────────────
     const stableKey = `${this.chainId}|${v.operator}|${v.rule}|${v.violationBlock}`;
-    const coarseKey = `${this.chainId}|${v.operator}|${v.rule}`;
-    // (a) exact same violation@block already handled (this process, or on disk from a prior run).
+    const coarseKey = this.coarseKey(v.operator, v.rule);
+    // Exact same violation@block already handled (this process, or on disk from a prior run).
     if (this.proposedStableKeys.has(stableKey) || (await this.archive.has(proofHash))) {
       this.logger.debug(
         `Audit: ${v.operator} ${v.rule}@${v.violationBlock} already proposed (proof ${proofHash}) — skip`
@@ -495,91 +542,10 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       return null;
     }
 
-    // (b) COOLDOWN gates the on-chain ATTEMPT only (never the archival). An ongoing violation
-    //     whose block advances each tick must not re-send a tx every interval — otherwise a
-    //     persistently-reverting proposal (e.g. proposer not an active validator) would burn
-    //     admin-wallet gas and churn nonces forever. The cooldown is armed on ATTEMPT (below),
-    //     regardless of the tx result, keyed on the COARSE chainId|operator|rule.
-    const last = this.lastProposalAt.get(coarseKey);
-    const withinCooldown = last !== undefined && this.clock() - last < this.cooldownMs;
-
-    // File the slash proposal (proposal-INTENT), unless suppressed by the cooldown. Best-effort:
-    // on failure (no wallet / revert) the proof is still archived so the evidence survives.
-    let proposalTx: string | null = null;
-    let onchainProposalId: bigint | null = null;
-    if (withinCooldown) {
-      this.logger.debug(
-        `Audit: ${v.operator} ${v.rule} within cooldown (${this.clock() - (last as number)}ms < ` +
-          `${this.cooldownMs}ms) — attempt suppressed, archiving evidence only`
-      );
-    } else {
-      // Arm the cooldown on ATTEMPT (before the result) so a reverting tx still backs off for
-      // cooldownMs instead of retrying every advancing-block tick.
-      this.lastProposalAt.set(coarseKey, this.clock());
-      if (this.executeSlash) {
-        // INCREMENT 2 (execute-slash ARMED): the FULL two-step on-chain slash orchestration —
-        // queue (co-signed) → createProposal(evidenceHash=proofHash) → execute (co-signed). Each
-        // step is wrapped so a co-sign/tx failure is logged but the evidence is still archived
-        // below (evidence never lost) and the poll loop never crashes.
-        const res = await this.coordinateQuorumCoSign({
-          operator: v.operator,
-          slashLevel: v.slashLevel,
-          reason: v.reason,
-          epoch,
-          evidenceHash: proofHash,
-        });
-        proposalTx = res.proposalTx;
-        onchainProposalId = res.proposalId;
-      } else {
-        // DEFAULT (execute-slash OFF): only FILE the proposal (proposal-INTENT), binding the
-        // archived evidence via evidenceHash=proofHash. No queue/execute → nothing is slashed.
-        // Best-effort: on failure (no wallet / revert) the proof is still archived below.
-        try {
-          const res = await this.blockchainService.createProposalWithEvidence(
-            this.dvtValidatorAddress,
-            v.operator,
-            v.slashLevel,
-            v.reason,
-            proofHash
-          );
-          proposalTx = res.txHash;
-          onchainProposalId = res.proposalId;
-        } catch (err: unknown) {
-          const msg = err instanceof Error ? err.message : String(err);
-          this.logger.error(`Audit: ${v.operator} createProposal failed — ${msg}`);
-        }
-      }
-    }
-
-    // Use the REAL on-chain proposal id (decimal string). When unresolved — attempt suppressed
-    // by cooldown, write failed, or the ProposalCreated event was absent — store null + a clear
-    // note rather than fabricating an id (a fake id would never match the on-chain proposal and
-    // would break increment-2's quorum co-sign / verifyAndExecute).
-    const proposalId: string | null = onchainProposalId !== null ? onchainProposalId.toString() : null;
-    const proposalIdNote = withinCooldown
-      ? "id-unresolved: proposal attempt suppressed by cooldown"
-      : proposalTx === null
-        ? "id-unresolved: proposal write failed"
-        : onchainProposalId === null
-          ? "id-unresolved: ProposalCreated event not found in receipt"
-          : undefined;
-    // The message a DVT quorum would BLS-sign over the proposal (co-sign is increment 2). This
-    // MUST match BLSAggregator.verifyAndExecute's message-hash preimage (BLSAggregator.sol:406):
-    //   keccak256(abi.encode(proposalId, operator, slashLevel, repUsers[], newScores[], epoch, chainId))
-    // — 7 fields. For a slash-only proposal repUsers/newScores are empty ([]). Bound to the REAL id;
-    // when the id is unresolved the message is a placeholder ("0x") since there is no on-chain
-    // proposal to sign over yet.
-    // TODO(inc-2): epoch must match the value passed to verifyAndExecute at co-sign time.
-    const messageHash =
-      onchainProposalId !== null
-        ? ethers.keccak256(
-            ABI.encode(
-              ["uint256", "address", "uint8", "address[]", "uint256[]", "uint256", "uint256"],
-              [onchainProposalId, v.operator, v.slashLevel, [], [], epoch, this.chainId]
-            )
-          )
-        : "0x";
-
+    // Build the PRE-execution proof. The real proof.messageHash is the 8-field EXECUTE preimage,
+    // which needs the REAL proposalId (only known AFTER createProposal) — so it is "0x" + a note
+    // here and is filled in below once the proposal is filed. queueMessageHash (armed path) and
+    // the co-sign material are also set post-orchestration.
     const proof: SlashProof = {
       version: "dvt-slash-proof/1",
       chainId: this.chainId,
@@ -587,7 +553,8 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       slashLevel: v.slashLevel,
       reason: v.reason,
       epoch,
-      messageHash,
+      messageHash: "0x",
+      messageHashNote: "pre-execution: proposalId not yet resolved",
       evidence: {
         rule: v.rule,
         observed: v.debt.toString(),
@@ -596,8 +563,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
         violationBlock: v.violationBlock,
         observedAt: v.observedAt,
       },
-      proposalId,
-      // Quorum co-sign fields are placeholders until increment 2.
+      proposalId: null,
       signerMask: "0x",
       sigG2: "0x",
       proofHash,
@@ -606,25 +572,111 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       penaltyAmount: "0",
       attestations: {},
       createdAt: this.clock(),
-      ...(proposalTx ? { proposalTx } : {}),
-      ...(proposalIdNote ? { proposalIdNote } : {}),
     };
 
-    // Archive the evidence FIRST, then mark the violation@block handled. If archive.put throws
-    // (disk full / IO error), recordStableKey is NOT reached, so a later tick re-attempts the
-    // archive rather than the in-memory stableKey silently suppressing it for cooldownMs — the
-    // "evidence never lost" invariant. (The on-chain tx is still cooldown-gated above, so a retry
-    // re-archives without re-sending a proposal.)
+    // ── ARCHIVE-BEFORE-EXECUTE (finding-5, evidence + intent durable first) ─────────
+    // Persist the durable evidence + slash INTENT BEFORE any irreversible on-chain queue/execute,
+    // so a crash mid-slash cannot lose the record. recordStableKey ONLY after a successful put so
+    // an archive IO failure does not silently suppress a retry (the evidence-never-lost invariant).
     const { location } = await this.archive.put(proof);
     this.recordStableKey(stableKey);
+
+    // ── COOLDOWN + OVER-SLASH GUARD gate the on-chain ATTEMPT (never the archival) ──
+    // COOLDOWN: an ongoing violation whose block advances each tick must not re-send a tx every
+    // interval (a persistently-reverting proposal would burn admin-wallet gas / churn nonces).
+    const last = this.lastProposalAt.get(coarseKey);
+    const withinCooldown = last !== undefined && this.clock() - last < this.cooldownMs;
+
+    let proposalTx: string | null = null;
+    let queueTx: string | null = null;
+    let executeTx: string | null = null;
+    let onchainProposalId: bigint | null = null;
+    let proposalIdNote: string | undefined;
+
+    if (withinCooldown) {
+      this.logger.debug(
+        `Audit: ${v.operator} ${v.rule} within cooldown (${this.clock() - (last as number)}ms < ` +
+          `${this.cooldownMs}ms) — attempt suppressed, archiving evidence only`
+      );
+      proposalIdNote = "id-unresolved: proposal attempt suppressed by cooldown";
+    } else if (this.executeSlash && (await this.isCoarseAlreadySlashed(coarseKey, v.operator))) {
+      // ARMED path OVER-SLASH GUARD (finding-4/5): a slash already executed (in-memory) or is
+      // pending on-chain for this operator+rule → do NOT queue/execute the same ongoing condition
+      // again, even after cooldownMs with an advancing block. Evidence is still archived (above).
+      this.logger.warn(
+        `Audit: ${v.operator} ${v.rule} already slashed/pending — over-slash guard, on-chain slash SKIPPED`
+      );
+      proposalIdNote =
+        "id-unresolved: operator already slashed/pending for this rule (over-slash guard)";
+    } else {
+      // Arm the cooldown on ATTEMPT (before the result) so a reverting tx still backs off.
+      this.lastProposalAt.set(coarseKey, this.clock());
+      // UNIFIED proposal filing (finding-6): both the armed (queue → create → execute) and the
+      // file-only (create only) paths go through coordinateQuorumCoSign — one createProposalWith-
+      // Evidence call site. Every step catches its own failure so the evidence stays archived and
+      // the poll loop never crashes.
+      const res = await this.coordinateQuorumCoSign({
+        operator: v.operator,
+        slashLevel: v.slashLevel,
+        reason: v.reason,
+        epoch,
+        evidenceHash: proofHash,
+      });
+      proposalTx = res.proposalTx;
+      onchainProposalId = res.proposalId;
+      queueTx = res.queueTx;
+      executeTx = res.executeTx;
+      if (res.queueMessageHash) proof.queueMessageHash = res.queueMessageHash;
+      if (executeTx !== null) {
+        // A slash actually executed → arm the over-slash guard + record the real co-sign material.
+        this.markCoarseSlashed(coarseKey);
+        proof.signerMask = res.signerMask;
+        proof.sigG2 = res.sigG2;
+      }
+      if (onchainProposalId === null) {
+        proposalIdNote =
+          proposalTx === null
+            ? "id-unresolved: proposal write failed"
+            : "id-unresolved: ProposalCreated event not found in receipt";
+      }
+    }
+
+    // ── FINAL proof.messageHash = the 8-field EXECUTE preimage actually signed + submitted ──────
+    // (finding-1) buildExecuteMessageHash(proposalId, operator, slashLevel, epoch, chainId,
+    // evidenceHash=proofHash) — the SAME message the quorum co-signs and executeWithProof carries.
+    // When the id is unresolved there is no on-chain proposal to sign over → "0x" + a clear note.
+    const proposalId: string | null = onchainProposalId !== null ? onchainProposalId.toString() : null;
+    if (onchainProposalId !== null) {
+      proof.messageHash = buildExecuteMessageHash(
+        onchainProposalId,
+        v.operator,
+        v.slashLevel,
+        epoch,
+        this.chainId,
+        proofHash
+      );
+      delete proof.messageHashNote;
+    } else {
+      proof.messageHash = "0x";
+      proof.messageHashNote = proposalIdNote ?? "id-unresolved: no on-chain proposal to sign over";
+    }
+    proof.proposalId = proposalId;
+    if (proposalIdNote) proof.proposalIdNote = proposalIdNote;
+    if (proposalTx) proof.proposalTx = proposalTx;
+    if (queueTx) proof.queueTx = queueTx;
+    if (executeTx) proof.executeTx = executeTx;
+
+    // Update the archived proof with the on-chain results (idempotent overwrite on proofHash), so
+    // the evidence now references the queue/execute txs of the slash it justified (finding-2).
+    await this.archive.put(proof);
     this.logger.warn(
       `Audit: ${v.operator} VIOLATION ${v.rule} — proof ${proofHash} archived at ${location}` +
-        (proposalTx ? ` (proposal ${proposalTx})` : " (proposal NOT filed)")
+        (executeTx
+          ? ` (SLASH executed ${executeTx})`
+          : proposalTx
+            ? ` (proposal ${proposalTx})`
+            : " (proposal NOT filed)")
     );
-
-    // NOTE: the on-chain two-step slash (queue → createProposal → execute) already ran ABOVE
-    // via coordinateQuorumCoSign when executeSlash is armed. It runs BEFORE this archival on
-    // purpose but catches all of its own failures, so the evidence is archived regardless.
 
     const detection: AuditDetection = {
       operator: v.operator,
@@ -634,6 +686,8 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       reason: v.reason,
       detectedAt: v.observedAt,
       proposalTx,
+      queueTx,
+      executeTx,
     };
     this.recentDetections.unshift(detection);
     if (this.recentDetections.length > AuditService.MAX_RECENT) {
@@ -643,21 +697,46 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
   }
 
   /**
-   * INCREMENT 2 — the two-step slash-consensus orchestration that turns a filed audit violation
-   * into a real on-chain slash (SP #329). Two INDEPENDENT quorum-co-signed steps bracket the
-   * proposal, run in this exact order:
+   * Is a slash already in effect for this operator+rule? Checks the in-memory coarse guard first
+   * (fast, within-process), then a best-effort on-chain pending-slash read (the durable, restart-
+   * surviving signal). On the current SP the getter is absent so isSlashPending returns null →
+   * unknown → falls back to the in-memory guard. A true on-chain flag is cached into the in-memory
+   * guard so subsequent ticks short-circuit without another RPC.
+   */
+  private async isCoarseAlreadySlashed(coarseKey: string, operator: string): Promise<boolean> {
+    if (this.slashedCoarseKeys.has(coarseKey)) return true;
+    try {
+      const pending = await this.blockchainService.isSlashPending(this.superPaymasterAddress, operator);
+      if (pending === true) {
+        this.markCoarseSlashed(coarseKey);
+        return true;
+      }
+    } catch {
+      // best-effort: getter absent / RPC error → unknown, rely on the in-memory guard only.
+    }
+    return false;
+  }
+
+  /**
+   * The slash-consensus orchestration — the SINGLE createProposalWithEvidence call site for BOTH
+   * the file-only and the armed (SP #329 two-step) paths. Runs in this exact order:
    *
-   *   1. QUEUE    — co-sign the 5-field queue preimage → queueSlashWithProof (slash intent).
+   *   1. QUEUE    — (ARMED only) co-sign the 5-field queue preimage → queueSlashWithProof.
    *   2. PROPOSAL — createProposalWithEvidence(evidenceHash=proofHash) → the REAL proposal id,
-   *                 binding the on-chain slash to the archived evidence.
-   *   3. EXECUTE  — co-sign the 8-field execute preimage (bound to that real id + evidenceHash)
-   *                 → executeWithProof (slash-only ⇒ repUsers/newScores empty). Skipped when the
-   *                 proposal id is unresolved (a fabricated id would revert on-chain).
+   *                 binding the on-chain slash to the archived evidence. ALWAYS runs.
+   *   3. EXECUTE  — (ARMED only) co-sign the 8-field execute preimage (bound to that real id +
+   *                 evidenceHash) → executeWithProof (slash-only ⇒ repUsers/newScores empty).
+   *                 Skipped when the proposal id is unresolved (a fabricated id would revert).
    *
-   * Each step is wrapped: a co-sign or tx failure is logged and swallowed so the caller still
-   * archives the evidence (evidence never lost) and the poll loop never crashes. With the default
-   * PendingSlotCoSigner every co-sign throws (SP validator slots pending the 24h timelock), so
-   * this reduces to: nothing queued, proposal filed, nothing executed.
+   * When executeSlash is OFF (default) only step 2 runs — the file-only path: proposal filed +
+   * evidence bound, nothing queued or slashed. Each step is wrapped: a co-sign or tx failure is
+   * logged and swallowed so the caller still archives the evidence (evidence never lost) and the
+   * poll loop never crashes. With the default PendingSlotCoSigner every co-sign throws (SP
+   * validator slots pending the 24h timelock), so the armed path reduces to just the proposal.
+   *
+   * Returns the queue/proposal/execute tx hashes, the real proposalId, the queueMessageHash (armed
+   * path, so the caller can archive the co-signed queue preimage), and the EXECUTE co-sign material
+   * (signerMask hex + sigG2) — "0x"/"0x" unless a slash actually executed.
    *
    * TODO(inc-2 live): the real multi-node gossip BLS aggregation behind coSigner — collect peer
    * signatures over the messageHash, build the signerMask bitmap by SP-assigned validator slot,
@@ -674,34 +753,43 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     proposalId: bigint | null;
     queueTx: string | null;
     executeTx: string | null;
+    queueMessageHash: string | null;
+    signerMask: string;
+    sigG2: string;
   }> {
     const { operator, slashLevel, reason, epoch, evidenceHash } = args;
+    const armed = this.executeSlash;
     let queueTx: string | null = null;
     let proposalTx: string | null = null;
     let proposalId: bigint | null = null;
     let executeTx: string | null = null;
+    let queueMessageHash: string | null = null;
+    let signerMask = "0x";
+    let sigG2 = "0x";
 
-    // ── Step 1: QUEUE (quorum co-signed) ──────────────────────────────────────────
-    try {
-      const queueMsgHash = buildQueueMessageHash(operator, slashLevel, epoch, this.chainId);
-      const { signerMask, sigG2 } = await this.coSigner.coSign(queueMsgHash);
-      const proof = encodeProof(signerMask, sigG2);
-      queueTx = await this.blockchainService.queueSlashWithProof(
-        this.dvtValidatorAddress,
-        operator,
-        slashLevel,
-        epoch,
-        proof
-      );
-      this.logger.warn(`Audit: ${operator} slash QUEUED (tx ${queueTx})`);
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      this.logger.error(
-        `Audit: ${operator} slash queue step failed — ${msg} (evidence archived; slash not queued)`
-      );
+    // ── Step 1: QUEUE (ARMED only, quorum co-signed) ──────────────────────────────
+    if (armed) {
+      try {
+        queueMessageHash = buildQueueMessageHash(operator, slashLevel, epoch, this.chainId);
+        const cosign = await this.coSigner.coSign(queueMessageHash);
+        const proof = encodeProof(cosign.signerMask, cosign.sigG2);
+        queueTx = await this.blockchainService.queueSlashWithProof(
+          this.dvtValidatorAddress,
+          operator,
+          slashLevel,
+          epoch,
+          proof
+        );
+        this.logger.warn(`Audit: ${operator} slash QUEUED (tx ${queueTx})`);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.logger.error(
+          `Audit: ${operator} slash queue step failed — ${msg} (evidence archived; slash not queued)`
+        );
+      }
     }
 
-    // ── Step 2: file the proposal (binds evidenceHash=proofHash) ───────────────────
+    // ── Step 2: file the proposal (ALWAYS — binds evidenceHash=proofHash) ──────────
     try {
       const res = await this.blockchainService.createProposalWithEvidence(
         this.dvtValidatorAddress,
@@ -717,43 +805,48 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       this.logger.error(`Audit: ${operator} createProposal failed — ${msg}`);
     }
 
-    // ── Step 3: EXECUTE (quorum co-signed) — only with a REAL proposal id ───────────
-    if (proposalId === null) {
-      this.logger.error(
-        `Audit: ${operator} slash execute SKIPPED — no real proposalId ` +
-          `(createProposal failed or ProposalCreated absent); a fabricated id would revert`
-      );
-      return { proposalTx, proposalId, queueTx, executeTx };
+    // ── Step 3: EXECUTE (ARMED only, quorum co-signed) — only with a REAL proposal id ──
+    if (armed) {
+      if (proposalId === null) {
+        this.logger.error(
+          `Audit: ${operator} slash execute SKIPPED — no real proposalId ` +
+            `(createProposal failed or ProposalCreated absent); a fabricated id would revert`
+        );
+      } else {
+        try {
+          const execMsgHash = buildExecuteMessageHash(
+            proposalId,
+            operator,
+            slashLevel,
+            epoch,
+            this.chainId,
+            evidenceHash
+          );
+          const cosign = await this.coSigner.coSign(execMsgHash);
+          const proof = encodeProof(cosign.signerMask, cosign.sigG2);
+          executeTx = await this.blockchainService.executeSlashWithProof(
+            this.dvtValidatorAddress,
+            proposalId,
+            [], // slash-only ⇒ no reputation users
+            [], // slash-only ⇒ no reputation scores
+            epoch,
+            proof
+          );
+          // Record the EXECUTE co-sign material so the archived proof references the real slash.
+          signerMask = ethers.toBeHex(cosign.signerMask);
+          sigG2 = cosign.sigG2;
+          this.logger.warn(
+            `Audit: ${operator} slash EXECUTED (proposal ${proposalId}, tx ${executeTx})`
+          );
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err);
+          this.logger.error(
+            `Audit: ${operator} slash execute step failed — ${msg} (evidence archived; slash not executed)`
+          );
+        }
+      }
     }
-    try {
-      const execMsgHash = buildExecuteMessageHash(
-        proposalId,
-        operator,
-        slashLevel,
-        epoch,
-        this.chainId,
-        evidenceHash
-      );
-      const { signerMask, sigG2 } = await this.coSigner.coSign(execMsgHash);
-      const proof = encodeProof(signerMask, sigG2);
-      executeTx = await this.blockchainService.executeSlashWithProof(
-        this.dvtValidatorAddress,
-        proposalId,
-        [], // slash-only ⇒ no reputation users
-        [], // slash-only ⇒ no reputation scores
-        epoch,
-        proof
-      );
-      this.logger.warn(
-        `Audit: ${operator} slash EXECUTED (proposal ${proposalId}, tx ${executeTx})`
-      );
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      this.logger.error(
-        `Audit: ${operator} slash execute step failed — ${msg} (evidence archived; slash not executed)`
-      );
-    }
-    return { proposalTx, proposalId, queueTx, executeTx };
+    return { proposalTx, proposalId, queueTx, executeTx, queueMessageHash, signerMask, sigG2 };
   }
 
   /** Read-only status for GET /audit/status. No secrets. */

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -90,6 +90,10 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
    * when both auditEnabled AND this are true — so nothing is auto-slashed until explicitly enabled.
    */
   private readonly executeSlash: boolean;
+  /** Confirmation depth for the finalized-block fallback (finding-3, reorg-safe evidence). */
+  private readonly finalityConfirmations: number;
+  /** How far back to scan on-chain slash-executed events for the durable guard (finding-2). */
+  private readonly slashLookbackBlocks: number;
   private readonly archive: IProofArchive;
   /** Quorum co-sign seam — default PendingSlotCoSigner (fails closed until SP assigns BLS slots). */
   private readonly coSigner: IQuorumCoSigner;
@@ -173,6 +177,8 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     this.gtokenStakingAddress = config.get<string>("auditGtokenStakingAddress") ?? "";
     this.apntsTokenAddress = config.get<string>("auditApntsTokenAddress") ?? "";
     this.executeSlash = config.get<boolean>("auditExecuteSlash") === true;
+    this.finalityConfirmations = config.get<number>("auditFinalityConfirmations") ?? 12;
+    this.slashLookbackBlocks = config.get<number>("auditSlashLookbackBlocks") ?? 50_000;
     this.clock = clock ?? (() => Date.now());
     this.random = random ?? (() => Math.random());
     this.archive =
@@ -300,8 +306,10 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
   }
 
   /**
-   * Record that an on-chain slash EXECUTED for this operator+rule so the armed execute path does
-   * not re-slash the same ongoing condition on later ticks. Bounded by a defensive LRU-style cap.
+   * Record (in-memory only) that an on-chain slash EXECUTED for this operator+rule so the armed
+   * execute path does not re-slash the same ongoing condition on later ticks. Bounded by a
+   * defensive LRU-style cap. Durability across restart is handled separately via the archive
+   * journal (recordCoarseSlashed / archive.recordSlashed).
    */
   private markCoarseSlashed(coarseKey: string): void {
     this.slashedCoarseKeys.add(coarseKey);
@@ -312,11 +320,35 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
   }
 
   /**
-   * Clear the coarse over-slash guard once the operator is observed HEALTHY for a rule — the
-   * violation has resolved, so a genuinely new future violation is allowed to slash again.
+   * Record an executed slash in BOTH the in-memory guard and the DURABLE archive journal
+   * (finding-2), so an in-process restart reloads the marker and does not re-slash the same
+   * sustained condition. The archive write is best-effort: a journal IO failure must not abort
+   * the audit (the on-chain slash already happened; the in-memory guard still holds this run).
    */
-  private clearCoarseSlashed(operator: string, rule: string): void {
-    this.slashedCoarseKeys.delete(this.coarseKey(operator, rule));
+  private async recordCoarseSlashed(coarseKey: string): Promise<void> {
+    this.markCoarseSlashed(coarseKey);
+    try {
+      await this.archive.recordSlashed(coarseKey);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(`Audit: failed to persist durable slashed marker ${coarseKey} — ${msg}`);
+    }
+  }
+
+  /**
+   * Clear the coarse over-slash guard (in-memory AND durable journal) once the operator is
+   * observed HEALTHY for a rule — the violation has resolved, so a genuinely new future violation
+   * is allowed to slash again. The durable removal is best-effort (a healthy read is not itself
+   * safety-critical; the on-chain slash-executed scan remains as the conservative backstop).
+   */
+  private async clearCoarseSlashed(operator: string, rule: string): Promise<void> {
+    const coarseKey = this.coarseKey(operator, rule);
+    this.slashedCoarseKeys.delete(coarseKey);
+    try {
+      await this.archive.removeSlashed(coarseKey);
+    } catch {
+      // best-effort — a stale durable marker is re-checked against the chain scan anyway.
+    }
   }
 
   /**
@@ -368,9 +400,12 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
    * credit-over-limit rule. On a confirmed violation, archive a proof and file a proposal.
    */
   async auditOperator(operator: string): Promise<void> {
-    // Pin EVERY rule input to ONE block so creditLimit, availableCredit and debt can never
-    // be mixed across blocks (no phantom over-limit from a mid-read state change).
-    const violationBlock = await this.blockchainService.getBlockNumber();
+    // Pin EVERY rule input to ONE FINALIZED block (finding-3) so creditLimit, availableCredit and
+    // debt can never be mixed across blocks (no phantom over-limit from a mid-read state change)
+    // AND the block the irreversible slash is justified by cannot be undone by a reorg. The block
+    // HASH is recorded in the evidence so the justification is pinned to a specific finalized block.
+    const { number: violationBlock, hash: violationBlockHash } =
+      await this.blockchainService.getViolationBlock(this.finalityConfirmations);
 
     // All per-operator reads are pinned to the SAME block; issue them concurrently (5-6 reads)
     // rather than serially. reputation + DVT stake lock are auxiliary evidence (not part of the
@@ -413,7 +448,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       this.logger.debug(
         `Audit: ${operator} creditLimit=0 (unconfigured/de-registered) — SKIP (fail-safe, not over-limit)`
       );
-      this.clearCoarseSlashed(operator, RULE_CREDIT_OVER_LIMIT);
+      await this.clearCoarseSlashed(operator, RULE_CREDIT_OVER_LIMIT);
       return;
     }
     // CROSS-CONTRACT AGREEMENT: both SuperPaymaster signals must agree before flagging. If
@@ -424,7 +459,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       this.logger.debug(
         `Audit: ${operator} availableCredit=${availableCredit}>0 (within SP ceiling) — SKIP (no false over-limit)`
       );
-      this.clearCoarseSlashed(operator, RULE_CREDIT_OVER_LIMIT);
+      await this.clearCoarseSlashed(operator, RULE_CREDIT_OVER_LIMIT);
       return;
     }
 
@@ -439,14 +474,14 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       this.logger.debug(
         `Audit: ${operator} not over limit (debt=${debt} ≤ limit=${creditLimit}, usage=${usageBps}bps)`
       );
-      this.clearCoarseSlashed(operator, RULE_CREDIT_OVER_LIMIT);
+      await this.clearCoarseSlashed(operator, RULE_CREDIT_OVER_LIMIT);
       return;
     }
     if (usageBps < this.creditThresholdBps) {
       this.logger.debug(
         `Audit: ${operator} over limit but under margin (usage=${usageBps}bps < ${this.creditThresholdBps}bps)`
       );
-      this.clearCoarseSlashed(operator, RULE_CREDIT_OVER_LIMIT);
+      await this.clearCoarseSlashed(operator, RULE_CREDIT_OVER_LIMIT);
       return;
     }
 
@@ -480,6 +515,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       creditLimit,
       debt,
       violationBlock,
+      violationBlockHash,
       sources,
       observedAt,
     });
@@ -508,6 +544,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     creditLimit: bigint;
     debt: bigint;
     violationBlock: number;
+    violationBlockHash: string;
     sources: EvidenceSource[];
     observedAt: number;
   }): Promise<AuditDetection | null> {
@@ -561,6 +598,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
         threshold: v.creditLimit.toString(),
         sources: v.sources,
         violationBlock: v.violationBlock,
+        violationBlockHash: v.violationBlockHash,
         observedAt: v.observedAt,
       },
       proposalId: null,
@@ -599,7 +637,10 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
           `${this.cooldownMs}ms) — attempt suppressed, archiving evidence only`
       );
       proposalIdNote = "id-unresolved: proposal attempt suppressed by cooldown";
-    } else if (this.executeSlash && (await this.isCoarseAlreadySlashed(coarseKey, v.operator))) {
+    } else if (
+      this.executeSlash &&
+      (await this.isCoarseAlreadySlashed(coarseKey, v.operator, v.violationBlock))
+    ) {
       // ARMED path OVER-SLASH GUARD (finding-4/5): a slash already executed (in-memory) or is
       // pending on-chain for this operator+rule → do NOT queue/execute the same ongoing condition
       // again, even after cooldownMs with an advancing block. Evidence is still archived (above).
@@ -615,21 +656,29 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       // file-only (create only) paths go through coordinateQuorumCoSign — one createProposalWith-
       // Evidence call site. Every step catches its own failure so the evidence stays archived and
       // the poll loop never crashes.
-      const res = await this.coordinateQuorumCoSign({
-        operator: v.operator,
-        slashLevel: v.slashLevel,
-        reason: v.reason,
-        epoch,
-        evidenceHash: proofHash,
-      });
+      // Pass the in-flight `proof` so coordinateQuorumCoSign RE-ARCHIVES it after each CONFIRMED
+      // on-chain step (finding-4): a crash between a confirmed queue/execute tx and the final
+      // archive below can no longer lose that tx record — durable state always reflects what was
+      // actually submitted.
+      const res = await this.coordinateQuorumCoSign(
+        {
+          operator: v.operator,
+          slashLevel: v.slashLevel,
+          reason: v.reason,
+          epoch,
+          evidenceHash: proofHash,
+        },
+        proof
+      );
       proposalTx = res.proposalTx;
       onchainProposalId = res.proposalId;
       queueTx = res.queueTx;
       executeTx = res.executeTx;
       if (res.queueMessageHash) proof.queueMessageHash = res.queueMessageHash;
       if (executeTx !== null) {
-        // A slash actually executed → arm the over-slash guard + record the real co-sign material.
-        this.markCoarseSlashed(coarseKey);
+        // A slash actually executed → arm the DURABLE over-slash guard (in-memory + archive journal,
+        // finding-2) so a restart does not re-slash, and record the real co-sign material.
+        await this.recordCoarseSlashed(coarseKey);
         proof.signerMask = res.signerMask;
         proof.sigG2 = res.sigG2;
       }
@@ -641,13 +690,16 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       }
     }
 
-    // ── FINAL proof.messageHash = the 8-field EXECUTE preimage actually signed + submitted ──────
+    // ── FINAL proof.messageHash = the 8-field EXECUTE preimage actually SUBMITTED ────────────────
     // (finding-1) buildExecuteMessageHash(proposalId, operator, slashLevel, epoch, chainId,
     // evidenceHash=proofHash) — the SAME message the quorum co-signs and executeWithProof carries.
-    // When the id is unresolved there is no on-chain proposal to sign over → "0x" + a clear note.
+    // (finding-5) messageHash is set ONLY when the execute tx actually landed. When the proposal id
+    // resolved but NO execute was submitted (file-only path, or execute skipped/failed), the
+    // computed-but-unsubmitted preimage is kept under intendedExecuteMessageHash — never conflated
+    // with a submitted one. When the id is unresolved there is no preimage to compute at all → "0x".
     const proposalId: string | null = onchainProposalId !== null ? onchainProposalId.toString() : null;
     if (onchainProposalId !== null) {
-      proof.messageHash = buildExecuteMessageHash(
+      const executePreimage = buildExecuteMessageHash(
         onchainProposalId,
         v.operator,
         v.slashLevel,
@@ -655,7 +707,20 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
         this.chainId,
         proofHash
       );
-      delete proof.messageHashNote;
+      if (executeTx !== null) {
+        // The execute actually ran: this IS the submitted preimage.
+        proof.messageHash = executePreimage;
+        delete proof.messageHashNote;
+        delete proof.intendedExecuteMessageHash;
+      } else {
+        // Proposal filed but nothing executed (file-only, or execute skipped/failed): the preimage
+        // is only an INTENT, kept out of messageHash so the record is unambiguous (finding-5).
+        proof.messageHash = "0x";
+        proof.intendedExecuteMessageHash = executePreimage;
+        proof.messageHashNote =
+          proposalIdNote ??
+          "intent-only: execute preimage computed but NOT submitted (see intendedExecuteMessageHash)";
+      }
     } else {
       proof.messageHash = "0x";
       proof.messageHashNote = proposalIdNote ?? "id-unresolved: no on-chain proposal to sign over";
@@ -697,14 +762,54 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
   }
 
   /**
-   * Is a slash already in effect for this operator+rule? Checks the in-memory coarse guard first
-   * (fast, within-process), then a best-effort on-chain pending-slash read (the durable, restart-
-   * surviving signal). On the current SP the getter is absent so isSlashPending returns null →
-   * unknown → falls back to the in-memory guard. A true on-chain flag is cached into the in-memory
-   * guard so subsequent ticks short-circuit without another RPC.
+   * Is a slash already in effect for this operator+rule? Layered guards, cheapest → most durable:
+   *
+   *   1. IN-MEMORY coarse guard (fast, within-process).
+   *   2. DURABLE archive journal (finding-2) — an executed-slash marker persisted to disk, so an
+   *      in-process RESTART reloads it and does not re-slash a still-sustained violation. Cached
+   *      back into the in-memory guard on a hit.
+   *   3. ON-CHAIN slash-executed EVENTS (finding-2) — SlashExecutedWithProof / SlashExecuted within
+   *      a recent block window on the BLSAggregator and SuperPaymaster. An emitted event is a
+   *      permanent on-chain fact, so this is the authoritative, restart-surviving guard even if the
+   *      local journal was lost. A hit is persisted to BOTH the durable journal and the memory guard.
+   *   4. Best-effort on-chain PENDING flag (isSlashPending) — null ("unknown") on the current SP
+   *      (private `_pendingSlash`), so it only helps a future deployment that exposes a getter.
+   *
+   * `violationBlock` bounds the event scan window (`violationBlock - slashLookbackBlocks`). Every
+   * remote read is best-effort: an error is swallowed and treated as "no signal", never "not slashed".
    */
-  private async isCoarseAlreadySlashed(coarseKey: string, operator: string): Promise<boolean> {
+  private async isCoarseAlreadySlashed(
+    coarseKey: string,
+    operator: string,
+    violationBlock: number
+  ): Promise<boolean> {
     if (this.slashedCoarseKeys.has(coarseKey)) return true;
+
+    // (2) DURABLE journal — survives a restart within the same process/disk.
+    try {
+      if (await this.archive.hasSlashed(coarseKey)) {
+        this.markCoarseSlashed(coarseKey); // cache in-memory (do not re-write the marker)
+        return true;
+      }
+    } catch {
+      // best-effort: journal read error → fall through to the on-chain scan.
+    }
+
+    // (3) ON-CHAIN slash-executed events — the authoritative cross-restart guard.
+    try {
+      const fromBlock = Math.max(0, violationBlock - this.slashLookbackBlocks);
+      const scanTargets = [this.blsAggregatorAddress, this.superPaymasterAddress].filter(Boolean);
+      for (const target of scanTargets) {
+        if (await this.blockchainService.getRecentSlashExecuted(target, operator, fromBlock)) {
+          await this.recordCoarseSlashed(coarseKey); // persist durable + memory
+          return true;
+        }
+      }
+    } catch {
+      // best-effort: RPC/range error → fall through to the pending flag.
+    }
+
+    // (4) Best-effort on-chain pending flag (null/unknown on the current SP).
     try {
       const pending = await this.blockchainService.isSlashPending(this.superPaymasterAddress, operator);
       if (pending === true) {
@@ -712,7 +817,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
         return true;
       }
     } catch {
-      // best-effort: getter absent / RPC error → unknown, rely on the in-memory guard only.
+      // best-effort: getter absent / RPC error → unknown, rely on the guards above.
     }
     return false;
   }
@@ -726,13 +831,19 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
    *                 binding the on-chain slash to the archived evidence. ALWAYS runs.
    *   3. EXECUTE  — (ARMED only) co-sign the 8-field execute preimage (bound to that real id +
    *                 evidenceHash) → executeWithProof (slash-only ⇒ repUsers/newScores empty).
-   *                 Skipped when the proposal id is unresolved (a fabricated id would revert).
+   *                 STRICTLY contingent on the TWO-STEP SAFETY (finding-1): it runs ONLY when the
+   *                 queue step CONFIRMED (queueTx !== null) AND the proposal id resolved. If the
+   *                 queue co-sign/tx failed, the whole slash aborts to file+archive only — a slash
+   *                 must never execute without its confirmed queue pre-flag.
    *
    * When executeSlash is OFF (default) only step 2 runs — the file-only path: proposal filed +
    * evidence bound, nothing queued or slashed. Each step is wrapped: a co-sign or tx failure is
    * logged and swallowed so the caller still archives the evidence (evidence never lost) and the
    * poll loop never crashes. With the default PendingSlotCoSigner every co-sign throws (SP
    * validator slots pending the 24h timelock), so the armed path reduces to just the proposal.
+   *
+   * When `proof` is passed, it is RE-ARCHIVED after each CONFIRMED on-chain step (finding-4) so a
+   * crash between a confirmed tx and the caller's final archive cannot lose that tx record.
    *
    * Returns the queue/proposal/execute tx hashes, the real proposalId, the queueMessageHash (armed
    * path, so the caller can archive the co-signed queue preimage), and the EXECUTE co-sign material
@@ -742,13 +853,16 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
    * signatures over the messageHash, build the signerMask bitmap by SP-assigned validator slot,
    * aggregate into sigG2 — lands once SP hands out slots via registerBLSPublicKey.
    */
-  async coordinateQuorumCoSign(args: {
-    operator: string;
-    slashLevel: number;
-    reason: string;
-    epoch: number;
-    evidenceHash: string;
-  }): Promise<{
+  async coordinateQuorumCoSign(
+    args: {
+      operator: string;
+      slashLevel: number;
+      reason: string;
+      epoch: number;
+      evidenceHash: string;
+    },
+    proof?: SlashProof
+  ): Promise<{
     proposalTx: string | null;
     proposalId: bigint | null;
     queueTx: string | null;
@@ -767,20 +881,39 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     let signerMask = "0x";
     let sigG2 = "0x";
 
+    // Re-archive the in-flight proof after a CONFIRMED on-chain step (finding-4). Best-effort: a
+    // journal IO error must not abort the orchestration (the on-chain tx already happened, and the
+    // caller re-archives once more at the end). Idempotent on proofHash.
+    const persistStep = async (): Promise<void> => {
+      if (!proof) return;
+      try {
+        await this.archive.put(proof);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.logger.error(`Audit: ${operator} per-step re-archive failed — ${msg}`);
+      }
+    };
+
     // ── Step 1: QUEUE (ARMED only, quorum co-signed) ──────────────────────────────
     if (armed) {
       try {
         queueMessageHash = buildQueueMessageHash(operator, slashLevel, epoch, this.chainId);
         const cosign = await this.coSigner.coSign(queueMessageHash);
-        const proof = encodeProof(cosign.signerMask, cosign.sigG2);
+        const encoded = encodeProof(cosign.signerMask, cosign.sigG2);
         queueTx = await this.blockchainService.queueSlashWithProof(
           this.dvtValidatorAddress,
           operator,
           slashLevel,
           epoch,
-          proof
+          encoded
         );
         this.logger.warn(`Audit: ${operator} slash QUEUED (tx ${queueTx})`);
+        // Durable BEFORE execute: the confirmed queueTx is persisted now (finding-4).
+        if (proof) {
+          proof.queueTx = queueTx;
+          proof.queueMessageHash = queueMessageHash;
+          await persistStep();
+        }
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
         this.logger.error(
@@ -805,9 +938,16 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       this.logger.error(`Audit: ${operator} createProposal failed — ${msg}`);
     }
 
-    // ── Step 3: EXECUTE (ARMED only, quorum co-signed) — only with a REAL proposal id ──
+    // ── Step 3: EXECUTE (ARMED only) — TWO-STEP SAFETY: confirmed queue + real id required ──
     if (armed) {
-      if (proposalId === null) {
+      if (queueTx === null) {
+        // finding-1: never execute a slash whose queue pre-flag did not confirm. Abort to
+        // file+archive only — the evidence + proposal remain, but no irreversible slash fires.
+        this.logger.error(
+          `Audit: ${operator} slash execute SKIPPED — queue step did not confirm (queueTx null); ` +
+            `two-step safety requires a confirmed queueSlashWithProof before executeWithProof`
+        );
+      } else if (proposalId === null) {
         this.logger.error(
           `Audit: ${operator} slash execute SKIPPED — no real proposalId ` +
             `(createProposal failed or ProposalCreated absent); a fabricated id would revert`
@@ -823,14 +963,14 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
             evidenceHash
           );
           const cosign = await this.coSigner.coSign(execMsgHash);
-          const proof = encodeProof(cosign.signerMask, cosign.sigG2);
+          const encoded = encodeProof(cosign.signerMask, cosign.sigG2);
           executeTx = await this.blockchainService.executeSlashWithProof(
             this.dvtValidatorAddress,
             proposalId,
             [], // slash-only ⇒ no reputation users
             [], // slash-only ⇒ no reputation scores
             epoch,
-            proof
+            encoded
           );
           // Record the EXECUTE co-sign material so the archived proof references the real slash.
           signerMask = ethers.toBeHex(cosign.signerMask);
@@ -838,6 +978,13 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
           this.logger.warn(
             `Audit: ${operator} slash EXECUTED (proposal ${proposalId}, tx ${executeTx})`
           );
+          // Durable immediately after the irreversible slash confirms (finding-4).
+          if (proof) {
+            proof.executeTx = executeTx;
+            proof.signerMask = signerMask;
+            proof.sigG2 = sigG2;
+            await persistStep();
+          }
         } catch (err: unknown) {
           const msg = err instanceof Error ? err.message : String(err);
           this.logger.error(

--- a/src/modules/audit/proof-archive.ts
+++ b/src/modules/audit/proof-archive.ts
@@ -38,10 +38,20 @@ export interface Evidence {
   /** Each raw source reading that supports the detection. */
   sources: EvidenceSource[];
   /**
-   * Block number ALL rule inputs were pinned to (from one provider.getBlockNumber()).
-   * Part of the content-address identity — two nodes reading the same block agree.
+   * Block number ALL rule inputs were pinned to (a FINALIZED/safe block, from
+   * blockchain.getViolationBlock()). Part of the content-address identity — two nodes
+   * reading the same block agree.
    */
   violationBlock: number;
+  /**
+   * Block HASH of `violationBlock` (finding-3). Pinning the irreversible slash to a
+   * finalized block's hash — not just its number — makes the evidence reorg-safe: a
+   * reorg that rewrites `violationBlock` would change this hash, so the justification
+   * cannot be silently invalidated. Deliberately EXCLUDED from the content-address
+   * identity (a finalized block's hash is a deterministic function of its number, and
+   * two nodes reading the same finalized number already agree on the hash).
+   */
+  violationBlockHash?: string;
   /**
    * Unix ms when the observation was made. Kept for humans ONLY — deliberately
    * EXCLUDED from the content-address identity so wall-clock never perturbs proofHash.
@@ -73,13 +83,24 @@ export interface SlashProof {
   epoch: number;
   /**
    * The 8-field EXECUTE preimage the quorum co-signs before executeWithProof — the SAME message
-   * actually submitted on-chain: buildExecuteMessageHash(proposalId, operator, slashLevel, epoch,
-   * chainId, evidenceHash=proofHash). "0x" (with a `messageHashNote`) when the real proposalId is
-   * unresolved (proposal not filed / event absent) — never a stale or wrong preimage.
+   * actually SUBMITTED on-chain: buildExecuteMessageHash(proposalId, operator, slashLevel, epoch,
+   * chainId, evidenceHash=proofHash). Set ONLY when the execute tx actually landed (`executeTx`
+   * present, finding-5). "0x" (with a `messageHashNote`) when nothing was submitted — i.e. the
+   * file-only path (executeSlash off), a skipped/failed execute, or an unresolved proposalId. In
+   * the file-only-but-proposal-resolved case the computed-but-not-submitted preimage is kept under
+   * `intendedExecuteMessageHash` so the record stays unambiguous about what was vs wasn't sent.
    */
   messageHash: string;
-  /** Present only when `messageHash` is "0x": why the execute preimage could not be computed. */
+  /** Present only when `messageHash` is "0x": why the execute preimage was not the submitted one. */
   messageHashNote?: string;
+  /**
+   * The 8-field EXECUTE preimage that WOULD be co-signed + submitted, computed once the real
+   * proposalId is known but NO execute tx was sent (file-only path, or execute skipped/failed).
+   * Kept distinct from `messageHash` (finding-5) so a reader never mistakes an intended preimage
+   * for one that was actually submitted. Undefined when the execute was submitted (then it lives in
+   * `messageHash`) or when the proposalId is unresolved (no preimage can be computed at all).
+   */
+  intendedExecuteMessageHash?: string;
   /**
    * The 5-field QUEUE preimage co-signed before queueSlashWithProof — buildQueueMessageHash(
    * operator, slashLevel, epoch, chainId). Present only on the armed (executeSlash) path where the
@@ -171,11 +192,31 @@ export interface IProofArchive {
   put(proof: SlashProof): Promise<{ proofHash: string; location: string }>;
   has(proofHash: string): Promise<boolean>;
   count(): Promise<number>;
+  /**
+   * DURABLE executed-slash journal (finding-2). `recordSlashed` persists a coarse
+   * `chainId|operator|rule` marker after a slash EXECUTES so a process restart reloads it and
+   * does NOT re-slash the same sustained condition; `hasSlashed` reads it back; `removeSlashed`
+   * clears it once the operator is observed healthy (condition resolved → a genuinely new
+   * violation may slash again). Content-free markers, addressed by the coarse key only.
+   */
+  recordSlashed(coarseKey: string): Promise<void>;
+  hasSlashed(coarseKey: string): Promise<boolean>;
+  removeSlashed(coarseKey: string): Promise<void>;
 }
 
 /** Filesystem-backed archive: one `<proofHash>.json` per detection under `dir`. */
 export class LocalProofArchive implements IProofArchive {
   constructor(private readonly dir: string) {}
+
+  /** Sub-directory holding the durable executed-slash markers (kept out of the proof set). */
+  private slashedDir(): string {
+    return path.join(this.dir, "slashed");
+  }
+
+  /** Filesystem-safe marker filename for a coarse key (encoded so `|`/case survive verbatim). */
+  private slashedFile(coarseKey: string): string {
+    return path.join(this.slashedDir(), `${encodeURIComponent(coarseKey)}.slashed`);
+  }
 
   async put(proof: SlashProof): Promise<{ proofHash: string; location: string }> {
     await fs.mkdir(this.dir, { recursive: true });
@@ -196,10 +237,34 @@ export class LocalProofArchive implements IProofArchive {
   async count(): Promise<number> {
     try {
       const entries = await fs.readdir(this.dir);
+      // Only `<proofHash>.json` proof files count — the `slashed/` marker dir is excluded.
       return entries.filter(e => e.endsWith(".json")).length;
     } catch {
       // Directory not created yet → nothing archived.
       return 0;
+    }
+  }
+
+  async recordSlashed(coarseKey: string): Promise<void> {
+    await fs.mkdir(this.slashedDir(), { recursive: true });
+    // The marker's existence is the signal; its content is the raw key for human inspection.
+    await fs.writeFile(this.slashedFile(coarseKey), coarseKey, "utf8");
+  }
+
+  async hasSlashed(coarseKey: string): Promise<boolean> {
+    try {
+      await fs.access(this.slashedFile(coarseKey));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async removeSlashed(coarseKey: string): Promise<void> {
+    try {
+      await fs.rm(this.slashedFile(coarseKey));
+    } catch {
+      // Already absent (never slashed, or cleared before) → nothing to do.
     }
   }
 }
@@ -218,6 +283,18 @@ export class IpfsProofArchive implements IProofArchive {
   }
 
   async count(): Promise<number> {
+    throw new Error("IpfsProofArchive not implemented — increment 3");
+  }
+
+  async recordSlashed(): Promise<void> {
+    throw new Error("IpfsProofArchive not implemented — increment 3");
+  }
+
+  async hasSlashed(): Promise<boolean> {
+    throw new Error("IpfsProofArchive not implemented — increment 3");
+  }
+
+  async removeSlashed(): Promise<void> {
     throw new Error("IpfsProofArchive not implemented — increment 3");
   }
 }

--- a/src/modules/audit/proof-archive.ts
+++ b/src/modules/audit/proof-archive.ts
@@ -64,12 +64,31 @@ export interface SlashProof {
   operator: string;
   slashLevel: number;
   reason: string;
+  /**
+   * DETERMINISTIC slash epoch — the violationBlock (an on-chain fact), NOT a wall-clock value.
+   * Bound into BOTH co-sign preimages (queue + execute) and passed as the on-chain epoch arg, so
+   * two DVT nodes observing the SAME violation derive the SAME epoch → the SAME messageHash → the
+   * gossip BLS aggregate verifies. (observedAt stays the only wall-clock field, under `evidence`.)
+   */
   epoch: number;
-  /** BLS message the quorum signs over the proposal. */
+  /**
+   * The 8-field EXECUTE preimage the quorum co-signs before executeWithProof — the SAME message
+   * actually submitted on-chain: buildExecuteMessageHash(proposalId, operator, slashLevel, epoch,
+   * chainId, evidenceHash=proofHash). "0x" (with a `messageHashNote`) when the real proposalId is
+   * unresolved (proposal not filed / event absent) — never a stale or wrong preimage.
+   */
   messageHash: string;
-  /** Bitmask of co-signers — empty until increment 2. */
+  /** Present only when `messageHash` is "0x": why the execute preimage could not be computed. */
+  messageHashNote?: string;
+  /**
+   * The 5-field QUEUE preimage co-signed before queueSlashWithProof — buildQueueMessageHash(
+   * operator, slashLevel, epoch, chainId). Present only on the armed (executeSlash) path where the
+   * queue step actually runs; undefined on the file-only proposal path.
+   */
+  queueMessageHash?: string;
+  /** Bitmask of co-signers (hex) — "0x" until a real quorum execute co-sign lands. */
   signerMask: string;
-  /** Aggregated G2 signature — empty until increment 2. */
+  /** Aggregated G2 signature — "0x" until a real quorum execute co-sign lands. */
   sigG2: string;
   /** Content address of this record (keccak256 over the immutable evidence core). */
   proofHash: string;
@@ -85,10 +104,20 @@ export interface SlashProof {
   createdAt: number;
   /**
    * Tx hash of the createProposal SUBMISSION (proposal-intent), when filed. This is the
-   * proposal tx, NOT the slash execution — execution (BLSAggregator.verifyAndExecute) is
-   * the deferred increment-2 step. Undefined when no proposal was filed.
+   * proposal tx, NOT the slash execution. Undefined when no proposal was filed.
    */
   proposalTx?: string;
+  /**
+   * Tx hash of the STEP-1 queueSlashWithProof submission (armed executeSlash path only). The
+   * on-chain slash-intent pre-flag. Undefined when the queue step did not run / failed.
+   */
+  queueTx?: string;
+  /**
+   * Tx hash of the STEP-2 executeWithProof submission — the irreversible on-chain slash. Present
+   * only on the armed path after a successful quorum co-sign + execute. Undefined otherwise. This
+   * is what durably references the evidence to the executed slash (finding-2).
+   */
+  executeTx?: string;
 }
 
 /**

--- a/src/modules/audit/slash-consensus.spec.ts
+++ b/src/modules/audit/slash-consensus.spec.ts
@@ -1,0 +1,92 @@
+import { ethers } from "ethers";
+import {
+  SlashLevel,
+  QUEUE_SLASH_TAG,
+  PendingSlotCoSigner,
+  buildQueueMessageHash,
+  buildExecuteMessageHash,
+  encodeProof,
+} from "./slash-consensus.js";
+
+const OPERATOR = ethers.getAddress("0x" + "12".repeat(20));
+const EVIDENCE_HASH = "0x" + "cd".repeat(32);
+const CHAIN_ID = 11155111;
+
+describe("slash-consensus primitives (SP #329)", () => {
+  it("QUEUE_SLASH_TAG is keccak256 of the UTF-8 literal, matching Solidity keccak256(\"QUEUE_SLASH\")", () => {
+    expect(QUEUE_SLASH_TAG).toBe(ethers.keccak256(ethers.toUtf8Bytes("QUEUE_SLASH")));
+  });
+
+  it("SlashLevel enum matches the on-chain values (WARNING=0, MINOR=1, MAJOR=2)", () => {
+    expect(SlashLevel.WARNING).toBe(0);
+    expect(SlashLevel.MINOR).toBe(1);
+    expect(SlashLevel.MAJOR).toBe(2);
+  });
+
+  it("buildQueueMessageHash byte-matches a hand-computed 5-field AbiCoder reference (with domain tag)", () => {
+    const epoch = 1_700_000;
+    const slashLevel = SlashLevel.MINOR;
+    const reference = ethers.keccak256(
+      new ethers.AbiCoder().encode(
+        ["bytes32", "address", "uint8", "uint256", "uint256"],
+        [
+          ethers.keccak256(ethers.toUtf8Bytes("QUEUE_SLASH")),
+          OPERATOR,
+          slashLevel,
+          epoch,
+          CHAIN_ID,
+        ]
+      )
+    );
+    expect(buildQueueMessageHash(OPERATOR, slashLevel, epoch, CHAIN_ID)).toBe(reference);
+    expect(reference).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+
+  it("buildExecuteMessageHash byte-matches a hand-computed 8-field reference (empty rep arrays + evidenceHash)", () => {
+    const proposalId = 42n;
+    const epoch = 1_700_000;
+    const slashLevel = SlashLevel.MINOR;
+    const reference = ethers.keccak256(
+      new ethers.AbiCoder().encode(
+        ["uint256", "address", "uint8", "address[]", "uint256[]", "uint256", "uint256", "bytes32"],
+        [proposalId, OPERATOR, slashLevel, [], [], epoch, CHAIN_ID, EVIDENCE_HASH]
+      )
+    );
+    expect(
+      buildExecuteMessageHash(proposalId, OPERATOR, slashLevel, epoch, CHAIN_ID, EVIDENCE_HASH)
+    ).toBe(reference);
+    expect(reference).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+
+  it("the queue and execute preimages are distinct (domain separation holds)", () => {
+    const epoch = 1_700_000;
+    const queue = buildQueueMessageHash(OPERATOR, SlashLevel.MINOR, epoch, CHAIN_ID);
+    const exec = buildExecuteMessageHash(1n, OPERATOR, SlashLevel.MINOR, epoch, CHAIN_ID, EVIDENCE_HASH);
+    expect(queue).not.toBe(exec);
+  });
+
+  it("buildExecuteMessageHash is sensitive to evidenceHash (evidence binding is real)", () => {
+    const a = buildExecuteMessageHash(1n, OPERATOR, 1, 5, CHAIN_ID, "0x" + "11".repeat(32));
+    const b = buildExecuteMessageHash(1n, OPERATOR, 1, 5, CHAIN_ID, "0x" + "22".repeat(32));
+    expect(a).not.toBe(b);
+  });
+
+  it("encodeProof produces abi.encode(uint256 signerMask, bytes sigG2) and round-trips", () => {
+    const signerMask = 0b101n;
+    const sigG2 = "0x" + "ab".repeat(64);
+    const encoded = encodeProof(signerMask, sigG2);
+    // Matches a direct AbiCoder reference.
+    expect(encoded).toBe(new ethers.AbiCoder().encode(["uint256", "bytes"], [signerMask, sigG2]));
+    // And decodes back to the same values.
+    const [mask, sig] = new ethers.AbiCoder().decode(["uint256", "bytes"], encoded);
+    expect(mask).toBe(signerMask);
+    expect(sig).toBe(sigG2);
+  });
+
+  it("PendingSlotCoSigner fails closed: coSign throws the deferred-slot error", async () => {
+    const coSigner = new PendingSlotCoSigner();
+    await expect(coSigner.coSign("0x" + "00".repeat(32))).rejects.toThrow(
+      /quorum co-sign deferred.*registerBLSPublicKey.*24h timelock/s
+    );
+  });
+});

--- a/src/modules/audit/slash-consensus.spec.ts
+++ b/src/modules/audit/slash-consensus.spec.ts
@@ -13,7 +13,7 @@ const EVIDENCE_HASH = "0x" + "cd".repeat(32);
 const CHAIN_ID = 11155111;
 
 describe("slash-consensus primitives (SP #329)", () => {
-  it("QUEUE_SLASH_TAG is keccak256 of the UTF-8 literal, matching Solidity keccak256(\"QUEUE_SLASH\")", () => {
+  it('QUEUE_SLASH_TAG is keccak256 of the UTF-8 literal, matching Solidity keccak256("QUEUE_SLASH")', () => {
     expect(QUEUE_SLASH_TAG).toBe(ethers.keccak256(ethers.toUtf8Bytes("QUEUE_SLASH")));
   });
 
@@ -29,13 +29,7 @@ describe("slash-consensus primitives (SP #329)", () => {
     const reference = ethers.keccak256(
       new ethers.AbiCoder().encode(
         ["bytes32", "address", "uint8", "uint256", "uint256"],
-        [
-          ethers.keccak256(ethers.toUtf8Bytes("QUEUE_SLASH")),
-          OPERATOR,
-          slashLevel,
-          epoch,
-          CHAIN_ID,
-        ]
+        [ethers.keccak256(ethers.toUtf8Bytes("QUEUE_SLASH")), OPERATOR, slashLevel, epoch, CHAIN_ID]
       )
     );
     expect(buildQueueMessageHash(OPERATOR, slashLevel, epoch, CHAIN_ID)).toBe(reference);
@@ -61,7 +55,14 @@ describe("slash-consensus primitives (SP #329)", () => {
   it("the queue and execute preimages are distinct (domain separation holds)", () => {
     const epoch = 1_700_000;
     const queue = buildQueueMessageHash(OPERATOR, SlashLevel.MINOR, epoch, CHAIN_ID);
-    const exec = buildExecuteMessageHash(1n, OPERATOR, SlashLevel.MINOR, epoch, CHAIN_ID, EVIDENCE_HASH);
+    const exec = buildExecuteMessageHash(
+      1n,
+      OPERATOR,
+      SlashLevel.MINOR,
+      epoch,
+      CHAIN_ID,
+      EVIDENCE_HASH
+    );
     expect(queue).not.toBe(exec);
   });
 

--- a/src/modules/audit/slash-consensus.ts
+++ b/src/modules/audit/slash-consensus.ts
@@ -1,0 +1,119 @@
+import { ethers } from "ethers";
+
+/**
+ * DVT Phase 2 (目标2) — slash-consensus primitives, increment 2.
+ *
+ * These are the PURE, side-effect-free building blocks the two-step slash orchestration
+ * (AuditService.coordinateQuorumCoSign) is composed from, plus the quorum co-sign seam.
+ * They are broken out here so the exact on-chain preimages can be unit-tested in isolation
+ * against a hand-computed ethers.AbiCoder reference — a byte mismatch here would make every
+ * DVTValidator write revert (BLS aggregate verification is over these exact hashes).
+ *
+ * Interface source of truth: SuperPaymaster #329 (finalized). The two slash steps are
+ * INDEPENDENT (each quorum co-signed once over its own preimage, each carrying its own proof):
+ *
+ *   Step 1 (queue):   DVTValidator.queueSlashWithProof(operator, slashLevel, epoch, proof)
+ *     messageHash = keccak256(abi.encode(
+ *       keccak256("QUEUE_SLASH"), operator, slashLevel, epoch, block.chainid))   // 5 fields
+ *
+ *   Step 2 (execute): DVTValidator.executeWithProof(id, repUsers, newScores, epoch, proof)
+ *     messageHash = keccak256(abi.encode(
+ *       proposalId, operator, slashLevel, repUsers[], newScores[],
+ *       epoch, block.chainid, evidenceHash))                                     // 8 fields
+ *     For a slash-only proposal repUsers and newScores are BOTH empty ([]).
+ *
+ *   proof (both steps): abi.encode(uint256 signerMask, bytes sigG2)
+ */
+
+const ABI = new ethers.AbiCoder();
+
+/**
+ * Domain-separation tag for the queue-slash preimage. keccak256("QUEUE_SLASH") — the UTF-8
+ * bytes of the literal, exactly matching the Solidity `keccak256("QUEUE_SLASH")`.
+ */
+export const QUEUE_SLASH_TAG = ethers.id("QUEUE_SLASH");
+
+/**
+ * On-chain slash severity enum (SP #329 SlashLevel). The audit's credit-over-limit rule maps
+ * to MINOR (see AuditService). WARNING is 2-of-3 quorum in the N=3 bootstrap; MINOR/MAJOR 3-of-3.
+ */
+export enum SlashLevel {
+  WARNING = 0,
+  MINOR = 1,
+  MAJOR = 2,
+}
+
+/**
+ * Step-1 queue preimage — keccak256 over the 5-field encoding with the QUEUE_SLASH domain tag.
+ * This is the message the DVT quorum co-signs before queueSlashWithProof.
+ */
+export function buildQueueMessageHash(
+  operator: string,
+  slashLevel: number,
+  epoch: bigint | number,
+  chainId: bigint | number
+): string {
+  return ethers.keccak256(
+    ABI.encode(
+      ["bytes32", "address", "uint8", "uint256", "uint256"],
+      [QUEUE_SLASH_TAG, operator, slashLevel, epoch, chainId]
+    )
+  );
+}
+
+/**
+ * Step-2 execute preimage — keccak256 over the 8-field encoding. repUsers/newScores are empty
+ * for a slash-only proposal; evidenceHash binds the on-chain slash to the archived proof
+ * (the audit passes proofHash here). This is the message the DVT quorum co-signs before
+ * executeWithProof.
+ */
+export function buildExecuteMessageHash(
+  proposalId: bigint | number,
+  operator: string,
+  slashLevel: number,
+  epoch: bigint | number,
+  chainId: bigint | number,
+  evidenceHash: string
+): string {
+  return ethers.keccak256(
+    ABI.encode(
+      ["uint256", "address", "uint8", "address[]", "uint256[]", "uint256", "uint256", "bytes32"],
+      [proposalId, operator, slashLevel, [], [], epoch, chainId, evidenceHash]
+    )
+  );
+}
+
+/** abi.encode(uint256 signerMask, bytes sigG2) — the wire proof both slash steps carry. */
+export function encodeProof(signerMask: bigint, sigG2: string): string {
+  return ABI.encode(["uint256", "bytes"], [signerMask, sigG2]);
+}
+
+/**
+ * The quorum co-sign seam. Given a messageHash, an implementation gathers enough peer BLS
+ * signatures to meet the slash-level threshold, aggregates them into a single G2 signature,
+ * and returns the aggregate together with the signerMask bitmap (bit i set ⇔ SP validator
+ * slot i contributed). AuditService injects this so the two-step orchestration is fully
+ * unit-testable now, ahead of the real gossip aggregator.
+ */
+export interface IQuorumCoSigner {
+  coSign(messageHash: string): Promise<{ signerMask: bigint; sigG2: string }>;
+}
+
+/**
+ * Default (deferred) co-signer. The real multi-node gossip BLS aggregation — collect peer
+ * signatures over the messageHash, build the signerMask by SP-assigned validator slot, and
+ * aggregate into sigG2 — needs SuperPaymaster to hand out slots via registerBLSPublicKey,
+ * which is gated behind a 24h timelock. Until then every co-sign fails closed, so the audit
+ * still FILES + ARCHIVES the proposal but never sends a queue/execute that would revert.
+ *
+ * TODO(inc-2 live): real gossip aggregator once SP assigns slots.
+ */
+export class PendingSlotCoSigner implements IQuorumCoSigner {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async coSign(_messageHash: string): Promise<{ signerMask: bigint; sigG2: string }> {
+    throw new Error(
+      "quorum co-sign deferred — gossip BLS aggregation needs SP validator slots " +
+        "(registerBLSPublicKey, pending 24h timelock)"
+    );
+  }
+}

--- a/src/modules/blockchain/blockchain.service.spec.ts
+++ b/src/modules/blockchain/blockchain.service.spec.ts
@@ -1,0 +1,72 @@
+import { ethers } from "ethers";
+import { BlockchainService } from "./blockchain.service.js";
+
+/**
+ * Focused unit tests for the durable over-slash guard read `getRecentSlashExecuted` (Codex round-2
+ * HIGH fail-closed + MEDIUM level-narrowing). BlockchainService is constructed with a stub
+ * ConfigService (no RPC dial), then its private `provider` is replaced with a mock exposing only the
+ * `getLogs` the method calls.
+ */
+const CONTRACT = "0x" + "11".repeat(20);
+const OPERATOR = "0x" + "22".repeat(20);
+const OTHER_OPERATOR = "0x" + "33".repeat(20);
+
+/** SlashExecuted(uint256 indexed proposalId, address indexed operator, uint8 level) — level NON-indexed. */
+const SLASH_IFACE = new ethers.Interface([
+  "event SlashExecuted(uint256 indexed proposalId, address indexed operator, uint8 level)",
+]);
+
+/** Build a real, decodable SlashExecuted log for (proposalId, operator, level). */
+function makeSlashExecutedLog(proposalId: bigint, operator: string, level: number) {
+  const encoded = SLASH_IFACE.encodeEventLog("SlashExecuted", [proposalId, operator, level]);
+  return { topics: encoded.topics, data: encoded.data };
+}
+
+/** A BlockchainService whose `provider.getLogs` is the supplied stub. */
+function makeService(getLogs: (filter: any) => Promise<any[]>): BlockchainService {
+  const config = { get: (_k: string) => undefined } as any;
+  const svc = new BlockchainService(config);
+  (svc as any).provider = { getLogs };
+  return svc;
+}
+
+describe("BlockchainService.getRecentSlashExecuted", () => {
+  const LEVEL = 1; // SlashLevel.MINOR — the credit-over-limit rule's level.
+
+  it("HIGH fail-closed: a getLogs/provider error returns null (indeterminate), NEVER false", async () => {
+    const svc = makeService(async () => {
+      throw new Error("RPC range too wide");
+    });
+    const result = await svc.getRecentSlashExecuted(CONTRACT, OPERATOR, LEVEL, 0);
+    // Must be null ("cannot determine"), so the caller fails CLOSED rather than reading "not slashed".
+    expect(result).toBeNull();
+  });
+
+  it("MEDIUM level-narrowing: a slash for a DIFFERENT level does NOT match (returns false)", async () => {
+    // Only a level-2 slash exists; the rule asks about level-1 → no match.
+    const svc = makeService(async () => [makeSlashExecutedLog(7n, OPERATOR, 2)]);
+    const result = await svc.getRecentSlashExecuted(CONTRACT, OPERATOR, LEVEL, 0);
+    expect(result).toBe(false);
+  });
+
+  it("a slash for the SAME operator + SAME level matches (returns true)", async () => {
+    const svc = makeService(async () => [makeSlashExecutedLog(7n, OPERATOR, LEVEL)]);
+    const result = await svc.getRecentSlashExecuted(CONTRACT, OPERATOR, LEVEL, 0);
+    expect(result).toBe(true);
+  });
+
+  it("a clean scan with no matching logs returns false (determinate 'not slashed')", async () => {
+    const svc = makeService(async () => []);
+    const result = await svc.getRecentSlashExecuted(CONTRACT, OPERATOR, LEVEL, 0);
+    expect(result).toBe(false);
+  });
+
+  it("an undecodable log (matched the topic filter but wrong shape) is ignored, not a match", async () => {
+    // A log whose topics[0] is neither event's hash → parseLog throws → ignored → false.
+    const svc = makeService(async () => [
+      { topics: [ethers.id("SomethingElse(uint256)")], data: "0x" },
+    ]);
+    const result = await svc.getRecentSlashExecuted(CONTRACT, OTHER_OPERATOR, LEVEL, 0);
+    expect(result).toBe(false);
+  });
+});

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -622,12 +622,53 @@ export class BlockchainService {
   }
 
   /**
+   * Best-effort read of an operator's on-chain pending-slash flag. This is the DURABLE
+   * cross-restart guard against double-slashing a sustained violation (finding-4/5): if a slash
+   * is already queued/pending, the audit must NOT queue+execute another.
+   *
+   * SP #329 keeps `_pendingSlash` PRIVATE with no public getter, so on the current deployment this
+   * call reverts and returns `null` ("unknown") — the caller then falls back to the in-memory
+   * coarse operator|rule guard. Should a future SuperPaymaster expose `pendingSlash(address)`
+   * (or `isSlashPending`), this begins returning the real flag and becomes the authoritative,
+   * restart-surviving guard with no caller change. `null` is treated as "unknown", never "false".
+   */
+  async isSlashPending(
+    superPaymasterAddress: string,
+    operator: string,
+    blockTag?: number
+  ): Promise<boolean | null> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+    // Try both plausible public getter names; either returning a bool answers the question.
+    const abi = [
+      "function pendingSlash(address operator) view returns (bool)",
+      "function isSlashPending(address operator) view returns (bool)",
+    ];
+    const contract = new ethers.Contract(superPaymasterAddress, abi, this.provider);
+    for (const fn of ["pendingSlash", "isSlashPending"] as const) {
+      try {
+        const pending: boolean = await contract[fn](operator, { blockTag });
+        return Boolean(pending);
+      } catch {
+        // getter absent on this deployment — try the next name.
+      }
+    }
+    return null;
+  }
+
+  /**
    * File a slash proposal binding the archived evidence (SP #329 4-arg createProposal):
    *   createProposal(address operator, uint8 level, string reason, bytes32 evidenceHash) returns (uint256 id)
-   * Same admin-wallet + bumped-fees + await-receipt contract as createSlashProposal; the extra
-   * `evidenceHash` (the content-addressed proofHash) binds the on-chain proposal to the archived
-   * proof. Returns the tx hash and the REAL on-chain id parsed from ProposalCreated (`null` when
-   * the event is absent, so the caller never fabricates an id).
+   *
+   * NOTE: the 4-arg `createProposal` selector is ONLY exposed by the #329 DVTValidator
+   * (Sepolia default 0x568b1486BFE036e603eA11f0D03Dc47fa62c9E0e, config-overridable via
+   * AUDIT_DVT_VALIDATOR_ADDRESS), which ships both the legacy 3-arg and this evidence-binding
+   * 4-arg overload. Pointing this at an older 3-arg-only validator would revert (no matching
+   * selector). Same admin-wallet + bumped-fees + await-receipt contract as createSlashProposal;
+   * the extra `evidenceHash` (the content-addressed proofHash) binds the on-chain proposal to the
+   * archived proof. Returns the tx hash and the REAL on-chain id parsed from ProposalCreated
+   * (`null` when the event is absent, so the caller never fabricates an id).
    */
   async createProposalWithEvidence(
     dvtValidatorAddress: string,

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -469,9 +469,11 @@ export class BlockchainService {
         // This RPC/chain does not support the tag — fall through to the next.
       }
     }
-    // Fallback: latest minus a confirmation depth (chains without finalized/safe tags).
+    // Fallback: latest minus a confirmation depth (chains without finalized/safe tags). The
+    // confirmation depth is floored at 1 so the fallback NEVER resolves to the unconfirmed head
+    // (latest − 0): a finality-safe fallback must always sit at least one confirmation back.
     const latest = await this.provider.getBlockNumber();
-    const target = Math.max(0, latest - Math.max(0, confirmations));
+    const target = Math.max(0, latest - Math.max(1, confirmations));
     const b = await this.provider.getBlock(target);
     if (!b || typeof b.number !== "number" || !b.hash) {
       throw new Error(
@@ -492,14 +494,27 @@ export class BlockchainService {
    *
    * Unlike the private `_pendingSlash` (no getter → isSlashPending returns null), an emitted event
    * is a permanent on-chain fact, so this survives a node restart and is the authoritative guard
-   * against re-slashing a sustained violation. Best-effort: an absent event / RPC range error on a
-   * given filter is swallowed (treated as "no match"); returns false when nothing is found.
+   * against re-slashing a sustained violation.
+   *
+   * Returns `boolean | null`:
+   *   - `true`  — a matching slash event (operator + slashLevel) exists in the window.
+   *   - `false` — the window was scanned cleanly and NO matching event exists.
+   *   - `null`  — a provider/getLogs error made the scan INDETERMINATE. For a DUPLICATE-slash guard
+   *               on an IRREVERSIBLE action a provider error must NEVER be read as "not slashed"; the
+   *               caller treats `null` as "cannot determine" and fails CLOSED (do-not-slash).
+   *
+   * Match is narrowed to operator + slashLevel (NOT operator alone). `level` is a NON-indexed field
+   * in both events, so it is decoded from the log data and compared. This is INTENTIONALLY
+   * CONSERVATIVE: the audit rule is not itself on-chain, so a same-operator+level slash within the
+   * lookback window OVER-skips (never risks a double slash) rather than under-skips. A slash for a
+   * DIFFERENT level does not mark this rule as already-slashed.
    */
   async getRecentSlashExecuted(
     contractAddress: string,
     operator: string,
+    slashLevel: number,
     fromBlock: number
-  ): Promise<boolean> {
+  ): Promise<boolean | null> {
     if (!this.provider) {
       throw new Error("Blockchain provider not configured");
     }
@@ -510,21 +525,36 @@ export class BlockchainService {
     const opTopic = ethers.zeroPadValue(ethers.getAddress(operator), 32);
     const filters = [
       // SlashExecutedWithProof: operator is the 1st indexed field (topics[1]).
-      { topics: [iface.getEvent("SlashExecutedWithProof")!.topicHash, opTopic] },
+      { name: "SlashExecutedWithProof", topics: [iface.getEvent("SlashExecutedWithProof")!.topicHash, opTopic] },
       // SlashExecuted: proposalId is 1st indexed (topics[1]), operator 2nd (topics[2]).
-      { topics: [iface.getEvent("SlashExecuted")!.topicHash, null, opTopic] },
+      { name: "SlashExecuted", topics: [iface.getEvent("SlashExecuted")!.topicHash, null, opTopic] },
     ];
     for (const f of filters) {
+      let logs;
       try {
-        const logs = await this.provider.getLogs({
+        logs = await this.provider.getLogs({
           address: contractAddress,
           fromBlock: Math.max(0, fromBlock),
           toBlock: "latest",
           topics: f.topics as (string | null)[],
         });
-        if (logs.length > 0) return true;
-      } catch {
-        // Event not defined on this contract, or RPC range/filter error — try the next.
+      } catch (error: any) {
+        // FAIL-CLOSED: a getLogs/provider error means the window could NOT be scanned. Return null
+        // ("indeterminate") rather than swallowing to a false "no match" — the caller must not read
+        // an unreadable chain as "safe to slash" for an irreversible action.
+        this.logger.warn(
+          `getRecentSlashExecuted getLogs failed on ${contractAddress} (${f.name}): ${error.message} — indeterminate`
+        );
+        return null;
+      }
+      for (const log of logs) {
+        try {
+          // level is NON-indexed in both events → decode it from the log data and compare.
+          const parsed = iface.parseLog({ topics: log.topics as string[], data: log.data });
+          if (parsed && Number(parsed.args.level) === slashLevel) return true;
+        } catch {
+          // A log the topic filter matched but we could not decode — ignore (not our event shape).
+        }
       }
     }
     return false;

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -453,9 +453,7 @@ export class BlockchainService {
    * if even that fallback cannot resolve a block (misconfigured provider). All rule reads are then
    * block-pinned to the returned `number` (via blockTag), so nothing is read at an unstable head.
    */
-  async getViolationBlock(
-    confirmations = 12
-  ): Promise<{ number: number; hash: string }> {
+  async getViolationBlock(confirmations = 12): Promise<{ number: number; hash: string }> {
     if (!this.provider) {
       throw new Error("Blockchain provider not configured");
     }
@@ -525,9 +523,15 @@ export class BlockchainService {
     const opTopic = ethers.zeroPadValue(ethers.getAddress(operator), 32);
     const filters = [
       // SlashExecutedWithProof: operator is the 1st indexed field (topics[1]).
-      { name: "SlashExecutedWithProof", topics: [iface.getEvent("SlashExecutedWithProof")!.topicHash, opTopic] },
+      {
+        name: "SlashExecutedWithProof",
+        topics: [iface.getEvent("SlashExecutedWithProof")!.topicHash, opTopic],
+      },
       // SlashExecuted: proposalId is 1st indexed (topics[1]), operator 2nd (topics[2]).
-      { name: "SlashExecuted", topics: [iface.getEvent("SlashExecuted")!.topicHash, null, opTopic] },
+      {
+        name: "SlashExecuted",
+        topics: [iface.getEvent("SlashExecuted")!.topicHash, null, opTopic],
+      },
     ];
     for (const f of filters) {
       let logs;
@@ -601,7 +605,9 @@ export class BlockchainService {
       const debt = await contract.getDebt(operator, { blockTag });
       return BigInt(debt);
     } catch (error: any) {
-      this.logger.warn(`getDebt read failed on token ${tokenAddress} for ${operator}: ${error.message}`);
+      this.logger.warn(
+        `getDebt read failed on token ${tokenAddress} for ${operator}: ${error.message}`
+      );
       return null;
     }
   }
@@ -812,7 +818,9 @@ export class BlockchainService {
       evidenceHash,
       fees
     );
-    this.logger.log(`createProposal(${operator}, ${level}, evidence ${evidenceHash}) submitted: ${tx.hash}`);
+    this.logger.log(
+      `createProposal(${operator}, ${level}, evidence ${evidenceHash}) submitted: ${tx.hash}`
+    );
     const receipt = await tx.wait();
     if (!receipt || receipt.status !== 1) {
       throw new Error(
@@ -872,7 +880,9 @@ export class BlockchainService {
       proof,
       fees
     );
-    this.logger.log(`queueSlashWithProof(${operator}, ${slashLevel}, epoch ${epoch}) submitted: ${tx.hash}`);
+    this.logger.log(
+      `queueSlashWithProof(${operator}, ${slashLevel}, epoch ${epoch}) submitted: ${tx.hash}`
+    );
     const receipt = await tx.wait();
     if (!receipt || receipt.status !== 1) {
       throw new Error(

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -621,6 +621,151 @@ export class BlockchainService {
     return { txHash: tx.hash, proposalId };
   }
 
+  /**
+   * File a slash proposal binding the archived evidence (SP #329 4-arg createProposal):
+   *   createProposal(address operator, uint8 level, string reason, bytes32 evidenceHash) returns (uint256 id)
+   * Same admin-wallet + bumped-fees + await-receipt contract as createSlashProposal; the extra
+   * `evidenceHash` (the content-addressed proofHash) binds the on-chain proposal to the archived
+   * proof. Returns the tx hash and the REAL on-chain id parsed from ProposalCreated (`null` when
+   * the event is absent, so the caller never fabricates an id).
+   */
+  async createProposalWithEvidence(
+    dvtValidatorAddress: string,
+    operator: string,
+    level: number,
+    reason: string,
+    evidenceHash: string
+  ): Promise<{ txHash: string; proposalId: bigint | null }> {
+    if (!this.wallet) {
+      throw new Error("Blockchain not configured. Set ETH_PRIVATE_KEY environment variable.");
+    }
+    const abi = [
+      "function createProposal(address operator, uint8 level, string reason, bytes32 evidenceHash) returns (uint256)",
+      "event ProposalCreated(uint256 indexed id, address indexed operator, uint8 level)",
+    ];
+    const iface = new ethers.Interface(abi);
+    const contract = new ethers.Contract(dvtValidatorAddress, abi, this.wallet);
+    const fees = await bumpedFees(this.provider);
+    const tx: ethers.TransactionResponse = await contract.createProposal(
+      operator,
+      level,
+      reason,
+      evidenceHash,
+      fees
+    );
+    this.logger.log(`createProposal(${operator}, ${level}, evidence ${evidenceHash}) submitted: ${tx.hash}`);
+    const receipt = await tx.wait();
+    if (!receipt || receipt.status !== 1) {
+      throw new Error(
+        `createProposal tx ${tx.hash} failed (status ${receipt?.status ?? "unknown"})`
+      );
+    }
+    let proposalId: bigint | null = null;
+    for (const log of receipt.logs) {
+      try {
+        const parsed = iface.parseLog({ topics: [...log.topics], data: log.data });
+        if (parsed && parsed.name === "ProposalCreated") {
+          proposalId = BigInt(parsed.args.id ?? parsed.args[0]);
+          break;
+        }
+      } catch {
+        // Not a ProposalCreated log (or from another contract) — skip.
+      }
+    }
+    if (proposalId === null) {
+      this.logger.warn(
+        `createProposal ${tx.hash} confirmed but no ProposalCreated event found — id unresolved`
+      );
+    }
+    this.logger.log(
+      `createProposal(${operator}, ${level}) confirmed in block ${receipt.blockNumber}` +
+        (proposalId !== null ? ` (proposalId ${proposalId})` : "")
+    );
+    return { txHash: tx.hash, proposalId };
+  }
+
+  /**
+   * Step 1 of the two-step slash (SP #329):
+   *   queueSlashWithProof(address operator, uint8 slashLevel, uint256 epoch, bytes proof)
+   * `proof` is abi.encode(uint256 signerMask, bytes sigG2) from the quorum co-sign over the
+   * step-1 messageHash. Admin wallet + bumped fees + await-receipt (throws on non-success so the
+   * caller logs and archives the evidence anyway). Returns the tx hash.
+   */
+  async queueSlashWithProof(
+    dvtValidatorAddress: string,
+    operator: string,
+    slashLevel: number,
+    epoch: bigint | number,
+    proof: string
+  ): Promise<string> {
+    if (!this.wallet) {
+      throw new Error("Blockchain not configured. Set ETH_PRIVATE_KEY environment variable.");
+    }
+    const abi = [
+      "function queueSlashWithProof(address operator, uint8 slashLevel, uint256 epoch, bytes proof) external",
+    ];
+    const contract = new ethers.Contract(dvtValidatorAddress, abi, this.wallet);
+    const fees = await bumpedFees(this.provider);
+    const tx: ethers.TransactionResponse = await contract.queueSlashWithProof(
+      operator,
+      slashLevel,
+      epoch,
+      proof,
+      fees
+    );
+    this.logger.log(`queueSlashWithProof(${operator}, ${slashLevel}, epoch ${epoch}) submitted: ${tx.hash}`);
+    const receipt = await tx.wait();
+    if (!receipt || receipt.status !== 1) {
+      throw new Error(
+        `queueSlashWithProof tx ${tx.hash} failed (status ${receipt?.status ?? "unknown"})`
+      );
+    }
+    this.logger.log(`queueSlashWithProof(${operator}) confirmed in block ${receipt.blockNumber}`);
+    return tx.hash;
+  }
+
+  /**
+   * Step 2 of the two-step slash (SP #329):
+   *   executeWithProof(uint256 id, address[] repUsers, uint256[] newScores, uint256 epoch, bytes proof)
+   * For a slash-only proposal repUsers/newScores are empty. `proof` is abi.encode(signerMask, sigG2)
+   * from the quorum co-sign over the step-2 messageHash. Admin wallet + bumped fees +
+   * await-receipt (throws on non-success). Returns the tx hash.
+   */
+  async executeSlashWithProof(
+    dvtValidatorAddress: string,
+    id: bigint | number,
+    repUsers: string[],
+    newScores: Array<bigint | number>,
+    epoch: bigint | number,
+    proof: string
+  ): Promise<string> {
+    if (!this.wallet) {
+      throw new Error("Blockchain not configured. Set ETH_PRIVATE_KEY environment variable.");
+    }
+    const abi = [
+      "function executeWithProof(uint256 id, address[] repUsers, uint256[] newScores, uint256 epoch, bytes proof) external",
+    ];
+    const contract = new ethers.Contract(dvtValidatorAddress, abi, this.wallet);
+    const fees = await bumpedFees(this.provider);
+    const tx: ethers.TransactionResponse = await contract.executeWithProof(
+      id,
+      repUsers,
+      newScores,
+      epoch,
+      proof,
+      fees
+    );
+    this.logger.log(`executeWithProof(id ${id}, epoch ${epoch}) submitted: ${tx.hash}`);
+    const receipt = await tx.wait();
+    if (!receipt || receipt.status !== 1) {
+      throw new Error(
+        `executeWithProof tx ${tx.hash} failed (status ${receipt?.status ?? "unknown"})`
+      );
+    }
+    this.logger.log(`executeWithProof(id ${id}) confirmed in block ${receipt.blockNumber}`);
+    return tx.hash;
+  }
+
   /** Current network base-fee in gwei (0 on chains without EIP-1559). */
   async getBaseFeeGwei(): Promise<bigint> {
     const block = await this.provider.getBlock("latest");

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -442,6 +442,94 @@ export class BlockchainService {
     return this.provider.getBlockNumber();
   }
 
+  /**
+   * The block an irreversible slash is justified against — a FINALIZED (fallback: safe) block,
+   * returned as `{ number, hash }` (finding-3). Pinning the slash evidence to a finalized block,
+   * and recording its HASH, makes the justification reorg-safe: a reorg that rewrites the chain
+   * head cannot silently invalidate the block the audit read its rule inputs at.
+   *
+   * Order of preference: `provider.getBlock("finalized")`, then `"safe"` (post-Merge PoS tags),
+   * then — for RPCs/chains that expose neither — latest MINUS `confirmations` blocks. Throws only
+   * if even that fallback cannot resolve a block (misconfigured provider). All rule reads are then
+   * block-pinned to the returned `number` (via blockTag), so nothing is read at an unstable head.
+   */
+  async getViolationBlock(
+    confirmations = 12
+  ): Promise<{ number: number; hash: string }> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+    for (const tag of ["finalized", "safe"] as const) {
+      try {
+        const b = await this.provider.getBlock(tag);
+        if (b && typeof b.number === "number" && b.hash) {
+          return { number: b.number, hash: b.hash };
+        }
+      } catch {
+        // This RPC/chain does not support the tag — fall through to the next.
+      }
+    }
+    // Fallback: latest minus a confirmation depth (chains without finalized/safe tags).
+    const latest = await this.provider.getBlockNumber();
+    const target = Math.max(0, latest - Math.max(0, confirmations));
+    const b = await this.provider.getBlock(target);
+    if (!b || typeof b.number !== "number" || !b.hash) {
+      throw new Error(
+        `getViolationBlock: could not resolve a finalized/safe block (latest ${latest}, target ${target})`
+      );
+    }
+    return { number: b.number, hash: b.hash };
+  }
+
+  /**
+   * DURABLE (restart-surviving) over-slash guard (finding-2): did `operator` already get slashed
+   * recently on `contractAddress`? Queries the on-chain slash-executed events within a bounded
+   * `[fromBlock, latest]` window and returns true on the first match. Both event shapes are tried
+   * (either can carry the executed slash), each topic-filtered by the indexed `operator`:
+   *
+   *   SuperPaymaster.SlashExecutedWithProof(address indexed operator, uint8 level, ...)
+   *   BLSAggregator.SlashExecuted(uint256 indexed proposalId, address indexed operator, uint8 level)
+   *
+   * Unlike the private `_pendingSlash` (no getter → isSlashPending returns null), an emitted event
+   * is a permanent on-chain fact, so this survives a node restart and is the authoritative guard
+   * against re-slashing a sustained violation. Best-effort: an absent event / RPC range error on a
+   * given filter is swallowed (treated as "no match"); returns false when nothing is found.
+   */
+  async getRecentSlashExecuted(
+    contractAddress: string,
+    operator: string,
+    fromBlock: number
+  ): Promise<boolean> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+    const iface = new ethers.Interface([
+      "event SlashExecutedWithProof(address indexed operator, uint8 level, uint256 penalty, bytes32 proofHash, uint256 timestamp)",
+      "event SlashExecuted(uint256 indexed proposalId, address indexed operator, uint8 level)",
+    ]);
+    const opTopic = ethers.zeroPadValue(ethers.getAddress(operator), 32);
+    const filters = [
+      // SlashExecutedWithProof: operator is the 1st indexed field (topics[1]).
+      { topics: [iface.getEvent("SlashExecutedWithProof")!.topicHash, opTopic] },
+      // SlashExecuted: proposalId is 1st indexed (topics[1]), operator 2nd (topics[2]).
+      { topics: [iface.getEvent("SlashExecuted")!.topicHash, null, opTopic] },
+    ];
+    for (const f of filters) {
+      try {
+        const logs = await this.provider.getLogs({
+          address: contractAddress,
+          fromBlock: Math.max(0, fromBlock),
+          toBlock: "latest",
+          topics: f.topics as (string | null)[],
+        });
+        if (logs.length > 0) return true;
+      } catch {
+        // Event not defined on this contract, or RPC range/filter error — try the next.
+      }
+    }
+    return false;
+  }
+
   /** Runtime bytecode at `address` ("0x" when there's no contract). Used for a fail-closed
    *  bootstrap existence check before the audit poll trusts an address. */
   async getCode(address: string, blockTag?: number): Promise<string> {


### PR DESCRIPTION
## DVT Phase 2 (目标2) inc-2 — two-step slash-consensus orchestration

Builds on inc-1 (audit → violation → proof archive). inc-2 adds the **two-step slash consensus orchestration** that turns an archived violation proof into an on-chain slash on SuperPaymaster's DVTValidator (SP #329 finalized interface), quorum-co-signed by the DVT nodes.

**Execution stays default-OFF.** `AUDIT_EXECUTE_SLASH` defaults false and the real co-signer is a `PendingSlotCoSigner` stub that throws — so this PR ships the FILE + ARCHIVE + orchestration logic and its full test surface, but never sends a queue/execute that would revert. Real execution is gated on SuperPaymaster handing out BLS validator slots (`registerBLSPublicKey`, 24h timelock) + the live gossip aggregator.

### What's in it
- **`slash-consensus.ts`** — pure, byte-verified preimages: `buildQueueMessageHash` (5-field, `keccak256("QUEUE_SLASH")` domain tag), `buildExecuteMessageHash` (8-field incl. empty `repUsers[]`/`newScores[]` + `bytes32 evidenceHash`), `encodeProof(signerMask, sigG2)`. `IQuorumCoSigner` seam + deferred stub.
- **Two-step orchestration** (`audit.service.ts coordinateQuorumCoSign`) — queue → createProposal → execute, each independently quorum-co-signed over its own preimage; **execute strictly contingent on a confirmed queueTx**; per-step re-archive.
- **Finality-pinned evidence** — violation block read from finalized/safe (not `latest`), `violationBlockHash` stored, `AUDIT_FINALITY_CONFIRMATIONS` floored ≥ 1.
- **Restart-safe duplicate guard** — durable slashed journal + on-chain executed-slash scan (fail-CLOSED on indeterminate) + in-memory coarse keys.

### Review rounds baked in
1. `security-review` skill (0 findings)
2. `code-review` workflow high-effort (**5** confirmed: stale 7-field messageHash, discarded tx handles, wall-clock epoch, duplicate slash, execute-before-archive)
3. Codex round-1 (**BLOCKING** — 1 Critical execute-after-queue-fail + 2 High + Med/Low)
4. Codex round-2 residuals (1 High fail-open→**fail-closed** slash guard, 2 Med, 1 Low)

Every round's findings fixed with tests. Final: **247/247 tests**, type-check / build / lint clean.

### Not in this PR (gated / follow-up)
- Live execution (needs SP slots + 24h timelock apply + real gossip aggregator) — tonight's E2E.
- Per-token debt refinement (SP confirmed debt is per-operator `config.xPNTsToken`).

Refs #163.
