### PR TITLE
fix(CC-22): ownerAuth 1-byte tag + wire delivered e2e_account (0x92EA8b02)

### DIFF
--- a/deploy/sdk-dvt-config.testnet.json
+++ b/deploy/sdk-dvt-config.testnet.json
@@ -11,9 +11,11 @@
       "validatorVersion": "YetAnotherAA-Validator AAStarValidator (Plan A v3 stake-bound; validate() algId 0x01 + registerWithProof + on-chain RFC-9380). Mounted in airaccount v0.27.0 ValidatorRouter 0xe68d6A7Bb60DA4caE62ceC2439722fc5eEF87a5c (getAlgorithm(0x01)==this). Supersedes airaccount-contract v0.20.0 AAStarBLSAlgorithm 0xAF525A… for new integrations.",
       "entryPoint": "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
       "entryPointVersion": "v0.7",
+      "e2eAccount": "0x92EA8b02D34A4D5d10f0Db9Ea894e8bC72e292e8",
+      "e2eAccountNote": "airaccount-contract AAStarAirAccountV7 v0.27.0 implementing isValidOwnerAuth->0xa0cf00cf (CC-22). owner = 0xb5600060e6de5E11D3636731964218E53caadf0E (dvt1 operator). Source: airaccount-contract, NOT DVT-owned — see docs/INTERFACES.md §2.",
       "conventions": {
         "userOpHash": "EntryPoint.getUserOpHash(PackedUserOp) — node derives it; never send a bare hash",
-        "ownerAuth": "account.isValidOwnerAuth(userOpHash, ownerAuth) eth_call → magic 0xa0cf00cf. The account contract is the single source of truth for owner-auth (k1 ECDSA / P256 passkey / future schemes); the DVT node never verifies locally, so it never drifts from on-chain validation. Requires an account implementing isValidOwnerAuth(bytes32,bytes)→0xa0cf00cf (AAStarAirAccountV7).",
+        "ownerAuth": "account.isValidOwnerAuth(userOpHash, ownerAuth) eth_call → success magic 0xa0cf00cf, fail 0xffffffff. The account is the single source of truth (k1 ECDSA / P256 passkey / future); DVT forwards ownerAuth verbatim and never verifies locally. ownerAuth = 1-byte tag ‖ payload: 0x01 = owner ECDSA k1 (65-byte personal_sign(userOpHash), EIP-191); 0x02 = owner WebAuthn passkey (authenticatorData‖clientDataJSON‖…). A bare signature with no tag returns 0xffffffff → 403. Requires an account implementing isValidOwnerAuth(bytes32,bytes) (AAStarAirAccountV7).",
         "proofWire": "EIP-2537 G1/G2 (matches src/utils/bls.util.ts)",
         "failClosed": "POST /signature/sign returns 403 for every rejected request (never 400)",
         "mandatoryBlsAccount": "guard-enabled + approvedAlgIds=[0x01] (excludes 0x02 ECDSA)"

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -31,8 +31,13 @@ function isValidOwnerAuth(bytes32 userOpHash, bytes calldata ownerAuth) view ret
   - `0x01` — owner ECDSA (k1): payload = 65-byte `personal_sign(userOpHash)`
     (EIP-191, i.e. `sign(toEthSignedMessageHash(userOpHash))`; v normalized to
     27/28, low-S). recover must == owner EOA.
-  - `0x02` — owner WebAuthn passkey: payload =
-    `authenticatorData ‖ clientDataJSON ‖ …`.
+  - `0x02` — owner WebAuthn passkey (P256): payload =
+    `abi.encode(bytes authenticatorData, string clientDataJSONPrefix, string clientDataJSONSuffix, uint256 r, uint256 s)`
+    (the account reconstructs clientDataJSON as
+    `prefix ‖ base64url(challenge=userOpHash) ‖ suffix` and P256-verifies `r,s`
+    over `sha256(authenticatorData ‖ sha256(clientDataJSON))`). Exact encoding
+    is airaccount-owned; DVT forwards the payload verbatim. Not used by the k1
+    `e2e_account`.
   - A **bare** signature with no tag byte → `0xffffffff` → the DVT gate 403s.
     This is the exact bug KMS hit on CC-22 (`owner.signMessage(...)` without the
     `0x01` prefix). `userOpHash` is always derived by DVT, never trusted from

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -22,10 +22,26 @@ test so a drift fails CI instead of failing in production.
 function isValidOwnerAuth(bytes32 userOpHash, bytes calldata ownerAuth) view returns (bytes4)
 ```
 
-- **Success magic:** `0xa0cf00cf` — this is
-  `selector(isValidOwnerAuth(bytes32,bytes))`, used as the return magic exactly
-  like ERC-1271's `0x1626ba7e = selector(isValidSignature(bytes32,bytes))`. It
-  is **NOT** standard ERC-1271.
+- **Return:** success → `0xa0cf00cf` (=
+  `selector(isValidOwnerAuth(bytes32,bytes))`, used as magic like ERC-1271's
+  `0x1626ba7e = selector(isValidSignature)`, deliberately NOT the ERC-1271
+  magic); failure → `0xffffffff`.
+- **`ownerAuth` wire format** = 1-byte tag ‖ payload (airaccount, stable since
+  v0.23.0 / #159):
+  - `0x01` — owner ECDSA (k1): payload = 65-byte `personal_sign(userOpHash)`
+    (EIP-191, i.e. `sign(toEthSignedMessageHash(userOpHash))`; v normalized to
+    27/28, low-S). recover must == owner EOA.
+  - `0x02` — owner WebAuthn passkey: payload =
+    `authenticatorData ‖ clientDataJSON ‖ …`.
+  - A **bare** signature with no tag byte → `0xffffffff` → the DVT gate 403s.
+    This is the exact bug KMS hit on CC-22 (`owner.signMessage(...)` without the
+    `0x01` prefix). `userOpHash` is always derived by DVT, never trusted from
+    the caller.
+- **Delivered E2E account (Sepolia, CC-22):**
+  `0x92EA8b02D34A4D5d10f0Db9Ea894e8bC72e292e8` (AAStarAirAccountV7 v0.27.0),
+  owner `0xb5600060e6de5E11D3636731964218E53caadf0E` (= dvt1 operator, so
+  realnode-e2e signs with the same key). Mainnet account: airaccount to deliver
+  post-deploy.
 - **Why delegate:** the account contract is the single source of truth for
   owner-auth (k1 ECDSA / P256 passkey / future schemes). DVT never verifies
   locally → never drifts, and supports passkey accounts whose `owner() == 0x0`.

--- a/scripts/e2e/realnode-e2e.mjs
+++ b/scripts/e2e/realnode-e2e.mjs
@@ -79,7 +79,11 @@ const EP_ABI = [
   "function getUserOpHash((address sender,uint256 nonce,bytes initCode,bytes callData,bytes32 accountGasLimits,uint256 preVerificationGas,bytes32 gasFees,bytes paymasterAndData,bytes signature) userOp) view returns (bytes32)",
 ];
 const userOpHash = await withRpc(p => new ethers.Contract(ENTRY, EP_ABI, p).getUserOpHash(userOp));
-const ownerAuth = await owner.signMessage(ethers.getBytes(userOpHash));
+// ownerAuth = 1-byte tag ‖ payload (airaccount AAStarAirAccountV7 isValidOwnerAuth contract,
+// see docs/INTERFACES.md §1). tag 0x01 = owner ECDSA (k1): personal_sign(userOpHash) EIP-191.
+// A bare signature (no tag) returns 0xffffffff → the gate 403s (the bug KMS hit on CC-22).
+const ownerSig = await owner.signMessage(ethers.getBytes(userOpHash));
+const ownerAuth = "0x01" + ownerSig.slice(2);
 // Do not echo raw process.env values (ACCOUNT / owner.address) — CodeQL's clear-text-logging
 // query flags any process.env value reaching console.log (js/clear-text-logging), and the
 // operator already knows what they passed. Log a non-tainted confirmation instead.

--- a/scripts/e2e/selftest.mjs
+++ b/scripts/e2e/selftest.mjs
@@ -2,21 +2,61 @@
 // the Stage-1 gate (bad ownerAuth -> 403). Usage: node scripts/e2e/selftest.mjs
 import { ethers } from "ethers";
 import { readFileSync } from "fs";
-const strip=s=>s.replace(/^["']|["']$/g,"");
-const env=Object.fromEntries(readFileSync(".env.sepolia","utf8").split("\n").filter(l=>l.includes("=")).map(l=>{const i=l.indexOf("=");return[l.slice(0,i).trim(),strip(l.slice(i+1).trim())]}));
-const provider=new ethers.JsonRpcProvider(env.SEPOLIA_RPC_URL);
-const ENTRY=env.ENTRY_POINT_ADDRESS||env.ENTRYPOINT_ADDRESS;
-const ACCOUNT="0x45Dfe3D5938fDf5a8D30641C3FDA9c9fb1F31ba9";
-const owner=new ethers.Wallet(env.PRIVATE_KEY_SUPPLIER);
-const userOp={sender:ACCOUNT,nonce:"0",initCode:"0x",callData:"0x",accountGasLimits:"0x"+"00".repeat(32),preVerificationGas:"0",gasFees:"0x"+"00".repeat(32),paymasterAndData:"0x",signature:"0x"};
-const ep=new ethers.Contract(ENTRY,["function getUserOpHash((address sender,uint256 nonce,bytes initCode,bytes callData,bytes32 accountGasLimits,uint256 preVerificationGas,bytes32 gasFees,bytes paymasterAndData,bytes signature) userOp) view returns (bytes32)"],provider);
-const uoh=await ep.getUserOpHash(userOp);
-const ownerAuth=await owner.signMessage(ethers.getBytes(uoh));
-for(const p of [3001,3002,3003]){
-  const info=await (await fetch(`http://localhost:${p}/node/info`)).json();
-  const r=await fetch(`http://localhost:${p}/signature/sign`,{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({userOp,ownerAuth})});
-  const ok=r.ok; const j=ok?await r.json():await r.text();
-  console.log(`:${p} info.nodeId=${(info.nodeId||"?").slice(0,12)}.. | sign ${ok?"✅ "+(j.message===uoh?"hash-bound":"??"):"❌ "+j}`);
+const strip = s => s.replace(/^["']|["']$/g, "");
+const env = Object.fromEntries(
+  readFileSync(".env.sepolia", "utf8")
+    .split("\n")
+    .filter(l => l.includes("="))
+    .map(l => {
+      const i = l.indexOf("=");
+      return [l.slice(0, i).trim(), strip(l.slice(i + 1).trim())];
+    })
+);
+const provider = new ethers.JsonRpcProvider(env.SEPOLIA_RPC_URL);
+const ENTRY = env.ENTRY_POINT_ADDRESS || env.ENTRYPOINT_ADDRESS;
+// e2e_account = airaccount AAStarAirAccountV7 implementing isValidOwnerAuth->0xa0cf00cf (CC-22).
+// owner = PRIVATE_KEY_SUPPLIER (dvt1 operator 0xb56000, the account's on-chain owner).
+const ACCOUNT = process.env.E2E_ACCOUNT || "0x92EA8b02D34A4D5d10f0Db9Ea894e8bC72e292e8";
+const owner = new ethers.Wallet(env.PRIVATE_KEY_SUPPLIER);
+const userOp = {
+  sender: ACCOUNT,
+  nonce: "0",
+  initCode: "0x",
+  callData: "0x",
+  accountGasLimits: "0x" + "00".repeat(32),
+  preVerificationGas: "0",
+  gasFees: "0x" + "00".repeat(32),
+  paymasterAndData: "0x",
+  signature: "0x",
+};
+const ep = new ethers.Contract(
+  ENTRY,
+  [
+    "function getUserOpHash((address sender,uint256 nonce,bytes initCode,bytes callData,bytes32 accountGasLimits,uint256 preVerificationGas,bytes32 gasFees,bytes paymasterAndData,bytes signature) userOp) view returns (bytes32)",
+  ],
+  provider
+);
+const uoh = await ep.getUserOpHash(userOp);
+// ownerAuth = 0x01 tag (owner ECDSA k1) ‖ personal_sign(userOpHash); bare sig (no tag) → 0xffffffff.
+const ownerAuth = "0x01" + (await owner.signMessage(ethers.getBytes(uoh))).slice(2);
+for (const p of [3001, 3002, 3003]) {
+  const info = await (await fetch(`http://localhost:${p}/node/info`)).json();
+  const r = await fetch(`http://localhost:${p}/signature/sign`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ userOp, ownerAuth }),
+  });
+  const ok = r.ok;
+  const j = ok ? await r.json() : await r.text();
+  console.log(
+    `:${p} info.nodeId=${(info.nodeId || "?").slice(0, 12)}.. | sign ${ok ? "✅ " + (j.message === uoh ? "hash-bound" : "??") : "❌ " + j}`
+  );
 }
-const bad=await fetch(`http://localhost:3001/signature/sign`,{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({userOp,ownerAuth:"0x"+"ab".repeat(65)})});
-console.log(`:3001 bad ownerAuth -> HTTP ${bad.status} ${bad.status===403?"✅ fail-closed":"❌"}`);
+const bad = await fetch(`http://localhost:3001/signature/sign`, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ userOp, ownerAuth: "0x" + "ab".repeat(65) }),
+});
+console.log(
+  `:3001 bad ownerAuth -> HTTP ${bad.status} ${bad.status === 403 ? "✅ fail-closed" : "❌"}`
+);


### PR DESCRIPTION
airaccount delivered the CC-22 `e2e_account` (`0x92EA8b02…`, AAStarAirAccountV7 v0.27.0, owner = dvt1 operator) and the `isValidOwnerAuth` ownerAuth contract. This wires both in and fixes the ownerAuth construction bug KMS hit.

- **ownerAuth = 1-byte tag ‖ payload**: `0x01` = owner ECDSA k1 (`personal_sign(userOpHash)`, EIP-191); `0x02` = passkey. A bare signature (no tag) → `0xffffffff` → 403. `realnode-e2e.mjs` / `selftest.mjs` now prepend the `0x01` tag (were bare `signMessage`).
- `selftest.mjs` ACCOUNT → the delivered account (was the outdated `0x45Dfe3`, standard ERC-1271 only).
- `deploy/sdk-dvt-config.testnet.json`: add `e2eAccount` + document the tag format.
- `docs/INTERFACES.md §1`: full ownerAuth wire contract (tags, magic `0xa0cf00cf`/`0xffffffff`) + delivered account — airaccount agreed this belongs in INTERFACES for version management.

DVT owner-gate code unchanged (forwards ownerAuth verbatim). `config:check` green. Refs CC-22.