### PR TITLE
feat(#163 CC-13 inc-2-live): real gossip BLS quorum co-signer (default-off)

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -85,3 +85,26 @@ node scripts/sync-dvt-config.mjs --validator 0x…   # also check/set the valida
 `config:check` only touches DVT-owned fields — airaccount-owned fields
 (`e2e_account`, router) are never rewritten. Wire `npm run config:check` into CI
 to fail the build if the committed config drifts from the running nodes.
+
+## 3. Slash-consensus proof schema — all DVT nodes MUST match (inc-2-live)
+
+**What it is:** the inc-2-live gossip slash quorum content-addresses its
+evidence with a `proofHash` derived from `ProofIdentity` in
+`src/modules/audit/proof-archive.ts`, versioned by `PROOF_SCHEMA_VERSION`. Every
+co-sign request carries that version (`CoSignRequest.proofSchemaVersion`), and
+the responder (`gossip-quorum-cosigner.ts:verifyAndSign`) **refuses** to co-sign
+any request whose version differs from its own — an explicit, logged refusal,
+not a silent hash divergence.
+
+**Operational contract — deploy the fleet atomically.** Because widening
+`ProofIdentity` changes `proofHash`, a mixed-version fleet (some nodes old, some
+new) computes **different** `proofHash`es and cannot reach quorum. Slash
+consensus then silently loses liveness until every node matches.
+**Upgrade/deploy all DVT nodes together (atomic); never do a rolling partial
+upgrade** that leaves nodes on different `PROOF_SCHEMA_VERSION`. When you bump
+the identity shape, bump `PROOF_SCHEMA_VERSION` and roll all nodes in one
+coordinated deploy.
+
+**Auto-check:** `proof-archive.spec.ts` asserts the version is bound into
+`proofHash`; `gossip-quorum-cosigner.spec.ts` asserts a version-mismatched
+request is refused.

--- a/src/config/configuration.spec.ts
+++ b/src/config/configuration.spec.ts
@@ -98,4 +98,15 @@ describe("configuration: auditSlashThresholds clamp (slash-quorum floor)", () =>
     expect(t.MINOR).toBe(3);
     expect(t.MAJOR).toBe(3);
   });
+
+  it("LOW (Codex R2): a numeric-prefix junk value ('4oops') is IGNORED, not read as 4", () => {
+    // parseInt would silently take 4; strict ^[0-9]+$ rejects it → the safe floor is kept.
+    process.env.AUDIT_SLASH_THRESHOLDS = "MINOR:4oops";
+    expect(configuration().auditSlashThresholds.MINOR).toBe(3);
+  });
+
+  it("LOW (Codex R2): an empty value ('MINOR:') keeps the floor", () => {
+    process.env.AUDIT_SLASH_THRESHOLDS = "MINOR:";
+    expect(configuration().auditSlashThresholds.MINOR).toBe(3);
+  });
 });

--- a/src/config/configuration.spec.ts
+++ b/src/config/configuration.spec.ts
@@ -42,3 +42,60 @@ describe("configuration: auditFinalityConfirmations floor", () => {
     expect(configuration().auditFinalityConfirmations).toBe(20);
   });
 });
+
+/**
+ * HIGH 1 (Codex): AUDIT_SLASH_THRESHOLDS must be CLAMPED UP to the pinned live floor
+ * (WARNING ≥ 2, MINOR ≥ 3, MAJOR ≥ 3) so a misconfiguration like `MINOR:1` can never let a single
+ * local signature pass as quorum and defeat the 3-of-3 slash invariant. HIGHER values are kept.
+ */
+describe("configuration: auditSlashThresholds clamp (slash-quorum floor)", () => {
+  const saved = { ...process.env };
+
+  beforeEach(() => {
+    process.env.ETH_RPC_URL = "http://localhost:8545";
+    process.env.VALIDATOR_CONTRACT_ADDRESS = "0x" + "12".repeat(20);
+  });
+
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  it("unset → the pinned live defaults 2/3/3", () => {
+    delete process.env.AUDIT_SLASH_THRESHOLDS;
+    expect(configuration().auditSlashThresholds).toEqual({ WARNING: 2, MINOR: 3, MAJOR: 3 });
+  });
+
+  it("MINOR:1 (below floor) → clamped UP to 3", () => {
+    process.env.AUDIT_SLASH_THRESHOLDS = "MINOR:1";
+    expect(configuration().auditSlashThresholds.MINOR).toBe(3);
+  });
+
+  it("WARNING:1 (below floor) → clamped UP to 2", () => {
+    process.env.AUDIT_SLASH_THRESHOLDS = "WARNING:1";
+    expect(configuration().auditSlashThresholds.WARNING).toBe(2);
+  });
+
+  it("MAJOR:1 (below floor) → clamped UP to 3", () => {
+    process.env.AUDIT_SLASH_THRESHOLDS = "MAJOR:1";
+    expect(configuration().auditSlashThresholds.MAJOR).toBe(3);
+  });
+
+  it("MINOR:4 (above floor) → preserved (higher thresholds still configurable)", () => {
+    process.env.AUDIT_SLASH_THRESHOLDS = "MINOR:4";
+    expect(configuration().auditSlashThresholds.MINOR).toBe(4);
+  });
+
+  it("mixed: MINOR:1,WARNING:5 → MINOR clamped to 3, WARNING preserved at 5", () => {
+    process.env.AUDIT_SLASH_THRESHOLDS = "MINOR:1,WARNING:5";
+    const t = configuration().auditSlashThresholds;
+    expect(t.MINOR).toBe(3);
+    expect(t.WARNING).toBe(5);
+  });
+
+  it("a malformed / non-positive entry keeps that level at its floor default", () => {
+    process.env.AUDIT_SLASH_THRESHOLDS = "MINOR:0,MAJOR:notanumber";
+    const t = configuration().auditSlashThresholds;
+    expect(t.MINOR).toBe(3);
+    expect(t.MAJOR).toBe(3);
+  });
+});

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -303,8 +303,10 @@ function parseSlashThresholds(raw?: string): { WARNING: number; MINOR: number; M
   if (!raw) return out;
   for (const pair of raw.split(",")) {
     const [k, v] = pair.split(":").map(s => s.trim());
-    const n = parseInt(v, 10);
-    if ((k === "WARNING" || k === "MINOR" || k === "MAJOR") && Number.isFinite(n) && n > 0) {
+    // STRICT numeric parse (Codex R2 LOW): reject "4oops"/"" — parseInt would silently take 4.
+    // A malformed value is IGNORED so the safe floor is kept (never a weaker/garbage quorum).
+    const n = /^[0-9]+$/.test(v ?? "") ? Number(v) : NaN;
+    if ((k === "WARNING" || k === "MINOR" || k === "MAJOR") && Number.isSafeInteger(n) && n > 0) {
       const floor = SLASH_THRESHOLD_FLOOR[k];
       if (n < floor) {
         console.warn(

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -284,18 +284,37 @@ function parseAllowlist(allowlistString: string): string[] {
 }
 
 /**
+ * Per-severity SAFE MINIMUM quorum (the pinned live policy, N=3 BLSAggregator bootstrap). A
+ * configured override may only RAISE a threshold, never lower it below this floor — otherwise a
+ * value like `MINOR:1` would let a single local signature pass as quorum and defeat the 3-of-3
+ * invariant that gates a REAL, irreversible on-chain GToken slash. HIGH 1 (Codex): clamp UP.
+ */
+const SLASH_THRESHOLD_FLOOR = { WARNING: 2, MINOR: 3, MAJOR: 3 } as const;
+
+/**
  * Parse the optional AUDIT_SLASH_THRESHOLDS override ("WARNING:2,MINOR:3,MAJOR:3") into the
  * per-severity quorum table. Defaults to the on-chain BLSAggregator bootstrap (N=3): 2/3/3.
- * Malformed / non-positive entries are ignored (the default for that level is kept).
+ * Malformed / non-positive entries are ignored (the default for that level is kept). Any parsed
+ * value BELOW the safe floor is CLAMPED UP to the floor (with a warning) so a misconfiguration can
+ * never weaken the quorum below the pinned live policy; HIGHER values are preserved as configured.
  */
 function parseSlashThresholds(raw?: string): { WARNING: number; MINOR: number; MAJOR: number } {
-  const out = { WARNING: 2, MINOR: 3, MAJOR: 3 };
+  const out = { ...SLASH_THRESHOLD_FLOOR } as { WARNING: number; MINOR: number; MAJOR: number };
   if (!raw) return out;
   for (const pair of raw.split(",")) {
     const [k, v] = pair.split(":").map(s => s.trim());
     const n = parseInt(v, 10);
     if ((k === "WARNING" || k === "MINOR" || k === "MAJOR") && Number.isFinite(n) && n > 0) {
-      out[k] = n;
+      const floor = SLASH_THRESHOLD_FLOOR[k];
+      if (n < floor) {
+        console.warn(
+          `⚠️  AUDIT_SLASH_THRESHOLDS ${k}:${n} is below the safe minimum (${floor}) — ` +
+            `clamping UP to ${floor} (the 3-of-3 slash quorum invariant cannot be weakened)`
+        );
+        out[k] = floor;
+      } else {
+        out[k] = n;
+      }
     }
   }
   return out;

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -238,6 +238,21 @@ export default () => {
     // slashes. Size this to your RPC's getLogs block-range limit (many public endpoints cap ~10k) so
     // the scan stays determinate. It is only consulted on the armed executeSlash path.
     auditSlashLookbackBlocks: parseInt(process.env.AUDIT_SLASH_LOOKBACK_BLOCKS || "50000", 10),
+    // Live gossip quorum co-sign (inc-2). Only consulted on the armed executeSlash path.
+    // AUDIT_COSIGN_TIMEOUT_MS: how long the requester waits for peer signatures before resolving
+    //   with whatever partial set arrived (then it enforces the threshold; under → no submit).
+    // AUDIT_SLASH_THRESHOLDS: optional per-severity quorum override "WARNING:2,MINOR:3,MAJOR:3"
+    //   (the on-chain BLSAggregator bootstrap for N=3). Must match / not exceed the on-chain table.
+    // AUDIT_MAX_SLOTS: how many 1-indexed BLSAggregator slots to scan (= on-chain MAX_VALIDATORS).
+    // AUDIT_SLOT_MAP: optional boot-time cross-check only (never the runtime slot source — the
+    //   on-chain BLSAggregator is authoritative); format "0xoperator:slot,..." for diagnostics.
+    auditCoSignTimeoutMs: parseInt(process.env.AUDIT_COSIGN_TIMEOUT_MS || "15000", 10),
+    auditSlashThresholds: parseSlashThresholds(process.env.AUDIT_SLASH_THRESHOLDS),
+    auditMaxSlots: (() => {
+      const parsed = parseInt(process.env.AUDIT_MAX_SLOTS || "13", 10);
+      return Number.isFinite(parsed) && parsed > 0 ? parsed : 13;
+    })(),
+    auditSlotMap: process.env.AUDIT_SLOT_MAP || undefined,
 
     // Gossip Network
     gossipPublicUrl: process.env.GOSSIP_PUBLIC_URL || `ws://localhost:${port}/ws`,
@@ -266,4 +281,22 @@ function parseAllowlist(allowlistString: string): string[] {
     .split(",")
     .map(a => a.trim())
     .filter(a => a.length > 0);
+}
+
+/**
+ * Parse the optional AUDIT_SLASH_THRESHOLDS override ("WARNING:2,MINOR:3,MAJOR:3") into the
+ * per-severity quorum table. Defaults to the on-chain BLSAggregator bootstrap (N=3): 2/3/3.
+ * Malformed / non-positive entries are ignored (the default for that level is kept).
+ */
+function parseSlashThresholds(raw?: string): { WARNING: number; MINOR: number; MAJOR: number } {
+  const out = { WARNING: 2, MINOR: 3, MAJOR: 3 };
+  if (!raw) return out;
+  for (const pair of raw.split(",")) {
+    const [k, v] = pair.split(":").map(s => s.trim());
+    const n = parseInt(v, 10);
+    if ((k === "WARNING" || k === "MINOR" || k === "MAJOR") && Number.isFinite(n) && n > 0) {
+      out[k] = n;
+    }
+  }
+  return out;
 }

--- a/src/modules/audit/audit.module.ts
+++ b/src/modules/audit/audit.module.ts
@@ -1,16 +1,50 @@
 import { Module } from "@nestjs/common";
+import { ConfigModule, ConfigService } from "@nestjs/config";
 import { AuditService } from "./audit.service.js";
 import { AuditController } from "./audit.controller.js";
 import { BlockchainModule } from "../blockchain/blockchain.module.js";
+import { GossipModule } from "../gossip/gossip.module.js";
+import { BlsModule } from "../bls/bls.module.js";
+import { NodeModule } from "../node/node.module.js";
+import { GossipService } from "../gossip/gossip.service.js";
+import { BlsService } from "../bls/bls.service.js";
+import { NodeService } from "../node/node.service.js";
+import { BlockchainService } from "../blockchain/blockchain.service.js";
+import { IQuorumCoSigner, PendingSlotCoSigner, QUORUM_COSIGNER } from "./slash-consensus.js";
+import { GossipQuorumCoSigner } from "./gossip-quorum-cosigner.js";
 
 /**
- * DVT Phase 2 (目标2) — autonomous operator audit module (increment 1). Reuses the shared
- * BlockchainService (single provider/wallet) for all chain reads/writes.
+ * DVT Phase 2 (目标2) — autonomous operator audit module. Reuses the shared BlockchainService
+ * (single provider/wallet) for all chain reads/writes.
+ *
+ * The quorum co-signer is FACTORY-provided (inc-2 live): an ARMED node (AUDIT_EXECUTE_SLASH=true)
+ * gets the real gossip-based BLS aggregator (GossipQuorumCoSigner, wired to GossipService); a
+ * disarmed node gets the fail-closed PendingSlotCoSigner default. The co-signer self-checks
+ * slot/peer availability at coSign time and throws (audit degrades to file+archive) if unavailable.
+ * DI is one-way: AuditModule imports GossipModule/BlsModule/NodeModule — not the reverse.
  */
 @Module({
-  imports: [BlockchainModule],
+  imports: [BlockchainModule, GossipModule, BlsModule, NodeModule, ConfigModule],
   controllers: [AuditController],
-  providers: [AuditService],
+  providers: [
+    AuditService,
+    {
+      provide: QUORUM_COSIGNER,
+      useFactory: (
+        config: ConfigService,
+        gossip: GossipService,
+        bls: BlsService,
+        node: NodeService,
+        blockchain: BlockchainService
+      ): IQuorumCoSigner => {
+        if (config.get<boolean>("auditExecuteSlash") === true) {
+          return new GossipQuorumCoSigner(gossip, bls, node, blockchain, config);
+        }
+        return new PendingSlotCoSigner();
+      },
+      inject: [ConfigService, GossipService, BlsService, NodeService, BlockchainService],
+    },
+  ],
   exports: [AuditService],
 })
 export class AuditModule {}

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -3,6 +3,7 @@ import { AuditService } from "./audit.service.js";
 import { IProofArchive, SlashProof, computeProofHash } from "./proof-archive.js";
 import {
   IQuorumCoSigner,
+  CoSignRequest,
   buildQueueMessageHash,
   buildExecuteMessageHash,
   encodeProof,
@@ -97,16 +98,20 @@ function makeBlockchain(
   };
 }
 
-/** A deterministic mock quorum co-signer that always succeeds (fixed mask + sig). */
+/** A deterministic mock quorum co-signer that always succeeds (fixed mask + sig). It records the
+ *  messageHash of each structured CoSignRequest so existing assertions on `calls[i]` still hold. */
 function makeCoSigner(
   signerMask = 0b111n,
   sigG2 = "0x" + "ab".repeat(64)
-): IQuorumCoSigner & { calls: string[] } {
+): IQuorumCoSigner & { calls: string[]; requests: CoSignRequest[] } {
   const calls: string[] = [];
+  const requests: CoSignRequest[] = [];
   return {
     calls,
-    async coSign(messageHash: string) {
-      calls.push(messageHash);
+    requests,
+    async coSign(req: CoSignRequest) {
+      calls.push(req.messageHash);
+      requests.push(req);
       return { signerMask, sigG2 };
     },
   };

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -326,14 +326,21 @@ describe("AuditService", () => {
     expect(sourceNames).toContain(`IxPNTsToken(${APNTS_TOKEN}).getDebt`);
     expect(sourceNames).toContain("SuperPaymaster.getAvailableCredit");
 
-    // proofHash is a real content address over ON-CHAIN identity: recomputing matches.
+    // proofHash is a real content address over the FULL ON-CHAIN identity: recomputing matches.
     const recomputed = computeProofHash({
       chainId: proof.chainId,
       operator: proof.operator,
       rule: proof.evidence.rule,
       creditLimit: proof.evidence.threshold,
+      availableCredit: "0", // over-limit ⇒ SP-enforced availableCredit is 0
       debt: proof.evidence.observed,
       violationBlock: proof.evidence.violationBlock,
+      violationBlockHash: proof.evidence.violationBlockHash!,
+      slashLevel: proof.slashLevel,
+      registry: ethers.getAddress(REGISTRY),
+      superPaymaster: ethers.getAddress(SUPER_PAYMASTER),
+      dvtValidator: ethers.getAddress(DVT_VALIDATOR),
+      apntsToken: ethers.getAddress(APNTS_TOKEN),
     });
     expect(recomputed).toBe(proof.proofHash);
     expect(proof.proofHash).toMatch(/^0x[0-9a-f]{64}$/);
@@ -434,11 +441,18 @@ describe("AuditService", () => {
     const archive = makeArchive();
     const identityHash = computeProofHash({
       chainId: 11155111,
-      operator: OPERATOR,
+      operator: ethers.getAddress(OPERATOR),
       rule: "credit-over-limit",
       creditLimit: "1000",
+      availableCredit: "0",
       debt: "2000",
       violationBlock: BLOCK,
+      violationBlockHash: BLOCK_HASH,
+      slashLevel: 1,
+      registry: ethers.getAddress(REGISTRY),
+      superPaymaster: ethers.getAddress(SUPER_PAYMASTER),
+      dvtValidator: ethers.getAddress(DVT_VALIDATOR),
+      apntsToken: ethers.getAddress(APNTS_TOKEN),
     });
     (archive.records as SlashProof[]).push({ proofHash: identityHash } as SlashProof);
     const svc = makeService(blockchain, makeConfig(), archive);

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -1,6 +1,11 @@
 import { ethers } from "ethers";
 import { AuditService } from "./audit.service.js";
-import { IProofArchive, SlashProof, computeProofHash } from "./proof-archive.js";
+import {
+  IProofArchive,
+  SlashProof,
+  computeProofHash,
+  PROOF_SCHEMA_VERSION,
+} from "./proof-archive.js";
 import {
   IQuorumCoSigner,
   CoSignRequest,
@@ -328,6 +333,7 @@ describe("AuditService", () => {
 
     // proofHash is a real content address over the FULL ON-CHAIN identity: recomputing matches.
     const recomputed = computeProofHash({
+      proofSchemaVersion: PROOF_SCHEMA_VERSION,
       chainId: proof.chainId,
       operator: proof.operator,
       rule: proof.evidence.rule,
@@ -335,7 +341,6 @@ describe("AuditService", () => {
       availableCredit: "0", // over-limit ⇒ SP-enforced availableCredit is 0
       debt: proof.evidence.observed,
       violationBlock: proof.evidence.violationBlock,
-      violationBlockHash: proof.evidence.violationBlockHash!,
       slashLevel: proof.slashLevel,
       registry: ethers.getAddress(REGISTRY),
       superPaymaster: ethers.getAddress(SUPER_PAYMASTER),
@@ -440,6 +445,7 @@ describe("AuditService", () => {
     // Pre-seed the archive with the exact proof for this violation@block.
     const archive = makeArchive();
     const identityHash = computeProofHash({
+      proofSchemaVersion: PROOF_SCHEMA_VERSION,
       chainId: 11155111,
       operator: ethers.getAddress(OPERATOR),
       rule: "credit-over-limit",
@@ -447,7 +453,6 @@ describe("AuditService", () => {
       availableCredit: "0",
       debt: "2000",
       violationBlock: BLOCK,
-      violationBlockHash: BLOCK_HASH,
       slashLevel: 1,
       registry: ethers.getAddress(REGISTRY),
       superPaymaster: ethers.getAddress(SUPER_PAYMASTER),

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -11,7 +11,7 @@ import { ethers } from "ethers";
 import { BlockchainService } from "../blockchain/blockchain.service.js";
 import { CapabilityRegistry } from "../capability/capability-registry.service.js";
 import type { IProofArchive, SlashProof, EvidenceSource, ProofIdentity } from "./proof-archive.js";
-import { LocalProofArchive, computeProofHash } from "./proof-archive.js";
+import { LocalProofArchive, computeProofHash, PROOF_SCHEMA_VERSION } from "./proof-archive.js";
 import type { IQuorumCoSigner, CoSignRequest, CoSignVerifier } from "./slash-consensus.js";
 import {
   SlashLevel,
@@ -663,16 +663,14 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
 
       if (!this.isCreditOverLimit(creditLimit, availableCredit, debt)) return NO;
 
-      // Re-read the pinned block's hash (part of the content-address, LOW). Fail closed if it
-      // cannot be read — this node then cannot reproduce the requester's proofHash, so it refuses.
-      const violationBlockHash = await this.blockchainService.getBlockHash(blockTag);
-      if (!violationBlockHash) return NO;
-
       // Re-derive the content-address from the SAME on-chain identity (wall-clock-free), so it
       // equals the requester's proofHash for the identical violation. Every slash-critical input —
-      // availableCredit, slashLevel, block hash, and the source contract/token addresses — is
-      // committed, so evidenceHash is a full content address of exactly what would be slashed.
+      // availableCredit, slashLevel, and the source contract/token addresses — is committed at the
+      // FINALIZED block, so evidenceHash is a full content address of exactly what would be slashed.
+      // No block-HEADER read is needed (finding-2): reorg-safety comes from the finality-pinned
+      // `epoch`, so a non-archive node that cannot read an old header still reproduces this proofHash.
       const identity: ProofIdentity = {
+        proofSchemaVersion: PROOF_SCHEMA_VERSION,
         chainId: this.chainId,
         operator,
         rule: RULE_CREDIT_OVER_LIMIT,
@@ -680,7 +678,6 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
         availableCredit: availableCredit.toString(),
         debt: (debt as bigint).toString(),
         violationBlock: blockTag,
-        violationBlockHash,
         slashLevel: SLASH_LEVEL_CREDIT_OVER_LIMIT,
         registry: this.normalizeAddress(this.registryAddress),
         superPaymaster: this.normalizeAddress(this.superPaymasterAddress),
@@ -724,6 +721,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     // Content-address IDENTITY = ON-CHAIN facts only (no wall-clock). Two DVT nodes seeing
     // the same violation at the same block derive the same proofHash + proposalId.
     const identity: ProofIdentity = {
+      proofSchemaVersion: PROOF_SCHEMA_VERSION,
       chainId: this.chainId,
       operator: v.operator,
       rule: v.rule,
@@ -731,7 +729,6 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       availableCredit: v.availableCredit.toString(),
       debt: v.debt.toString(),
       violationBlock: v.violationBlock,
-      violationBlockHash: v.violationBlockHash,
       slashLevel: v.slashLevel,
       registry: this.normalizeAddress(this.registryAddress),
       superPaymaster: this.normalizeAddress(this.superPaymasterAddress),
@@ -1108,6 +1105,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       try {
         queueMessageHash = buildQueueMessageHash(operator, slashLevel, epoch, this.chainId);
         const cosign = await this.coSigner.coSign({
+          proofSchemaVersion: PROOF_SCHEMA_VERSION,
           step: "queue",
           operator,
           slashLevel,
@@ -1180,6 +1178,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
             evidenceHash
           );
           const cosign = await this.coSigner.coSign({
+            proofSchemaVersion: PROOF_SCHEMA_VERSION,
             step: "execute",
             operator,
             slashLevel,

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -1,4 +1,5 @@
 import {
+  Inject,
   Injectable,
   Logger,
   Optional,
@@ -11,10 +12,11 @@ import { BlockchainService } from "../blockchain/blockchain.service.js";
 import { CapabilityRegistry } from "../capability/capability-registry.service.js";
 import type { IProofArchive, SlashProof, EvidenceSource, ProofIdentity } from "./proof-archive.js";
 import { LocalProofArchive, computeProofHash } from "./proof-archive.js";
-import type { IQuorumCoSigner } from "./slash-consensus.js";
+import type { IQuorumCoSigner, CoSignRequest, CoSignVerifier } from "./slash-consensus.js";
 import {
   SlashLevel,
   PendingSlotCoSigner,
+  QUORUM_COSIGNER,
   buildQueueMessageHash,
   buildExecuteMessageHash,
   encodeProof,
@@ -146,7 +148,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     /** Test seam: injectable archive; defaults to a LocalProofArchive at auditProofDir. */
     @Optional() archive?: IProofArchive,
     /** Injected quorum co-signer; defaults to the deferred PendingSlotCoSigner (fails closed). */
-    @Optional() coSigner?: IQuorumCoSigner
+    @Optional() @Inject(QUORUM_COSIGNER) coSigner?: IQuorumCoSigner
   ) {
     this.enabled = config.get<boolean>("auditEnabled") === true;
     this.intervalMs = config.get<number>("auditIntervalMs") ?? 60_000;
@@ -253,6 +255,17 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
         return;
       }
     }
+    // Wire the gossip quorum co-sign responder (inc-2 live). When the injected co-signer is the
+    // live GossipQuorumCoSigner (armed node), hand it the independent violation verifier and let
+    // it register its responder handler on GossipService, so this armed node re-verifies + co-signs
+    // peer slash requests from first principles even if it never itself requests. A no-op on the
+    // disarmed PendingSlotCoSigner default (no `arm` method).
+    const armable = this.coSigner as Partial<{ arm: (v: CoSignVerifier) => void }>;
+    if (typeof armable.arm === "function") {
+      armable.arm(req => this.verifyViolationForCoSign(req));
+      this.logger.log("DVT audit: gossip quorum co-sign responder ARMED");
+    }
+
     // Phase-jitter the first tick across [0, intervalMs) so redundant auditors that boot
     // together don't all file the same proposal in the same window.
     const jitterMs = this.computeJitterMs();
@@ -568,6 +581,90 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
    */
   private async readOperatorDebt(operator: string, blockTag: number): Promise<bigint | null> {
     return this.blockchainService.getDebt(this.apntsTokenAddress, operator, blockTag);
+  }
+
+  /**
+   * Pure credit-over-limit predicate — the SINGLE rule decision shared by the audit tick's
+   * detection (auditOperator) and the co-sign responder's independent re-confirmation
+   * (verifyViolationForCoSign), so a peer confirms EXACTLY the condition the requester detected
+   * (no rule drift). Mirrors the inline checks in auditOperator: null debt / creditLimit==0 /
+   * availableCredit>0 / debt<=limit / under-margin all resolve to `false` (not a violation).
+   */
+  private isCreditOverLimit(
+    creditLimit: bigint,
+    availableCredit: bigint,
+    debt: bigint | null
+  ): boolean {
+    if (debt === null) return false;
+    if (creditLimit === 0n) return false;
+    if (availableCredit > 0n) return false;
+    if (!(debt > creditLimit)) return false;
+    const usageBps = (debt * 10_000n) / creditLimit;
+    if (usageBps < this.creditThresholdBps) return false;
+    return true;
+  }
+
+  /**
+   * The RESPONDER-side independent violation re-confirmation (inc-2 live). Given a peer's co-sign
+   * request, re-read the operator's on-chain state PINNED at `epoch` (= the violationBlock) and
+   * re-apply this node's OWN credit-over-limit rule, then re-derive the content-address. Returns
+   * `{ confirmed, proofHash }`; the responder compares the proofHash against the request's
+   * evidenceHash for the execute step (the innocent-operator defense). Fail-closed: an
+   * un-watchlisted operator, a chain/level mismatch, an unreadable debt, or any RPC error resolves
+   * to `{ confirmed: false, proofHash: null }` — this node then refuses to co-sign.
+   */
+  async verifyViolationForCoSign(
+    req: CoSignRequest
+  ): Promise<{ confirmed: boolean; proofHash: string | null }> {
+    const NO = { confirmed: false, proofHash: null };
+    try {
+      // Bind to THIS node's chain + rule: a request for another chain or a slashLevel this node's
+      // rule never assigns cannot be confirmed (the messageHash recompute already catches chain,
+      // this is defense-in-depth + the queue-step level check).
+      if (req.chainId !== this.chainId) return NO;
+      if (req.slashLevel !== SLASH_LEVEL_CREDIT_OVER_LIMIT) return NO;
+
+      let operator: string;
+      try {
+        operator = ethers.getAddress(req.operator);
+      } catch {
+        return NO;
+      }
+      if (!this.watchlist.includes(operator)) return NO;
+
+      const blockTag = req.epoch;
+      if (!Number.isInteger(blockTag) || blockTag < 0) return NO;
+
+      // Re-read the SAME rule inputs the tick reads, pinned at the epoch block.
+      const [creditLimit, availableCredit, debt] = await Promise.all([
+        this.blockchainService.getCreditLimit(this.registryAddress, operator, blockTag),
+        this.blockchainService.getAvailableCredit(
+          this.superPaymasterAddress,
+          operator,
+          this.apntsTokenAddress,
+          blockTag
+        ),
+        this.readOperatorDebt(operator, blockTag),
+      ]);
+
+      if (!this.isCreditOverLimit(creditLimit, availableCredit, debt)) return NO;
+
+      // Re-derive the content-address from the SAME on-chain identity (wall-clock-free), so it
+      // equals the requester's proofHash for the identical violation.
+      const identity: ProofIdentity = {
+        chainId: this.chainId,
+        operator,
+        rule: RULE_CREDIT_OVER_LIMIT,
+        creditLimit: creditLimit.toString(),
+        debt: (debt as bigint).toString(),
+        violationBlock: blockTag,
+      };
+      return { confirmed: true, proofHash: computeProofHash(identity) };
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`verifyViolationForCoSign refused (indeterminate): ${msg}`);
+      return NO;
+    }
   }
 
   /**
@@ -974,7 +1071,15 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     if (armed) {
       try {
         queueMessageHash = buildQueueMessageHash(operator, slashLevel, epoch, this.chainId);
-        const cosign = await this.coSigner.coSign(queueMessageHash);
+        const cosign = await this.coSigner.coSign({
+          step: "queue",
+          operator,
+          slashLevel,
+          epoch,
+          chainId: this.chainId,
+          evidenceHash,
+          messageHash: queueMessageHash,
+        });
         const encoded = encodeProof(cosign.signerMask, cosign.sigG2);
         queueTx = await this.blockchainService.queueSlashWithProof(
           this.dvtValidatorAddress,
@@ -1038,7 +1143,16 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
             this.chainId,
             evidenceHash
           );
-          const cosign = await this.coSigner.coSign(execMsgHash);
+          const cosign = await this.coSigner.coSign({
+            step: "execute",
+            operator,
+            slashLevel,
+            epoch,
+            chainId: this.chainId,
+            proposalId: proposalId.toString(),
+            evidenceHash,
+            messageHash: execMsgHash,
+          });
           const encoded = encodeProof(cosign.signerMask, cosign.sigG2);
           executeTx = await this.blockchainService.executeSlashWithProof(
             this.dvtValidatorAddress,

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -321,6 +321,19 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
   }
 
   /**
+   * Checksum-normalize a config address for the content-address identity so two DVT nodes with
+   * differently-cased AUDIT_* addresses still derive the SAME proofHash (LOW). Falls back to the raw
+   * string if it is not a valid address (bootstrap already gates existence, so this is defensive).
+   */
+  private normalizeAddress(addr: string): string {
+    try {
+      return ethers.getAddress(addr);
+    } catch {
+      return addr;
+    }
+  }
+
+  /**
    * Record (in-memory only) that an on-chain slash EXECUTED for this operator+rule so the armed
    * execute path does not re-slash the same ongoing condition on later ticks. Bounded by a
    * defensive LRU-style cap. Durability across restart is handled separately via the archive
@@ -565,6 +578,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       reason,
       rule: RULE_CREDIT_OVER_LIMIT,
       creditLimit,
+      availableCredit,
       debt,
       violationBlock,
       violationBlockHash,
@@ -649,15 +663,29 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
 
       if (!this.isCreditOverLimit(creditLimit, availableCredit, debt)) return NO;
 
+      // Re-read the pinned block's hash (part of the content-address, LOW). Fail closed if it
+      // cannot be read — this node then cannot reproduce the requester's proofHash, so it refuses.
+      const violationBlockHash = await this.blockchainService.getBlockHash(blockTag);
+      if (!violationBlockHash) return NO;
+
       // Re-derive the content-address from the SAME on-chain identity (wall-clock-free), so it
-      // equals the requester's proofHash for the identical violation.
+      // equals the requester's proofHash for the identical violation. Every slash-critical input —
+      // availableCredit, slashLevel, block hash, and the source contract/token addresses — is
+      // committed, so evidenceHash is a full content address of exactly what would be slashed.
       const identity: ProofIdentity = {
         chainId: this.chainId,
         operator,
         rule: RULE_CREDIT_OVER_LIMIT,
         creditLimit: creditLimit.toString(),
+        availableCredit: availableCredit.toString(),
         debt: (debt as bigint).toString(),
         violationBlock: blockTag,
+        violationBlockHash,
+        slashLevel: SLASH_LEVEL_CREDIT_OVER_LIMIT,
+        registry: this.normalizeAddress(this.registryAddress),
+        superPaymaster: this.normalizeAddress(this.superPaymasterAddress),
+        dvtValidator: this.normalizeAddress(this.dvtValidatorAddress),
+        apntsToken: this.normalizeAddress(this.apntsTokenAddress),
       };
       return { confirmed: true, proofHash: computeProofHash(identity) };
     } catch (err: unknown) {
@@ -678,6 +706,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     reason: string;
     rule: string;
     creditLimit: bigint;
+    availableCredit: bigint;
     debt: bigint;
     violationBlock: number;
     violationBlockHash: string;
@@ -699,8 +728,15 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       operator: v.operator,
       rule: v.rule,
       creditLimit: v.creditLimit.toString(),
+      availableCredit: v.availableCredit.toString(),
       debt: v.debt.toString(),
       violationBlock: v.violationBlock,
+      violationBlockHash: v.violationBlockHash,
+      slashLevel: v.slashLevel,
+      registry: this.normalizeAddress(this.registryAddress),
+      superPaymaster: this.normalizeAddress(this.superPaymasterAddress),
+      dvtValidator: this.normalizeAddress(this.dvtValidatorAddress),
+      apntsToken: this.normalizeAddress(this.apntsTokenAddress),
     };
     const proofHash = computeProofHash(identity);
 

--- a/src/modules/audit/gossip-quorum-cosigner.spec.ts
+++ b/src/modules/audit/gossip-quorum-cosigner.spec.ts
@@ -11,6 +11,7 @@ import {
   buildSignerMask,
 } from "./slash-consensus.js";
 import type { CoSignRequestPayload, CoSignResponsePayload } from "../gossip/gossip.interfaces.js";
+import { PROOF_SCHEMA_VERSION } from "./proof-archive.js";
 import { bls, sigs, BLS_DST } from "../../utils/bls.util.js";
 
 /**
@@ -56,16 +57,38 @@ async function signOver(privHex: string, messageHash: string): Promise<string> {
   return (await signPoint(privHex, messageHash)).toHex();
 }
 
-/** On-chain slot registry mock: slot i (1-indexed) → PRIVS[i-1]. */
-function makeBlockchain(slotCount = 3) {
+/** The validator EOA the mock binds to a 1-indexed slot (matches getValidatorAtSlot below). */
+function validatorAddr(slot: number): string {
+  return ethers.getAddress("0x" + String(slot).padStart(2, "0").repeat(20));
+}
+
+/**
+ * On-chain slot registry mock: slot i (1-indexed) → validatorAddr(i) with BLS key PRIVS[i-1].
+ * `ownSlot` sets what getWalletAddress reports as THIS node's operator EOA (finding-3: resolveOwnSlot
+ * now looks its slot up via getRegisteredSlot(operatorEoa), not a BLS-key scan). Omit `ownSlot` to
+ * simulate a node with no wallet / no registered slot.
+ */
+function makeBlockchain(slotCount = 3, ownSlot?: number) {
   return {
     async getValidatorAtSlot(_addr: string, slot: number): Promise<string | null> {
-      if (slot >= 1 && slot <= slotCount)
-        return ethers.getAddress("0x" + String(slot).padStart(2, "0").repeat(20));
+      if (slot >= 1 && slot <= slotCount) return validatorAddr(slot);
       return null;
     },
     async getBlsPublicKeyAtSlot(_addr: string, slot: number): Promise<string | null> {
       if (slot >= 1 && slot <= slotCount) return uncompressedPub(PRIVS[slot - 1]);
+      return null;
+    },
+    getWalletAddress(): string | null {
+      return ownSlot && ownSlot >= 1 ? validatorAddr(ownSlot) : null;
+    },
+    async getRegisteredSlot(_addr: string, operatorEoa: string): Promise<number | null> {
+      let eoa: string;
+      try {
+        eoa = ethers.getAddress(operatorEoa);
+      } catch {
+        return null;
+      }
+      for (let s = 1; s <= slotCount; s++) if (validatorAddr(s) === eoa) return s;
       return null;
     },
   } as any;
@@ -121,6 +144,7 @@ const ALWAYS_CONFIRM: CoSignVerifier = async req => ({
 function executeReq(overrides: Partial<CoSignRequest> = {}): CoSignRequest {
   const evidenceHash = (overrides.evidenceHash as string) ?? "0x" + "ee".repeat(32);
   const base: CoSignRequest = {
+    proofSchemaVersion: PROOF_SCHEMA_VERSION,
     step: "execute",
     operator: OPERATOR,
     slashLevel: SlashLevel.MINOR,
@@ -168,7 +192,7 @@ describe("GossipQuorumCoSigner", () => {
       makeGossip(peers),
       blsService,
       makeNode(PRIVS[0]),
-      makeBlockchain(),
+      makeBlockchain(3, 1),
       makeConfig()
     );
     cs.arm(ALWAYS_CONFIRM);
@@ -196,7 +220,7 @@ describe("GossipQuorumCoSigner", () => {
       makeGossip(peers),
       blsService,
       makeNode(PRIVS[0]),
-      makeBlockchain(),
+      makeBlockchain(3, 1),
       makeConfig()
     );
     cs.arm(ALWAYS_CONFIRM);
@@ -209,7 +233,7 @@ describe("GossipQuorumCoSigner", () => {
       makeGossip([]),
       blsService,
       makeNode(PRIVS[0]),
-      makeBlockchain(),
+      makeBlockchain(3, 1),
       makeConfig()
     );
     cs.arm(ALWAYS_CONFIRM);
@@ -229,7 +253,7 @@ describe("GossipQuorumCoSigner", () => {
       makeGossip([forged, good]),
       blsService,
       makeNode(PRIVS[0]),
-      makeBlockchain(),
+      makeBlockchain(3, 1),
       makeConfig()
     );
     cs.arm(ALWAYS_CONFIRM);
@@ -245,7 +269,7 @@ describe("GossipQuorumCoSigner", () => {
       makeGossip([spoofed]),
       blsService,
       makeNode(PRIVS[0]),
-      makeBlockchain(),
+      makeBlockchain(3, 1),
       makeConfig()
     );
     cs.arm(ALWAYS_CONFIRM);
@@ -262,7 +286,7 @@ describe("GossipQuorumCoSigner", () => {
       makeGossip([a, b]),
       blsService,
       makeNode(PRIVS[0]),
-      makeBlockchain(),
+      makeBlockchain(3, 1),
       makeConfig()
     );
     cs.arm(ALWAYS_CONFIRM);
@@ -290,7 +314,7 @@ describe("GossipQuorumCoSigner", () => {
       makeGossip([], 0),
       blsService,
       makeNode(PRIVS[0]),
-      makeBlockchain(),
+      makeBlockchain(3, 1),
       makeConfig()
     );
     cs.arm(ALWAYS_CONFIRM);
@@ -316,7 +340,7 @@ describe("GossipQuorumCoSigner", () => {
       makeGossip([]),
       blsService,
       makeNode(PRIVS[0]),
-      makeBlockchain(),
+      makeBlockchain(3, 1),
       makeConfig()
     );
     cs.arm(async () => ({ confirmed: false, proofHash: null }));
@@ -340,7 +364,7 @@ describe("GossipQuorumCoSigner", () => {
       makeGossip(peers),
       blsService,
       makeNode(PRIVS[0]),
-      makeBlockchain(),
+      makeBlockchain(3, 1),
       makeConfig()
     );
     cs.arm(ALWAYS_CONFIRM);
@@ -360,7 +384,7 @@ describe("GossipQuorumCoSigner", () => {
       makeGossip([]),
       blsService,
       makeNode(PRIVS[1], "node-2"),
-      makeBlockchain(),
+      makeBlockchain(3, 2),
       makeConfig()
     );
     cs.arm(ALWAYS_CONFIRM);
@@ -450,9 +474,40 @@ describe("GossipQuorumCoSigner", () => {
     expect(await cs.verifyAndSign(payload(executeReq()))).toBeNull();
   });
 
+  it("finding-1: responder REFUSES a proofSchemaVersion mismatch (explicit, diagnosable)", async () => {
+    // A peer on a DIFFERENT inc-2-live version → refuse EXPLICITLY (would otherwise be a silent
+    // proofHash divergence that quietly loses quorum). Node/wallet at slot 2, everything else valid.
+    const req = executeReq({ proofSchemaVersion: PROOF_SCHEMA_VERSION + 1 });
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[1], "node-2"),
+      makeBlockchain(3, 2),
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    expect(await cs.verifyAndSign(payload(req))).toBeNull();
+  });
+
+  it("finding-1: responder signs when proofSchemaVersion matches", async () => {
+    const req = executeReq({ proofSchemaVersion: PROOF_SCHEMA_VERSION });
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[1], "node-2"),
+      makeBlockchain(3, 2),
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    const resp = await cs.verifyAndSign(payload(req));
+    expect(resp).not.toBeNull();
+    expect(resp!.slot).toBe(2);
+  });
+
   it("responder signs a QUEUE step when evidenceHash matches the re-derived proofHash (MEDIUM 2)", async () => {
     const queueEvidence = "0x" + "cc".repeat(32);
     const queueReq: CoSignRequest = {
+      proofSchemaVersion: PROOF_SCHEMA_VERSION,
       step: "queue",
       operator: OPERATOR,
       slashLevel: SlashLevel.MINOR,
@@ -467,7 +522,7 @@ describe("GossipQuorumCoSigner", () => {
       makeGossip([]),
       blsService,
       makeNode(PRIVS[1], "node-2"),
-      makeBlockchain(),
+      makeBlockchain(3, 2),
       makeConfig()
     );
     cs.arm(async () => ({ confirmed: true, proofHash: queueEvidence }));
@@ -478,6 +533,7 @@ describe("GossipQuorumCoSigner", () => {
 
   it("responder REFUSES a QUEUE step whose evidenceHash mismatches the re-derived proofHash (MEDIUM 2)", async () => {
     const queueReq: CoSignRequest = {
+      proofSchemaVersion: PROOF_SCHEMA_VERSION,
       step: "queue",
       operator: OPERATOR,
       slashLevel: SlashLevel.MINOR,
@@ -501,6 +557,7 @@ describe("GossipQuorumCoSigner", () => {
 
   it("responder REFUSES a QUEUE step with NO evidenceHash at all (MEDIUM 2)", async () => {
     const queueReq: CoSignRequest = {
+      proofSchemaVersion: PROOF_SCHEMA_VERSION,
       step: "queue",
       operator: OPERATOR,
       slashLevel: SlashLevel.MINOR,
@@ -541,72 +598,20 @@ describe("GossipQuorumCoSigner", () => {
     expect(await sigs.verify(agg, msgPoint, aggPub)).toBe(true);
   });
 
-  // ── FINDING 1: own-slot memoization ────────────────────────────────────────────
-  it("finding-1: resolveOwnSlot resolves once then serves from cache across verifyAndSign calls", async () => {
-    const bc = makeBlockchain();
-    let keyCalls = 0;
-    const orig = bc.getBlsPublicKeyAtSlot.bind(bc);
-    bc.getBlsPublicKeyAtSlot = async (addr: string, slot: number) => {
-      keyCalls++;
-      return orig(addr, slot);
+  // ── FINDING 3: own-slot O(1) lookup (getRegisteredSlot, no 13-slot scan) + memoization ──
+  it("finding-3: resolveOwnSlot resolves via ONE getRegisteredSlot read (no slot scan) then caches", async () => {
+    const bc = makeBlockchain(3, 2); // wallet EOA registered at slot 2
+    let registeredSlotCalls = 0;
+    let keyScanCalls = 0;
+    const origReg = bc.getRegisteredSlot.bind(bc);
+    bc.getRegisteredSlot = async (addr: string, eoa: string) => {
+      registeredSlotCalls++;
+      return origReg(addr, eoa);
     };
-    const cs = new GossipQuorumCoSigner(
-      makeGossip([]),
-      blsService,
-      makeNode(PRIVS[1], "node-2"), // own key registered at slot 2
-      bc,
-      makeConfig()
-    );
-    cs.arm(ALWAYS_CONFIRM);
-    const req = executeReq();
-
-    const r1 = await cs.verifyAndSign(payload(req));
-    expect(r1).not.toBeNull();
-    expect(r1!.slot).toBe(2);
-    const afterFirst = keyCalls;
-    expect(afterFirst).toBeGreaterThan(0); // first call actually scanned the slot registry
-
-    const r2 = await cs.verifyAndSign(payload(req));
-    expect(r2).not.toBeNull();
-    expect(r2!.slot).toBe(2);
-    expect(keyCalls).toBe(afterFirst); // second call served the slot from cache — ZERO extra reads
-  });
-
-  it("finding-1: a null (unregistered) resolution is NOT cached — retried on the next call", async () => {
-    let registered = false;
-    const targetKey = uncompressedPub(PRIVS[0]);
-    const bc = {
-      async getBlsPublicKeyAtSlot(_addr: string, slot: number): Promise<string | null> {
-        if (registered && slot === 1) return targetKey;
-        return null;
-      },
-      async getValidatorAtSlot(): Promise<string | null> {
-        return null;
-      },
-    } as any;
-    const cs = new GossipQuorumCoSigner(
-      makeGossip([]),
-      blsService,
-      makeNode(PRIVS[0]),
-      bc,
-      makeConfig()
-    );
-    cs.arm(ALWAYS_CONFIRM);
-
-    // Unregistered → null, and MUST NOT be cached.
-    expect(await (cs as any).resolveOwnSlot(compressedPub(PRIVS[0]))).toBeNull();
-    // A later on-chain registration is picked up on the next resolution (no stale null cache).
-    registered = true;
-    expect(await (cs as any).resolveOwnSlot(compressedPub(PRIVS[0]))).toBe(1);
-  });
-
-  it("finding-1: refreshOwnSlot forces re-resolution of a cached positive slot", async () => {
-    const bc = makeBlockchain();
-    let keyCalls = 0;
-    const orig = bc.getBlsPublicKeyAtSlot.bind(bc);
+    const origKey = bc.getBlsPublicKeyAtSlot.bind(bc);
     bc.getBlsPublicKeyAtSlot = async (addr: string, slot: number) => {
-      keyCalls++;
-      return orig(addr, slot);
+      keyScanCalls++;
+      return origKey(addr, slot);
     };
     const cs = new GossipQuorumCoSigner(
       makeGossip([]),
@@ -616,13 +621,86 @@ describe("GossipQuorumCoSigner", () => {
       makeConfig()
     );
     cs.arm(ALWAYS_CONFIRM);
-    expect(await (cs as any).resolveOwnSlot(compressedPub(PRIVS[1]))).toBe(2);
-    const afterFirst = keyCalls;
-    expect(await (cs as any).resolveOwnSlot(compressedPub(PRIVS[1]))).toBe(2);
-    expect(keyCalls).toBe(afterFirst); // cached
+    const req = executeReq();
+
+    const r1 = await cs.verifyAndSign(payload(req));
+    expect(r1).not.toBeNull();
+    expect(r1!.slot).toBe(2);
+    // ONE getRegisteredSlot read resolved the slot — NOT a 1..maxSlots getBlsPublicKeyAtSlot scan.
+    expect(registeredSlotCalls).toBe(1);
+    expect(keyScanCalls).toBe(0);
+
+    const r2 = await cs.verifyAndSign(payload(req));
+    expect(r2).not.toBeNull();
+    expect(r2!.slot).toBe(2);
+    expect(registeredSlotCalls).toBe(1); // cached — ZERO extra reads
+  });
+
+  it("finding-3: a null (unregistered) resolution is NOT cached — retried on the next call", async () => {
+    let registered = false;
+    const bc = makeBlockchain(3, 2);
+    const origReg = bc.getRegisteredSlot.bind(bc);
+    bc.getRegisteredSlot = async (addr: string, eoa: string) =>
+      registered ? origReg(addr, eoa) : null;
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[1], "node-2"),
+      bc,
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+
+    // Unregistered → null, and MUST NOT be cached.
+    expect(await (cs as any).resolveOwnSlot()).toBeNull();
+    // A later on-chain registration is picked up on the next resolution (no stale null cache).
+    registered = true;
+    expect(await (cs as any).resolveOwnSlot()).toBe(2);
+  });
+
+  it("finding-3: no wallet (getWalletAddress null) → resolveOwnSlot null WITHOUT any RPC", async () => {
+    const bc = makeBlockchain(3); // no ownSlot → getWalletAddress returns null
+    let regCalls = 0;
+    const origReg = bc.getRegisteredSlot.bind(bc);
+    bc.getRegisteredSlot = async (addr: string, eoa: string) => {
+      regCalls++;
+      return origReg(addr, eoa);
+    };
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[1], "node-2"),
+      bc,
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    expect(await (cs as any).resolveOwnSlot()).toBeNull();
+    expect(regCalls).toBe(0); // short-circuits before any on-chain read when there is no wallet
+  });
+
+  it("finding-3: refreshOwnSlot forces re-resolution of a cached positive slot", async () => {
+    const bc = makeBlockchain(3, 2);
+    let regCalls = 0;
+    const origReg = bc.getRegisteredSlot.bind(bc);
+    bc.getRegisteredSlot = async (addr: string, eoa: string) => {
+      regCalls++;
+      return origReg(addr, eoa);
+    };
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[1], "node-2"),
+      bc,
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    expect(await (cs as any).resolveOwnSlot()).toBe(2);
+    expect(regCalls).toBe(1);
+    expect(await (cs as any).resolveOwnSlot()).toBe(2);
+    expect(regCalls).toBe(1); // cached
     cs.refreshOwnSlot();
-    expect(await (cs as any).resolveOwnSlot(compressedPub(PRIVS[1]))).toBe(2);
-    expect(keyCalls).toBeGreaterThan(afterFirst); // forced re-scan after refresh
+    expect(await (cs as any).resolveOwnSlot()).toBe(2);
+    expect(regCalls).toBe(2); // forced re-read after refresh
   });
 
   // ── FINDING 2: validateResponse single on-chain read + per-call cache ───────────

--- a/src/modules/audit/gossip-quorum-cosigner.spec.ts
+++ b/src/modules/audit/gossip-quorum-cosigner.spec.ts
@@ -1,0 +1,496 @@
+import { ethers } from "ethers";
+import { GossipQuorumCoSigner } from "./gossip-quorum-cosigner.js";
+import { BlsService } from "../bls/bls.service.js";
+import { SignerService } from "../signer/signer.service.js";
+import {
+  CoSignRequest,
+  CoSignVerifier,
+  SlashLevel,
+  buildExecuteMessageHash,
+  buildQueueMessageHash,
+  buildSignerMask,
+} from "./slash-consensus.js";
+import type { CoSignRequestPayload, CoSignResponsePayload } from "../gossip/gossip.interfaces.js";
+import { bls, sigs, BLS_DST } from "../../utils/bls.util.js";
+
+/**
+ * inc-2-live — GossipQuorumCoSigner unit tests. Uses REAL BLS keys/signatures so the requester's
+ * cryptographic verification + on-chain binding are exercised for real (mocked GossipService +
+ * BlockchainService supply the transport + slot registry). The single most safety-critical unit.
+ */
+
+const OPERATOR = ethers.getAddress("0x" + "12".repeat(20));
+const CHAIN_ID = 11155111;
+const BLS_AGG = ethers.getAddress("0x" + "aa".repeat(20));
+const EPOCH = 12_345;
+const PROPOSAL_ID = "7";
+
+// Three deterministic BLS keypairs, one per node/slot.
+const PRIVS = ["0x" + "11".repeat(32), "0x" + "22".repeat(32), "0x" + "33".repeat(32)];
+
+// A real BlsService (real SignerService, no Rust) — all crypto is genuine.
+const signerService = new SignerService({ get: () => "local" } as any);
+const blsService = new BlsService({} as any, signerService, undefined);
+
+function privBytes(privHex: string): Uint8Array {
+  const h = privHex.slice(2);
+  const b = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) b[i] = parseInt(h.substr(i * 2, 2), 16);
+  return b;
+}
+
+function compressedPub(privHex: string): string {
+  return "0x" + sigs.getPublicKey(privBytes(privHex)).toHex();
+}
+
+function uncompressedPub(privHex: string): string {
+  return blsService.encodePublicKeyToEIP2537(sigs.getPublicKey(privBytes(privHex))).toLowerCase();
+}
+
+async function signPoint(privHex: string, messageHash: string): Promise<any> {
+  const msgPoint = await bls.G2.hashToCurve(ethers.getBytes(messageHash), { DST: BLS_DST });
+  return sigs.sign(msgPoint, privBytes(privHex));
+}
+
+async function signOver(privHex: string, messageHash: string): Promise<string> {
+  return (await signPoint(privHex, messageHash)).toHex();
+}
+
+/** On-chain slot registry mock: slot i (1-indexed) → PRIVS[i-1]. */
+function makeBlockchain(slotCount = 3) {
+  return {
+    async getValidatorAtSlot(_addr: string, slot: number): Promise<string | null> {
+      if (slot >= 1 && slot <= slotCount)
+        return ethers.getAddress("0x" + String(slot).padStart(2, "0").repeat(20));
+      return null;
+    },
+    async getBlsPublicKeyAtSlot(_addr: string, slot: number): Promise<string | null> {
+      if (slot >= 1 && slot <= slotCount) return uncompressedPub(PRIVS[slot - 1]);
+      return null;
+    },
+  } as any;
+}
+
+function makeNode(privHex: string, nodeId = "node-1") {
+  return {
+    getNodeForSigning: () => ({
+      nodeId,
+      nodeName: nodeId,
+      privateKey: privHex,
+      publicKey: compressedPub(privHex).slice(2),
+      description: "",
+    }),
+  } as any;
+}
+
+function makeConfig(overrides: Record<string, unknown> = {}) {
+  const cfg: Record<string, unknown> = {
+    auditBlsAggregatorAddress: BLS_AGG,
+    auditMaxSlots: 13,
+    auditCoSignTimeoutMs: 1000,
+    auditSlashThresholds: { WARNING: 2, MINOR: 3, MAJOR: 3 },
+    auditExecuteSlash: true,
+    auditWatchlist: [OPERATOR],
+    ...overrides,
+  };
+  return { get: (k: string) => cfg[k] } as any;
+}
+
+/** A gossip mock whose requestCoSignatures returns a fixed set of peer responses. */
+function makeGossip(peerResponses: CoSignResponsePayload[], peers = 2) {
+  return {
+    registered: null as any,
+    registerCoSignHandler(fn: any) {
+      this.registered = fn;
+    },
+    getPeers() {
+      return new Array(peers).fill({ nodeId: "peer" });
+    },
+    async requestCoSignatures(_payload: CoSignRequestPayload, opts: { threshold: number }) {
+      // Emulate the collector: return up to `threshold` distinct responses (or all if fewer).
+      return peerResponses.slice(0, Math.max(opts.threshold, peerResponses.length));
+    },
+  } as any;
+}
+
+const ALWAYS_CONFIRM: CoSignVerifier = async req => ({
+  confirmed: true,
+  proofHash: req.evidenceHash ?? "0x" + "ee".repeat(32),
+});
+
+function executeReq(overrides: Partial<CoSignRequest> = {}): CoSignRequest {
+  const evidenceHash = (overrides.evidenceHash as string) ?? "0x" + "ee".repeat(32);
+  const base: CoSignRequest = {
+    step: "execute",
+    operator: OPERATOR,
+    slashLevel: SlashLevel.MINOR,
+    epoch: EPOCH,
+    chainId: CHAIN_ID,
+    proposalId: PROPOSAL_ID,
+    evidenceHash,
+    messageHash: buildExecuteMessageHash(
+      BigInt(PROPOSAL_ID),
+      OPERATOR,
+      SlashLevel.MINOR,
+      EPOCH,
+      CHAIN_ID,
+      evidenceHash
+    ),
+    ...overrides,
+  };
+  return base;
+}
+
+async function peerResponse(
+  privHex: string,
+  slot: number,
+  messageHash: string,
+  nodeId: string
+): Promise<CoSignResponsePayload> {
+  return {
+    requestId: "req",
+    slot,
+    signerNodeId: nodeId,
+    signerPublicKey: compressedPub(privHex),
+    signatureCompact: await signOver(privHex, messageHash),
+    messageHash,
+  };
+}
+
+describe("GossipQuorumCoSigner", () => {
+  it("happy 3-of-3 execute → signerMask 7n + a re-verifiable aggregate", async () => {
+    const req = executeReq();
+    const peers = [
+      await peerResponse(PRIVS[1], 2, req.messageHash, "node-2"),
+      await peerResponse(PRIVS[2], 3, req.messageHash, "node-3"),
+    ];
+    const cs = new GossipQuorumCoSigner(
+      makeGossip(peers),
+      blsService,
+      makeNode(PRIVS[0]),
+      makeBlockchain(),
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+
+    const { signerMask, sigG2 } = await cs.coSign(req);
+    expect(signerMask).toBe(buildSignerMask([1, 2, 3]));
+    expect(signerMask).toBe(7n);
+    // sigG2 is EIP-2537 (256 bytes = 512 hex).
+    expect(sigG2).toMatch(/^0x[0-9a-f]{512}$/);
+
+    // sigG2 must be EXACTLY the EIP-2537 encoding of the aggregate of the 3 real signatures…
+    const rawSigs = await Promise.all(PRIVS.map(p => signPoint(p, req.messageHash)));
+    const expectedAgg = await blsService.aggregateSignaturesOnly(rawSigs);
+    expect(sigG2).toBe(blsService.encodeToEIP2537(expectedAgg));
+    // …and that aggregate verifies against the summed public keys over hashToCurve(messageHash).
+    const aggPub = PRIVS.map(p => sigs.getPublicKey(privBytes(p))).reduce((acc, pk) => acc.add(pk));
+    const msgPoint = await bls.G2.hashToCurve(ethers.getBytes(req.messageHash), { DST: BLS_DST });
+    expect(await sigs.verify(expectedAgg, msgPoint, aggPub)).toBe(true);
+  });
+
+  it("threshold NOT met (MINOR=3, only 2 signers) → THROWS (never aggregates)", async () => {
+    const req = executeReq();
+    const peers = [await peerResponse(PRIVS[1], 2, req.messageHash, "node-2")];
+    const cs = new GossipQuorumCoSigner(
+      makeGossip(peers),
+      blsService,
+      makeNode(PRIVS[0]),
+      makeBlockchain(),
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    await expect(cs.coSign(req)).rejects.toThrow(/only 2 valid unique-slot/);
+  });
+
+  it("timeout partial (no peer responses) → THROWS", async () => {
+    const req = executeReq();
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[0]),
+      makeBlockchain(),
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    await expect(cs.coSign(req)).rejects.toThrow(/need 3/);
+  });
+
+  it("forged participation: a signature that does not verify is DROPPED → below threshold → THROWS", async () => {
+    const req = executeReq();
+    // node-2 signs a DIFFERENT hash (forged) → its sig won't verify over req.messageHash.
+    const forged = await peerResponse(PRIVS[1], 2, req.messageHash, "node-2");
+    forged.signatureCompact = await signOver(
+      PRIVS[1],
+      buildQueueMessageHash(OPERATOR, 1, EPOCH, CHAIN_ID)
+    );
+    const good = await peerResponse(PRIVS[2], 3, req.messageHash, "node-3");
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([forged, good]),
+      blsService,
+      makeNode(PRIVS[0]),
+      makeBlockchain(),
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    // own(1) + good(3) = 2 valid < 3 (forged dropped).
+    await expect(cs.coSign(req)).rejects.toThrow(/only 2 valid unique-slot/);
+  });
+
+  it("slot↔pubkey mismatch on-chain: a valid sig from a key NOT registered at the claimed slot is DROPPED", async () => {
+    const req = executeReq();
+    // node-3's REAL key/sig, but it claims slot 2 (on-chain slot 2 = node-2's key) → binding fails.
+    const spoofed = await peerResponse(PRIVS[2], 2, req.messageHash, "node-3");
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([spoofed]),
+      blsService,
+      makeNode(PRIVS[0]),
+      makeBlockchain(),
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    // own(1) + spoofed(dropped) = 1 < 3.
+    await expect(cs.coSign(req)).rejects.toThrow(/only 1 valid unique-slot/);
+  });
+
+  it("duplicate slot from two responses counts once (dedup by slot)", async () => {
+    const req = executeReq();
+    // Two DISTINCT nodes both (impossibly) claim slot 2 with slot-2's key → count once.
+    const a = await peerResponse(PRIVS[1], 2, req.messageHash, "node-2a");
+    const b = await peerResponse(PRIVS[1], 2, req.messageHash, "node-2b");
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([a, b]),
+      blsService,
+      makeNode(PRIVS[0]),
+      makeBlockchain(),
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    // own(1) + slot2(once) = 2 < 3.
+    await expect(cs.coSign(req)).rejects.toThrow(/only 2 valid unique-slot/);
+  });
+
+  it("requester with no on-chain slot → THROWS (fail-closed precondition)", async () => {
+    const req = executeReq();
+    // Local node uses a key registered at NO slot (a 4th unregistered key).
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode("0x" + "44".repeat(32)),
+      makeBlockchain(3),
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    await expect(cs.coSign(req)).rejects.toThrow(/no on-chain validator slot/);
+  });
+
+  it("requester with no gossip peers → THROWS", async () => {
+    const req = executeReq();
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([], 0),
+      blsService,
+      makeNode(PRIVS[0]),
+      makeBlockchain(),
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    await expect(cs.coSign(req)).rejects.toThrow(/no gossip peers/);
+  });
+
+  it("disarmed (AUDIT_EXECUTE_SLASH=false) → coSign THROWS", async () => {
+    const req = executeReq();
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[0]),
+      makeBlockchain(),
+      makeConfig({ auditExecuteSlash: false })
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    await expect(cs.coSign(req)).rejects.toThrow(/not armed/);
+  });
+
+  it("requester cannot independently confirm the violation → THROWS", async () => {
+    const req = executeReq();
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[0]),
+      makeBlockchain(),
+      makeConfig()
+    );
+    cs.arm(async () => ({ confirmed: false, proofHash: null }));
+    await expect(cs.coSign(req)).rejects.toThrow(/could not independently confirm/);
+  });
+
+  it("WARNING threshold is 2 → own + 1 peer suffices", async () => {
+    const req = executeReq({
+      slashLevel: SlashLevel.WARNING,
+      messageHash: buildExecuteMessageHash(
+        BigInt(PROPOSAL_ID),
+        OPERATOR,
+        SlashLevel.WARNING,
+        EPOCH,
+        CHAIN_ID,
+        "0x" + "ee".repeat(32)
+      ),
+    });
+    const peers = [await peerResponse(PRIVS[1], 2, req.messageHash, "node-2")];
+    const cs = new GossipQuorumCoSigner(
+      makeGossip(peers),
+      blsService,
+      makeNode(PRIVS[0]),
+      makeBlockchain(),
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    const { signerMask } = await cs.coSign(req);
+    expect(signerMask).toBe(buildSignerMask([1, 2]));
+    expect(signerMask).toBe(3n);
+  });
+
+  // ── RESPONDER gate (verifyAndSign) ─────────────────────────────────────────────
+  function payload(req: CoSignRequest): CoSignRequestPayload {
+    return { ...req, requestId: "rid", requesterNodeId: "requester" };
+  }
+
+  it("responder signs on FULL agreement (own slot 2)", async () => {
+    const req = executeReq();
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[1], "node-2"),
+      makeBlockchain(),
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    const resp = await cs.verifyAndSign(payload(req));
+    expect(resp).not.toBeNull();
+    expect(resp!.slot).toBe(2);
+    expect(resp!.messageHash).toBe(req.messageHash);
+    // The returned signature verifies over the recomputed hash.
+    const sig = sigs.Signature.fromHex(resp!.signatureCompact.replace(/^0x/, ""));
+    const pk = bls.G1.Point.fromHex(resp!.signerPublicKey.replace(/^0x/, ""));
+    const msgPoint = await bls.G2.hashToCurve(ethers.getBytes(req.messageHash), { DST: BLS_DST });
+    expect(await sigs.verify(sig, msgPoint, pk)).toBe(true);
+  });
+
+  it("responder REFUSES when disarmed (AUDIT_EXECUTE_SLASH=false)", async () => {
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[1], "node-2"),
+      makeBlockchain(),
+      makeConfig({ auditExecuteSlash: false })
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    expect(await cs.verifyAndSign(payload(executeReq()))).toBeNull();
+  });
+
+  it("responder REFUSES an un-watchlisted operator", async () => {
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[1], "node-2"),
+      makeBlockchain(),
+      makeConfig({ auditWatchlist: [] })
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    expect(await cs.verifyAndSign(payload(executeReq()))).toBeNull();
+  });
+
+  it("responder REFUSES a messageHash that does not match the recompute (never trusts it)", async () => {
+    const req = executeReq({ messageHash: "0x" + "de".repeat(32) });
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[1], "node-2"),
+      makeBlockchain(),
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    expect(await cs.verifyAndSign(payload(req))).toBeNull();
+  });
+
+  it("responder REFUSES when re-derived proofHash != evidenceHash (execute innocent-operator defense)", async () => {
+    const req = executeReq();
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[1], "node-2"),
+      makeBlockchain(),
+      makeConfig()
+    );
+    // Verifier confirms but returns a DIFFERENT proofHash than the bound evidenceHash.
+    cs.arm(async () => ({ confirmed: true, proofHash: "0x" + "ba".repeat(32) }));
+    expect(await cs.verifyAndSign(payload(req))).toBeNull();
+  });
+
+  it("responder REFUSES when the violation is indeterminate (verifier not confirmed)", async () => {
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[1], "node-2"),
+      makeBlockchain(),
+      makeConfig()
+    );
+    cs.arm(async () => ({ confirmed: false, proofHash: null }));
+    expect(await cs.verifyAndSign(payload(executeReq()))).toBeNull();
+  });
+
+  it("responder REFUSES when it has no on-chain slot", async () => {
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode("0x" + "44".repeat(32), "node-x"), // unregistered key
+      makeBlockchain(3),
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    expect(await cs.verifyAndSign(payload(executeReq()))).toBeNull();
+  });
+
+  it("responder confirms a QUEUE step (no evidenceHash binding required)", async () => {
+    const queueReq: CoSignRequest = {
+      step: "queue",
+      operator: OPERATOR,
+      slashLevel: SlashLevel.MINOR,
+      epoch: EPOCH,
+      chainId: CHAIN_ID,
+      messageHash: buildQueueMessageHash(OPERATOR, SlashLevel.MINOR, EPOCH, CHAIN_ID),
+    };
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[1], "node-2"),
+      makeBlockchain(),
+      makeConfig()
+    );
+    cs.arm(async () => ({ confirmed: true, proofHash: "0x" + "cc".repeat(32) }));
+    const resp = await cs.verifyAndSign(payload(queueReq));
+    expect(resp).not.toBeNull();
+    expect(resp!.slot).toBe(2);
+  });
+
+  // ── sigG2 aggregate round-trip (256B, re-verifies) ──────────────────────────────
+  it("sigG2 aggregate round-trips: 3 real sigs → EIP-2537 256B → re-verifies", async () => {
+    const messageHash = buildExecuteMessageHash(
+      1n,
+      OPERATOR,
+      SlashLevel.MINOR,
+      EPOCH,
+      CHAIN_ID,
+      "0x" + "ee".repeat(32)
+    );
+    const msgPoint = await bls.G2.hashToCurve(ethers.getBytes(messageHash), { DST: BLS_DST });
+    const rawSigs = PRIVS.map(p => sigs.sign(msgPoint, privBytes(p)));
+    const agg = await blsService.aggregateSignaturesOnly(rawSigs);
+    const sigG2 = blsService.encodeToEIP2537(agg);
+    expect(sigG2).toMatch(/^0x[0-9a-f]{512}$/); // 256 bytes (uncompressed EIP-2537 G2)
+
+    // The aggregate point verifies against the summed public keys (the on-chain BLS.pairing check
+    // does the equivalent over these exact bytes via the EIP-2537 precompiles).
+    const aggPub = PRIVS.map(p => sigs.getPublicKey(privBytes(p))).reduce((acc, pk) => acc.add(pk));
+    expect(await sigs.verify(agg, msgPoint, aggPub)).toBe(true);
+  });
+});

--- a/src/modules/audit/gossip-quorum-cosigner.spec.ts
+++ b/src/modules/audit/gossip-quorum-cosigner.spec.ts
@@ -540,4 +540,153 @@ describe("GossipQuorumCoSigner", () => {
     const aggPub = PRIVS.map(p => sigs.getPublicKey(privBytes(p))).reduce((acc, pk) => acc.add(pk));
     expect(await sigs.verify(agg, msgPoint, aggPub)).toBe(true);
   });
+
+  // ── FINDING 1: own-slot memoization ────────────────────────────────────────────
+  it("finding-1: resolveOwnSlot resolves once then serves from cache across verifyAndSign calls", async () => {
+    const bc = makeBlockchain();
+    let keyCalls = 0;
+    const orig = bc.getBlsPublicKeyAtSlot.bind(bc);
+    bc.getBlsPublicKeyAtSlot = async (addr: string, slot: number) => {
+      keyCalls++;
+      return orig(addr, slot);
+    };
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[1], "node-2"), // own key registered at slot 2
+      bc,
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    const req = executeReq();
+
+    const r1 = await cs.verifyAndSign(payload(req));
+    expect(r1).not.toBeNull();
+    expect(r1!.slot).toBe(2);
+    const afterFirst = keyCalls;
+    expect(afterFirst).toBeGreaterThan(0); // first call actually scanned the slot registry
+
+    const r2 = await cs.verifyAndSign(payload(req));
+    expect(r2).not.toBeNull();
+    expect(r2!.slot).toBe(2);
+    expect(keyCalls).toBe(afterFirst); // second call served the slot from cache — ZERO extra reads
+  });
+
+  it("finding-1: a null (unregistered) resolution is NOT cached — retried on the next call", async () => {
+    let registered = false;
+    const targetKey = uncompressedPub(PRIVS[0]);
+    const bc = {
+      async getBlsPublicKeyAtSlot(_addr: string, slot: number): Promise<string | null> {
+        if (registered && slot === 1) return targetKey;
+        return null;
+      },
+      async getValidatorAtSlot(): Promise<string | null> {
+        return null;
+      },
+    } as any;
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[0]),
+      bc,
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+
+    // Unregistered → null, and MUST NOT be cached.
+    expect(await (cs as any).resolveOwnSlot(compressedPub(PRIVS[0]))).toBeNull();
+    // A later on-chain registration is picked up on the next resolution (no stale null cache).
+    registered = true;
+    expect(await (cs as any).resolveOwnSlot(compressedPub(PRIVS[0]))).toBe(1);
+  });
+
+  it("finding-1: refreshOwnSlot forces re-resolution of a cached positive slot", async () => {
+    const bc = makeBlockchain();
+    let keyCalls = 0;
+    const orig = bc.getBlsPublicKeyAtSlot.bind(bc);
+    bc.getBlsPublicKeyAtSlot = async (addr: string, slot: number) => {
+      keyCalls++;
+      return orig(addr, slot);
+    };
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[1], "node-2"),
+      bc,
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    expect(await (cs as any).resolveOwnSlot(compressedPub(PRIVS[1]))).toBe(2);
+    const afterFirst = keyCalls;
+    expect(await (cs as any).resolveOwnSlot(compressedPub(PRIVS[1]))).toBe(2);
+    expect(keyCalls).toBe(afterFirst); // cached
+    cs.refreshOwnSlot();
+    expect(await (cs as any).resolveOwnSlot(compressedPub(PRIVS[1]))).toBe(2);
+    expect(keyCalls).toBeGreaterThan(afterFirst); // forced re-scan after refresh
+  });
+
+  // ── FINDING 2: validateResponse single on-chain read + per-call cache ───────────
+  it("finding-2: validateResponse does NOT call getValidatorAtSlot separately", async () => {
+    const req = executeReq();
+    const bc = makeBlockchain();
+    let validatorCalls = 0;
+    bc.getValidatorAtSlot = async (): Promise<string | null> => {
+      validatorCalls++;
+      return null; // would REJECT if validateResponse still relied on it
+    };
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[0]),
+      bc,
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    const resp = await peerResponse(PRIVS[1], 2, req.messageHash, "node-2");
+    // Still valid (getBlsPublicKeyAtSlot non-null already implies live+active validator)…
+    expect(await (cs as any).validateResponse(req, resp)).toBe(true);
+    // …and getValidatorAtSlot was never separately invoked.
+    expect(validatorCalls).toBe(0);
+  });
+
+  it("finding-2: two same-slot responses in one coSign call read getBlsPublicKeyAtSlot ONCE (cache hit)", async () => {
+    const req = executeReq();
+    const bc = makeBlockchain();
+    let keyCalls = 0;
+    const orig = bc.getBlsPublicKeyAtSlot.bind(bc);
+    bc.getBlsPublicKeyAtSlot = async (addr: string, slot: number) => {
+      keyCalls++;
+      return orig(addr, slot);
+    };
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[0]),
+      bc,
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    const cache = new Map<number, string | null>();
+    const a = await peerResponse(PRIVS[1], 2, req.messageHash, "node-2a");
+    const b = await peerResponse(PRIVS[1], 2, req.messageHash, "node-2b");
+    expect(await (cs as any).validateResponse(req, a, cache)).toBe(true);
+    expect(await (cs as any).validateResponse(req, b, cache)).toBe(true);
+    expect(keyCalls).toBe(1); // second same-slot validation served from the shared per-call cache
+  });
+
+  it("finding-2: a slot whose getBlsPublicKeyAtSlot returns null is rejected", async () => {
+    const req = executeReq();
+    const bc = makeBlockchain(3);
+    bc.getBlsPublicKeyAtSlot = async (): Promise<string | null> => null;
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[0]),
+      bc,
+      makeConfig()
+    );
+    cs.arm(ALWAYS_CONFIRM);
+    const resp = await peerResponse(PRIVS[1], 2, req.messageHash, "node-2");
+    expect(await (cs as any).validateResponse(req, resp)).toBe(false);
+  });
 });

--- a/src/modules/audit/gossip-quorum-cosigner.spec.ts
+++ b/src/modules/audit/gossip-quorum-cosigner.spec.ts
@@ -450,7 +450,56 @@ describe("GossipQuorumCoSigner", () => {
     expect(await cs.verifyAndSign(payload(executeReq()))).toBeNull();
   });
 
-  it("responder confirms a QUEUE step (no evidenceHash binding required)", async () => {
+  it("responder signs a QUEUE step when evidenceHash matches the re-derived proofHash (MEDIUM 2)", async () => {
+    const queueEvidence = "0x" + "cc".repeat(32);
+    const queueReq: CoSignRequest = {
+      step: "queue",
+      operator: OPERATOR,
+      slashLevel: SlashLevel.MINOR,
+      epoch: EPOCH,
+      chainId: CHAIN_ID,
+      // The queue request now CARRIES evidenceHash (the on-chain 5-field preimage still excludes it;
+      // this only makes a queue quorum form when every signer agrees on the same evidence).
+      evidenceHash: queueEvidence,
+      messageHash: buildQueueMessageHash(OPERATOR, SlashLevel.MINOR, EPOCH, CHAIN_ID),
+    };
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[1], "node-2"),
+      makeBlockchain(),
+      makeConfig()
+    );
+    cs.arm(async () => ({ confirmed: true, proofHash: queueEvidence }));
+    const resp = await cs.verifyAndSign(payload(queueReq));
+    expect(resp).not.toBeNull();
+    expect(resp!.slot).toBe(2);
+  });
+
+  it("responder REFUSES a QUEUE step whose evidenceHash mismatches the re-derived proofHash (MEDIUM 2)", async () => {
+    const queueReq: CoSignRequest = {
+      step: "queue",
+      operator: OPERATOR,
+      slashLevel: SlashLevel.MINOR,
+      epoch: EPOCH,
+      chainId: CHAIN_ID,
+      evidenceHash: "0x" + "cc".repeat(32), // attacker-attached bogus evidence
+      messageHash: buildQueueMessageHash(OPERATOR, SlashLevel.MINOR, EPOCH, CHAIN_ID),
+    };
+    const cs = new GossipQuorumCoSigner(
+      makeGossip([]),
+      blsService,
+      makeNode(PRIVS[1], "node-2"),
+      makeBlockchain(),
+      makeConfig()
+    );
+    // Verifier confirms the real violation but re-derives a DIFFERENT proofHash than the bogus
+    // evidenceHash attached to the queue request → the responder refuses to co-sign.
+    cs.arm(async () => ({ confirmed: true, proofHash: "0x" + "dd".repeat(32) }));
+    expect(await cs.verifyAndSign(payload(queueReq))).toBeNull();
+  });
+
+  it("responder REFUSES a QUEUE step with NO evidenceHash at all (MEDIUM 2)", async () => {
     const queueReq: CoSignRequest = {
       step: "queue",
       operator: OPERATOR,
@@ -467,9 +516,7 @@ describe("GossipQuorumCoSigner", () => {
       makeConfig()
     );
     cs.arm(async () => ({ confirmed: true, proofHash: "0x" + "cc".repeat(32) }));
-    const resp = await cs.verifyAndSign(payload(queueReq));
-    expect(resp).not.toBeNull();
-    expect(resp!.slot).toBe(2);
+    expect(await cs.verifyAndSign(payload(queueReq))).toBeNull();
   });
 
   // ── sigG2 aggregate round-trip (256B, re-verifies) ──────────────────────────────

--- a/src/modules/audit/gossip-quorum-cosigner.ts
+++ b/src/modules/audit/gossip-quorum-cosigner.ts
@@ -1,0 +1,350 @@
+import { Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { ethers } from "ethers";
+import { v4 as uuidv4 } from "uuid";
+import { GossipService } from "../gossip/gossip.service.js";
+import type { CoSignRequestPayload, CoSignResponsePayload } from "../gossip/gossip.interfaces.js";
+import { BlsService } from "../bls/bls.service.js";
+import { NodeService } from "../node/node.service.js";
+import { BlockchainService } from "../blockchain/blockchain.service.js";
+import { bls, sigs } from "../../utils/bls.util.js";
+import {
+  CoSignRequest,
+  CoSignVerifier,
+  IQuorumCoSigner,
+  MAX_VALIDATORS,
+  SlashLevel,
+  buildSignerMask,
+  recomputeMessageHash,
+} from "./slash-consensus.js";
+
+/**
+ * DVT Phase 2 (目标2, inc-2 live) — the REAL gossip-based BLS quorum co-signer.
+ *
+ * This is the most safety-critical code in the system: its aggregate proof drives a real,
+ * irreversible on-chain GToken slash. It is DEFENSIVE and FAIL-CLOSED at every step — any
+ * uncertainty (unarmed node, un-watchlisted operator, hash mismatch, unconfirmable violation,
+ * unresolved slot, invalid signature, on-chain binding mismatch, or under-threshold count)
+ * results in a refusal (responder) or a throw (requester → the audit degrades to file+archive).
+ *
+ * Two roles, one gate:
+ *   • RESPONDER (`verifyAndSign`): every armed node re-derives the messageHash from the structured
+ *     request AND independently re-confirms the violation from its OWN on-chain read at the epoch
+ *     block, then signs ONLY on full agreement. Registered on GossipService at bootstrap so an
+ *     armed node responds even if it never itself requests.
+ *   • REQUESTER (`coSign`): the auditing node self-contributes (must independently agree), gathers
+ *     peer signatures over gossip, cryptographically verifies + on-chain-binds EVERY response, and
+ *     aggregates ONLY when a strict per-severity threshold of unique on-chain slots is met — never
+ *     submitting an under-threshold proof that would revert.
+ */
+export class GossipQuorumCoSigner implements IQuorumCoSigner {
+  private readonly logger = new Logger(GossipQuorumCoSigner.name);
+
+  private readonly blsAggregatorAddress: string;
+  private readonly maxSlots: number;
+  private readonly timeoutMs: number;
+  private readonly slashThresholds: { WARNING: number; MINOR: number; MAJOR: number };
+  private readonly executeSlash: boolean;
+  /** Canonicalized watchlist — the responder refuses to co-sign for any operator not on it. */
+  private readonly watchlist: string[];
+
+  /** Independent violation re-confirmation, wired by AuditService via `arm()`. */
+  private verifier: CoSignVerifier | null = null;
+
+  constructor(
+    private readonly gossip: GossipService,
+    private readonly blsService: BlsService,
+    private readonly nodeService: NodeService,
+    private readonly blockchain: BlockchainService,
+    config: ConfigService
+  ) {
+    this.blsAggregatorAddress = config.get<string>("auditBlsAggregatorAddress") ?? "";
+    const maxSlots = config.get<number>("auditMaxSlots") ?? MAX_VALIDATORS;
+    this.maxSlots =
+      Number.isInteger(maxSlots) && maxSlots > 0 && maxSlots <= MAX_VALIDATORS
+        ? maxSlots
+        : MAX_VALIDATORS;
+    this.timeoutMs = config.get<number>("auditCoSignTimeoutMs") ?? 15_000;
+    this.slashThresholds = config.get<{ WARNING: number; MINOR: number; MAJOR: number }>(
+      "auditSlashThresholds"
+    ) ?? { WARNING: 2, MINOR: 3, MAJOR: 3 };
+    this.executeSlash = config.get<boolean>("auditExecuteSlash") === true;
+    this.watchlist = (config.get<string[]>("auditWatchlist") ?? [])
+      .map(a => a.trim())
+      .filter(Boolean)
+      .map(a => {
+        try {
+          return ethers.getAddress(a);
+        } catch {
+          return null;
+        }
+      })
+      .filter((a): a is string => a !== null);
+  }
+
+  /**
+   * Wire the independent violation verifier and register the responder handler on GossipService.
+   * Called by AuditService at bootstrap so every armed node responds. Idempotent-safe.
+   */
+  arm(verifier: CoSignVerifier): void {
+    this.verifier = verifier;
+    this.gossip.registerCoSignHandler(payload => this.verifyAndSign(payload));
+    this.logger.log("Gossip quorum co-sign responder registered (armed)");
+  }
+
+  // ── RESPONDER ───────────────────────────────────────────────────────────────────
+
+  /**
+   * The peer gate. Returns a signed CoSignResponsePayload ONLY when every check passes; ANY
+   * failure or uncertainty returns `null` (silent, fail-closed refusal). Order:
+   *   1. local node armed (AUDIT_EXECUTE_SLASH)               — else refuse.
+   *   2. operator on the local watchlist                      — else refuse.
+   *   3. recompute messageHash locally, assert == request     — NEVER trust the requester's hash.
+   *   4. independent violation confirmation at `epoch` block  — proofHash === evidenceHash (execute).
+   *   5. resolve own on-chain validator slot                  — else refuse.
+   *   6. BLS-sign the LOCALLY-recomputed hash.
+   */
+  async verifyAndSign(req: CoSignRequestPayload): Promise<CoSignResponsePayload | null> {
+    try {
+      // 1. must be armed.
+      if (!this.executeSlash) return null;
+      if (!this.verifier) return null;
+
+      // 2. operator must be watchlisted.
+      let operator: string;
+      try {
+        operator = ethers.getAddress(req.operator);
+      } catch {
+        return null;
+      }
+      if (!this.watchlist.includes(operator)) return null;
+
+      // 3. recompute the messageHash from first principles; NEVER trust req.messageHash.
+      let localHash: string;
+      try {
+        localHash = recomputeMessageHash(req);
+      } catch {
+        return null;
+      }
+      if (localHash.toLowerCase() !== String(req.messageHash).toLowerCase()) return null;
+
+      // 4. independent violation confirmation (re-read on-chain at the epoch block).
+      const { confirmed, proofHash } = await this.verifier(req);
+      if (!confirmed || proofHash === null) return null;
+      if (req.step === "execute") {
+        // The linchpin "innocent-operator" defense: a substituted operator yields a different
+        // proofHash, so the execute co-sign only signs when our re-derived proofHash matches the
+        // evidenceHash bound into the preimage.
+        if (
+          typeof req.evidenceHash !== "string" ||
+          proofHash.toLowerCase() !== req.evidenceHash.toLowerCase()
+        ) {
+          return null;
+        }
+      }
+
+      // 5. resolve own on-chain validator slot (by our own BLS key).
+      const node = this.nodeService.getNodeForSigning();
+      const ownCompressed = await this.blsService.getPublicKeyFromPrivateKey(node.privateKey);
+      const slot = await this.resolveOwnSlot(ownCompressed);
+      if (slot === null) return null;
+
+      // 6. sign the locally-recomputed hash.
+      const sig = await this.blsService.signDerivedHash(localHash, node);
+      if (typeof sig.signatureCompact !== "string" || typeof sig.publicKey !== "string") {
+        return null; // fail-closed: cannot produce a valid response without both
+      }
+      return {
+        requestId: req.requestId,
+        slot,
+        signerNodeId: node.nodeId,
+        signerPublicKey: sig.publicKey,
+        signatureCompact: sig.signatureCompact,
+        messageHash: localHash,
+      };
+    } catch (error) {
+      this.logger.warn(
+        `verifyAndSign refused (unexpected error): ${error instanceof Error ? error.message : String(error)}`
+      );
+      return null;
+    }
+  }
+
+  // ── REQUESTER ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Gather a threshold quorum of peer signatures over the request's messageHash, validate every
+   * one cryptographically + on-chain-bind it to a registered slot, and aggregate into the SP wire
+   * proof (signerMask + EIP-2537 sigG2). THROWS on any precondition failure or when fewer than the
+   * per-severity threshold of valid unique-slot signatures are collected — so the audit degrades
+   * to file+archive and NEVER submits an under-threshold proof that would revert / double-slash.
+   */
+  async coSign(req: CoSignRequest): Promise<{ signerMask: bigint; sigG2: string }> {
+    // Fail-closed preconditions.
+    if (!this.executeSlash) {
+      throw new Error("gossip co-sign: node is not armed (AUDIT_EXECUTE_SLASH!=true)");
+    }
+    if (!this.verifier) {
+      throw new Error("gossip co-sign: responder/verifier not wired");
+    }
+    const node = this.nodeService.getNodeForSigning();
+    const ownCompressed = await this.blsService.getPublicKeyFromPrivateKey(node.privateKey);
+    const ownSlot = await this.resolveOwnSlot(ownCompressed);
+    if (ownSlot === null) {
+      throw new Error("gossip co-sign: local node has no on-chain validator slot — refusing");
+    }
+    if (this.gossip.getPeers().length === 0) {
+      throw new Error("gossip co-sign: no gossip peers available to reach quorum");
+    }
+
+    const threshold = this.thresholdFor(req.slashLevel);
+
+    // Self-contribution: the requester must independently agree via the SAME responder gate.
+    const own = await this.verifyAndSign({
+      ...req,
+      requestId: uuidv4(),
+      requesterNodeId: node.nodeId,
+    });
+    if (own === null) {
+      throw new Error(
+        "gossip co-sign: local node could not independently confirm the violation — refusing"
+      );
+    }
+
+    // Request peer signatures over gossip. The requester needs `threshold - 1` MORE (its own
+    // contribution counts), so ask peers for that many; 0 resolves immediately.
+    const requestId = uuidv4();
+    const payload: CoSignRequestPayload = { ...req, requestId, requesterNodeId: node.nodeId };
+    const peerThreshold = Math.max(0, threshold - 1);
+    const peerResponses = await this.gossip.requestCoSignatures(payload, {
+      threshold: peerThreshold,
+      timeoutMs: this.timeoutMs,
+    });
+
+    // Validate EVERY response (own + peers) before counting its bit. Dedup by slot.
+    const bySlot = new Map<number, { pubkey: string; sigCompact: string }>();
+    for (const resp of [own, ...peerResponses]) {
+      if (!(await this.validateResponse(req, resp))) continue;
+      if (!bySlot.has(resp.slot)) {
+        bySlot.set(resp.slot, { pubkey: resp.signerPublicKey, sigCompact: resp.signatureCompact });
+      }
+    }
+
+    // STRICT threshold enforcement: below → THROW (no aggregation, no on-chain call).
+    if (bySlot.size < threshold) {
+      throw new Error(
+        `gossip co-sign: only ${bySlot.size} valid unique-slot signature(s), need ${threshold} ` +
+          `for slashLevel ${req.slashLevel} — refusing (never submit under-threshold proof)`
+      );
+    }
+
+    // Aggregate: parse compact G2 sigs → aggregate → EIP-2537 sigG2; signerMask over the slots.
+    const slots = [...bySlot.keys()].sort((a, b) => a - b);
+    const signatures = slots.map(s => sigs.Signature.fromHex(strip0x(bySlot.get(s)!.sigCompact)));
+    const aggregate = await this.blsService.aggregateSignaturesOnly(signatures);
+    const sigG2 = this.blsService.encodeToEIP2537(aggregate);
+    const signerMask = buildSignerMask(slots);
+    this.logger.warn(
+      `Gossip quorum co-sign OK: ${slots.length} signers (slots ${slots.join(",")}), ` +
+        `signerMask=${signerMask} for ${req.step} slash of ${req.operator}`
+    );
+    return { signerMask, sigG2 };
+  }
+
+  // ── Internal helpers ────────────────────────────────────────────────────────────
+
+  /**
+   * Cryptographically verify a co-sign response AND bind it to the on-chain validator set. All of:
+   *   - slot in range,
+   *   - response messageHash === the locally recomputed hash,
+   *   - signatureCompact verifies against signerPublicKey over hashToCurve(messageHash),
+   *   - signerPublicKey === the on-chain key registered at that slot (uncompressed EIP-2537),
+   *   - the slot resolves to a non-zero on-chain validator.
+   * Any failure / error → false (the signature is dropped, never counted).
+   */
+  private async validateResponse(
+    req: CoSignRequest,
+    resp: CoSignResponsePayload
+  ): Promise<boolean> {
+    try {
+      if (!resp || typeof resp.slot !== "number") return false;
+      if (!Number.isInteger(resp.slot) || resp.slot < 1 || resp.slot > this.maxSlots) return false;
+      if (typeof resp.signerPublicKey !== "string" || typeof resp.signatureCompact !== "string") {
+        return false;
+      }
+
+      // The response MUST commit to the exact hash we recompute — never the requester's copy.
+      const expected = recomputeMessageHash(req);
+      if (String(resp.messageHash).toLowerCase() !== expected.toLowerCase()) return false;
+
+      // Cryptographic verification of the compact G2 signature over hashToCurve(messageHash).
+      const signature = sigs.Signature.fromHex(strip0x(resp.signatureCompact));
+      const publicKey = bls.G1.Point.fromHex(strip0x(resp.signerPublicKey));
+      const msgPoint = await this.blsService.hashMessageToCurve(expected);
+      const valid = await this.blsService.verifySignature(signature, msgPoint, publicKey);
+      if (!valid) return false;
+
+      // On-chain binding: the returned key MUST be the one registered at the claimed slot, and
+      // the slot MUST resolve to a live validator. Closes the "valid sig from an unregistered key
+      // claiming a slot" hole.
+      const onchainKey = await this.blockchain.getBlsPublicKeyAtSlot(
+        this.blsAggregatorAddress,
+        resp.slot
+      );
+      if (!onchainKey) return false;
+      const respUncompressed = this.uncompressedFromCompressed(resp.signerPublicKey);
+      if (onchainKey.toLowerCase() !== respUncompressed.toLowerCase()) return false;
+      const validator = await this.blockchain.getValidatorAtSlot(
+        this.blsAggregatorAddress,
+        resp.slot
+      );
+      if (!validator) return false;
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Resolve THIS node's own slot by matching its BLS key (uncompressed EIP-2537) against the
+   * on-chain key registered at each slot. Ties the slot directly to the key we actually sign with,
+   * so the requester's on-chain binding of our response cannot mismatch. `null` when unregistered.
+   */
+  private async resolveOwnSlot(compressedPubKey: string): Promise<number | null> {
+    let ownUncompressed: string;
+    try {
+      ownUncompressed = this.uncompressedFromCompressed(compressedPubKey).toLowerCase();
+    } catch {
+      return null;
+    }
+    for (let slot = 1; slot <= this.maxSlots; slot++) {
+      const onchain = await this.blockchain.getBlsPublicKeyAtSlot(this.blsAggregatorAddress, slot);
+      if (onchain && onchain.toLowerCase() === ownUncompressed) return slot;
+    }
+    return null;
+  }
+
+  /** Compressed 48-byte G1 (0x-hex) → uncompressed EIP-2537 128-byte (0x-hex). */
+  private uncompressedFromCompressed(compressed: string): string {
+    const point = bls.G1.Point.fromHex(strip0x(compressed));
+    return this.blsService.encodePublicKeyToEIP2537(point);
+  }
+
+  /** Per-severity quorum threshold (WARNING 2, MINOR/MAJOR 3 at N=3), from config with defaults. */
+  private thresholdFor(slashLevel: number): number {
+    const map = this.slashThresholds;
+    let value: number | undefined;
+    if (slashLevel === SlashLevel.WARNING) value = map.WARNING;
+    else if (slashLevel === SlashLevel.MINOR) value = map.MINOR;
+    else if (slashLevel === SlashLevel.MAJOR) value = map.MAJOR;
+    if (typeof value === "number" && Number.isInteger(value) && value > 0) return value;
+    // Defensive default when the table is malformed / the level is unknown.
+    return slashLevel === SlashLevel.WARNING ? 2 : 3;
+  }
+}
+
+/** Strip an optional 0x prefix. */
+function strip0x(hex: string): string {
+  return hex.startsWith("0x") ? hex.slice(2) : hex;
+}

--- a/src/modules/audit/gossip-quorum-cosigner.ts
+++ b/src/modules/audit/gossip-quorum-cosigner.ts
@@ -131,16 +131,18 @@ export class GossipQuorumCoSigner implements IQuorumCoSigner {
       // 4. independent violation confirmation (re-read on-chain at the epoch block).
       const { confirmed, proofHash } = await this.verifier(req);
       if (!confirmed || proofHash === null) return null;
-      if (req.step === "execute") {
-        // The linchpin "innocent-operator" defense: a substituted operator yields a different
-        // proofHash, so the execute co-sign only signs when our re-derived proofHash matches the
-        // evidenceHash bound into the preimage.
-        if (
-          typeof req.evidenceHash !== "string" ||
-          proofHash.toLowerCase() !== req.evidenceHash.toLowerCase()
-        ) {
-          return null;
-        }
+      // The linchpin "innocent-operator" / "bogus-evidence" defense (MEDIUM 2): bind evidenceHash
+      // for BOTH the queue AND the execute step. The request MUST carry an evidenceHash equal to the
+      // proofHash we independently re-derived. For execute this stops a substituted operator (the
+      // on-chain preimage already includes evidenceHash). For queue — whose 5-field on-chain preimage
+      // does NOT include evidenceHash — this still means a queue quorum only FORMS when every signer
+      // agrees on the same evidence, so a malicious requester cannot get a real queue quorum while
+      // attaching a bogus evidenceHash and submitting a spurious queue tx (gas / pending-state churn).
+      if (
+        typeof req.evidenceHash !== "string" ||
+        proofHash.toLowerCase() !== req.evidenceHash.toLowerCase()
+      ) {
+        return null;
       }
 
       // 5. resolve own on-chain validator slot (by our own BLS key).
@@ -216,9 +218,15 @@ export class GossipQuorumCoSigner implements IQuorumCoSigner {
     const requestId = uuidv4();
     const payload: CoSignRequestPayload = { ...req, requestId, requesterNodeId: node.nodeId };
     const peerThreshold = Math.max(0, threshold - 1);
+    // MEDIUM 1: hand the collector the SAME per-response validation (crypto + on-chain slot binding)
+    // and a slot-based dedup key, so ONLY validated, unique-slot peer responses count toward the
+    // collector's early-resolve — a peer cannot flood bogus responses to crowd out honest signers.
+    // coSign still re-validates + re-dedups the returned set below (idempotent defense-in-depth).
     const peerResponses = await this.gossip.requestCoSignatures(payload, {
       threshold: peerThreshold,
       timeoutMs: this.timeoutMs,
+      validate: resp => this.validateResponse(req, resp),
+      dedupKey: resp => resp.slot,
     });
 
     // Validate EVERY response (own + peers) before counting its bit. Dedup by slot.

--- a/src/modules/audit/gossip-quorum-cosigner.ts
+++ b/src/modules/audit/gossip-quorum-cosigner.ts
@@ -51,6 +51,15 @@ export class GossipQuorumCoSigner implements IQuorumCoSigner {
   /** Independent violation re-confirmation, wired by AuditService via `arm()`. */
   private verifier: CoSignVerifier | null = null;
 
+  /**
+   * Memoized own on-chain slot (finding-1: resolveOwnSlot was a serial 1..maxSlots RPC scan on EVERY
+   * coSign/verifyAndSign). The slot is FIXED on-chain at registerBLSPublicKey, so a POSITIVE result
+   * is cached permanently. A null (node not yet registered at a slot) is NOT cached — it re-resolves
+   * next time so a later registration is picked up. `refreshOwnSlot()` forces re-resolution.
+   */
+  private ownSlot: number | null = null;
+  private ownSlotResolved = false;
+
   constructor(
     private readonly gossip: GossipService,
     private readonly blsService: BlsService,
@@ -218,6 +227,10 @@ export class GossipQuorumCoSigner implements IQuorumCoSigner {
     const requestId = uuidv4();
     const payload: CoSignRequestPayload = { ...req, requestId, requesterNodeId: node.nodeId };
     const peerThreshold = Math.max(0, threshold - 1);
+    // finding-2: one per-coSign-call cache (slot → on-chain uncompressed key) SHARED between the
+    // collector's validate callback and the post-collection defense-in-depth loop, so repeated
+    // same-slot validations within a single coSign hit getBlsPublicKeyAtSlot at most once per slot.
+    const keyCache = new Map<number, string | null>();
     // MEDIUM 1: hand the collector the SAME per-response validation (crypto + on-chain slot binding)
     // and a slot-based dedup key, so ONLY validated, unique-slot peer responses count toward the
     // collector's early-resolve — a peer cannot flood bogus responses to crowd out honest signers.
@@ -225,14 +238,14 @@ export class GossipQuorumCoSigner implements IQuorumCoSigner {
     const peerResponses = await this.gossip.requestCoSignatures(payload, {
       threshold: peerThreshold,
       timeoutMs: this.timeoutMs,
-      validate: resp => this.validateResponse(req, resp),
+      validate: resp => this.validateResponse(req, resp, keyCache),
       dedupKey: resp => resp.slot,
     });
 
     // Validate EVERY response (own + peers) before counting its bit. Dedup by slot.
     const bySlot = new Map<number, { pubkey: string; sigCompact: string }>();
     for (const resp of [own, ...peerResponses]) {
-      if (!(await this.validateResponse(req, resp))) continue;
+      if (!(await this.validateResponse(req, resp, keyCache))) continue;
       if (!bySlot.has(resp.slot)) {
         bySlot.set(resp.slot, { pubkey: resp.signerPublicKey, sigCompact: resp.signatureCompact });
       }
@@ -266,13 +279,20 @@ export class GossipQuorumCoSigner implements IQuorumCoSigner {
    *   - slot in range,
    *   - response messageHash === the locally recomputed hash,
    *   - signatureCompact verifies against signerPublicKey over hashToCurve(messageHash),
-   *   - signerPublicKey === the on-chain key registered at that slot (uncompressed EIP-2537),
-   *   - the slot resolves to a non-zero on-chain validator.
-   * Any failure / error → false (the signature is dropped, never counted).
+   *   - signerPublicKey === the on-chain key registered at that slot (uncompressed EIP-2537).
+   * A NON-NULL getBlsPublicKeyAtSlot ALREADY implies the slot resolves to a non-zero, ACTIVE
+   * validator (it reads validatorAtSlot internally, returns null on the zero address, and checks
+   * isActive), so the previously-separate getValidatorAtSlot call was redundant and is dropped
+   * (finding-2). Any failure / error → false (the signature is dropped, never counted).
+   *
+   * `keyCache` (slot → on-chain key) is an optional PER-coSign-call memo so repeated same-slot
+   * validations within one coSign don't re-hit RPC. `null` is cached too (a null-keyed slot stays
+   * rejected for the whole call).
    */
   private async validateResponse(
     req: CoSignRequest,
-    resp: CoSignResponsePayload
+    resp: CoSignResponsePayload,
+    keyCache?: Map<number, string | null>
   ): Promise<boolean> {
     try {
       if (!resp || typeof resp.slot !== "number") return false;
@@ -292,21 +312,23 @@ export class GossipQuorumCoSigner implements IQuorumCoSigner {
       const valid = await this.blsService.verifySignature(signature, msgPoint, publicKey);
       if (!valid) return false;
 
-      // On-chain binding: the returned key MUST be the one registered at the claimed slot, and
-      // the slot MUST resolve to a live validator. Closes the "valid sig from an unregistered key
-      // claiming a slot" hole.
-      const onchainKey = await this.blockchain.getBlsPublicKeyAtSlot(
-        this.blsAggregatorAddress,
-        resp.slot
-      );
+      // On-chain binding: the returned key MUST be the one registered at the claimed slot. A
+      // non-null getBlsPublicKeyAtSlot already guarantees the slot resolves to a non-zero, ACTIVE
+      // validator (it reads validatorAtSlot + isActive internally), so no separate getValidatorAtSlot
+      // is needed. Memoize per coSign call so two responses for the same slot read RPC only once.
+      let onchainKey: string | null;
+      if (keyCache && keyCache.has(resp.slot)) {
+        onchainKey = keyCache.get(resp.slot) ?? null;
+      } else {
+        onchainKey = await this.blockchain.getBlsPublicKeyAtSlot(
+          this.blsAggregatorAddress,
+          resp.slot
+        );
+        if (keyCache) keyCache.set(resp.slot, onchainKey);
+      }
       if (!onchainKey) return false;
       const respUncompressed = this.uncompressedFromCompressed(resp.signerPublicKey);
       if (onchainKey.toLowerCase() !== respUncompressed.toLowerCase()) return false;
-      const validator = await this.blockchain.getValidatorAtSlot(
-        this.blsAggregatorAddress,
-        resp.slot
-      );
-      if (!validator) return false;
 
       return true;
     } catch {
@@ -320,6 +342,9 @@ export class GossipQuorumCoSigner implements IQuorumCoSigner {
    * so the requester's on-chain binding of our response cannot mismatch. `null` when unregistered.
    */
   private async resolveOwnSlot(compressedPubKey: string): Promise<number | null> {
+    // Serve a previously-resolved POSITIVE slot from cache (finding-1): the on-chain slot is fixed at
+    // registration, so once found it never changes for this key.
+    if (this.ownSlotResolved) return this.ownSlot;
     let ownUncompressed: string;
     try {
       ownUncompressed = this.uncompressedFromCompressed(compressedPubKey).toLowerCase();
@@ -328,9 +353,21 @@ export class GossipQuorumCoSigner implements IQuorumCoSigner {
     }
     for (let slot = 1; slot <= this.maxSlots; slot++) {
       const onchain = await this.blockchain.getBlsPublicKeyAtSlot(this.blsAggregatorAddress, slot);
-      if (onchain && onchain.toLowerCase() === ownUncompressed) return slot;
+      if (onchain && onchain.toLowerCase() === ownUncompressed) {
+        this.ownSlot = slot;
+        this.ownSlotResolved = true;
+        return slot;
+      }
     }
+    // Node not yet registered at any slot: do NOT cache the null — re-resolve next time so a later
+    // registration is picked up.
     return null;
+  }
+
+  /** Force re-resolution of the memoized own slot on the next resolveOwnSlot call. */
+  refreshOwnSlot(): void {
+    this.ownSlot = null;
+    this.ownSlotResolved = false;
   }
 
   /** Compressed 48-byte G1 (0x-hex) → uncompressed EIP-2537 128-byte (0x-hex). */

--- a/src/modules/audit/gossip-quorum-cosigner.ts
+++ b/src/modules/audit/gossip-quorum-cosigner.ts
@@ -8,6 +8,7 @@ import { BlsService } from "../bls/bls.service.js";
 import { NodeService } from "../node/node.service.js";
 import { BlockchainService } from "../blockchain/blockchain.service.js";
 import { bls, sigs } from "../../utils/bls.util.js";
+import { PROOF_SCHEMA_VERSION } from "./proof-archive.js";
 import {
   CoSignRequest,
   CoSignVerifier,
@@ -52,9 +53,10 @@ export class GossipQuorumCoSigner implements IQuorumCoSigner {
   private verifier: CoSignVerifier | null = null;
 
   /**
-   * Memoized own on-chain slot (finding-1: resolveOwnSlot was a serial 1..maxSlots RPC scan on EVERY
-   * coSign/verifyAndSign). The slot is FIXED on-chain at registerBLSPublicKey, so a POSITIVE result
-   * is cached permanently. A null (node not yet registered at a slot) is NOT cached — it re-resolves
+   * Memoized own on-chain slot. resolveOwnSlot is now an O(1) getBLSPublicKey(operatorEoa) read
+   * (finding-3) — the on-chain BLSAggregator returns this validator's slot DIRECTLY, so there is no
+   * 1..maxSlots scan. The slot is FIXED on-chain at registerBLSPublicKey, so a POSITIVE result is
+   * cached permanently. A null (node not yet registered, or no wallet) is NOT cached — it re-resolves
    * next time so a later registration is picked up. `refreshOwnSlot()` forces re-resolution.
    */
   private ownSlot: number | null = null;
@@ -119,6 +121,18 @@ export class GossipQuorumCoSigner implements IQuorumCoSigner {
       if (!this.executeSlash) return null;
       if (!this.verifier) return null;
 
+      // 1b. proof-schema version must match (finding-1). A mixed-version fleet computes DIFFERENT
+      // proofHashes, so co-signing would silently fail to reach quorum with no clear reason. Refuse
+      // EXPLICITLY with a WARNING (fail-closed, safe) so the operator can diagnose + align versions.
+      if (req.proofSchemaVersion !== PROOF_SCHEMA_VERSION) {
+        this.logger.warn(
+          `verifyAndSign refused: proof schema version mismatch: req=${req.proofSchemaVersion} ` +
+            `local=${PROOF_SCHEMA_VERSION} — all DVT nodes must run the same inc-2-live version; ` +
+            `refusing to co-sign`
+        );
+        return null;
+      }
+
       // 2. operator must be watchlisted.
       let operator: string;
       try {
@@ -154,10 +168,9 @@ export class GossipQuorumCoSigner implements IQuorumCoSigner {
         return null;
       }
 
-      // 5. resolve own on-chain validator slot (by our own BLS key).
+      // 5. resolve own on-chain validator slot (O(1) by our own operator EOA, finding-3).
       const node = this.nodeService.getNodeForSigning();
-      const ownCompressed = await this.blsService.getPublicKeyFromPrivateKey(node.privateKey);
-      const slot = await this.resolveOwnSlot(ownCompressed);
+      const slot = await this.resolveOwnSlot();
       if (slot === null) return null;
 
       // 6. sign the locally-recomputed hash.
@@ -199,8 +212,7 @@ export class GossipQuorumCoSigner implements IQuorumCoSigner {
       throw new Error("gossip co-sign: responder/verifier not wired");
     }
     const node = this.nodeService.getNodeForSigning();
-    const ownCompressed = await this.blsService.getPublicKeyFromPrivateKey(node.privateKey);
-    const ownSlot = await this.resolveOwnSlot(ownCompressed);
+    const ownSlot = await this.resolveOwnSlot();
     if (ownSlot === null) {
       throw new Error("gossip co-sign: local node has no on-chain validator slot — refusing");
     }
@@ -337,31 +349,29 @@ export class GossipQuorumCoSigner implements IQuorumCoSigner {
   }
 
   /**
-   * Resolve THIS node's own slot by matching its BLS key (uncompressed EIP-2537) against the
-   * on-chain key registered at each slot. Ties the slot directly to the key we actually sign with,
-   * so the requester's on-chain binding of our response cannot mismatch. `null` when unregistered.
+   * Resolve THIS node's own slot with a SINGLE on-chain read (finding-3): getRegisteredSlot reads
+   * BLSAggregator.getBLSPublicKey(ownOperatorEoa), which returns this validator's slot directly — no
+   * 1..maxSlots scan. The operator EOA is the node's on-chain wallet (the same EOA that registered
+   * the BLS key and submits the slash txs). `null` when there is no wallet or the operator holds no
+   * active slot. The requester still independently binds our returned slot to its on-chain key
+   * (validateResponse), so a slot whose registered key differs from our signing key is rejected there
+   * — safety does not rely on this lookup matching the key.
    */
-  private async resolveOwnSlot(compressedPubKey: string): Promise<number | null> {
-    // Serve a previously-resolved POSITIVE slot from cache (finding-1): the on-chain slot is fixed at
-    // registration, so once found it never changes for this key.
+  private async resolveOwnSlot(): Promise<number | null> {
+    // Serve a previously-resolved POSITIVE slot from cache: the on-chain slot is fixed at
+    // registration, so once found it never changes for this operator.
     if (this.ownSlotResolved) return this.ownSlot;
-    let ownUncompressed: string;
-    try {
-      ownUncompressed = this.uncompressedFromCompressed(compressedPubKey).toLowerCase();
-    } catch {
+    const operatorEoa = this.blockchain.getWalletAddress();
+    if (!operatorEoa) return null; // no wallet → cannot resolve own slot (do NOT cache)
+    const slot = await this.blockchain.getRegisteredSlot(this.blsAggregatorAddress, operatorEoa);
+    if (slot === null) {
+      // Not yet registered at an active slot: do NOT cache the null — re-resolve next time so a
+      // later registration is picked up.
       return null;
     }
-    for (let slot = 1; slot <= this.maxSlots; slot++) {
-      const onchain = await this.blockchain.getBlsPublicKeyAtSlot(this.blsAggregatorAddress, slot);
-      if (onchain && onchain.toLowerCase() === ownUncompressed) {
-        this.ownSlot = slot;
-        this.ownSlotResolved = true;
-        return slot;
-      }
-    }
-    // Node not yet registered at any slot: do NOT cache the null — re-resolve next time so a later
-    // registration is picked up.
-    return null;
+    this.ownSlot = slot;
+    this.ownSlotResolved = true;
+    return slot;
   }
 
   /** Force re-resolution of the memoized own slot on the next resolveOwnSlot call. */

--- a/src/modules/audit/proof-archive.spec.ts
+++ b/src/modules/audit/proof-archive.spec.ts
@@ -1,0 +1,77 @@
+import { ethers } from "ethers";
+import { ProofIdentity, PROOF_SCHEMA_VERSION, computeProofHash } from "./proof-archive.js";
+
+/**
+ * computeProofHash content-address properties (inc-2-live findings 1 + 2).
+ *
+ * The proofHash is the off-chain EVIDENCE content-address (NOT the on-chain slash messageHash). It
+ * must:
+ *   • bind PROOF_SCHEMA_VERSION so a widened identity changes the hash (finding-1 diagnosability);
+ *   • depend ONLY on the finalized-block economic reads, NOT any block HEADER (finding-2 liveness):
+ *     a non-archive responder that cannot read an old block's hash can still reproduce the hash.
+ */
+const OP = ethers.getAddress("0x" + "12".repeat(20));
+
+/** A complete, finalized-block ProofIdentity (no wall-clock, no block header). */
+function identity(overrides: Partial<ProofIdentity> = {}): ProofIdentity {
+  return {
+    proofSchemaVersion: PROOF_SCHEMA_VERSION,
+    chainId: 11155111,
+    operator: OP,
+    rule: "credit-over-limit",
+    creditLimit: "1000",
+    availableCredit: "0",
+    debt: "2000",
+    violationBlock: 777,
+    slashLevel: 1,
+    registry: ethers.getAddress("0x" + "a1".repeat(20)),
+    superPaymaster: ethers.getAddress("0x" + "a2".repeat(20)),
+    dvtValidator: ethers.getAddress("0x" + "a3".repeat(20)),
+    apntsToken: ethers.getAddress("0x" + "a4".repeat(20)),
+    ...overrides,
+  };
+}
+
+describe("computeProofHash", () => {
+  it("is a 32-byte keccak digest", () => {
+    expect(computeProofHash(identity())).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+
+  it("is deterministic for the same identity (cross-node / cross-tick agreement)", () => {
+    expect(computeProofHash(identity())).toBe(computeProofHash(identity()));
+  });
+
+  // ── FINDING 1: version is bound into the hash ──────────────────────────────────
+  it("finding-1: proofHash CHANGES when PROOF_SCHEMA_VERSION changes (version is bound in)", () => {
+    const current = computeProofHash(identity());
+    const bumped = computeProofHash(identity({ proofSchemaVersion: PROOF_SCHEMA_VERSION + 1 }));
+    expect(bumped).not.toBe(current);
+  });
+
+  // ── FINDING 2: no block-header dependency ──────────────────────────────────────
+  it("finding-2: ProofIdentity has NO violationBlockHash field (reorg-safety via finalized block)", () => {
+    // A stray blockHash on the object must NOT perturb the hash: only declared identity fields feed
+    // the content-address, so a non-archive node that cannot read the header still reproduces it.
+    const clean = computeProofHash(identity());
+    const withStrayHash = computeProofHash({
+      ...identity(),
+      // @ts-expect-error violationBlockHash is intentionally NOT part of ProofIdentity anymore.
+      violationBlockHash: "0x" + "cc".repeat(32),
+    });
+    expect(withStrayHash).not.toBe(clean);
+    // And a requester (no stray field) + responder (no stray field) still agree byte-for-byte.
+    expect(computeProofHash(identity())).toBe(clean);
+  });
+
+  it("finding-2: identical economic reads → identical proofHash regardless of the (unhashed) block header", () => {
+    // Two nodes read the SAME finalized-block economics. Neither hashes the header, so they agree
+    // even if one is a non-archive node that could never read the historical block hash.
+    const requester = computeProofHash(identity());
+    const nonArchiveResponder = computeProofHash(identity());
+    expect(nonArchiveResponder).toBe(requester);
+  });
+
+  it("still binds each economic input (a different debt → a different hash)", () => {
+    expect(computeProofHash(identity({ debt: "3000" }))).not.toBe(computeProofHash(identity()));
+  });
+});

--- a/src/modules/audit/proof-archive.ts
+++ b/src/modules/audit/proof-archive.ts
@@ -47,9 +47,9 @@ export interface Evidence {
    * Block HASH of `violationBlock` (finding-3). Pinning the irreversible slash to a
    * finalized block's hash — not just its number — makes the evidence reorg-safe: a
    * reorg that rewrites `violationBlock` would change this hash, so the justification
-   * cannot be silently invalidated. Deliberately EXCLUDED from the content-address
-   * identity (a finalized block's hash is a deterministic function of its number, and
-   * two nodes reading the same finalized number already agree on the hash).
+   * cannot be silently invalidated. Now ALSO part of the content-address identity (LOW):
+   * a finalized block's hash is a deterministic function of its number, so two nodes
+   * reading the same finalized number still derive the same proofHash.
    */
   violationBlockHash?: string;
   /**
@@ -154,10 +154,30 @@ export interface ProofIdentity {
   rule: string;
   /** On-chain credit limit at violationBlock (stringified). */
   creditLimit: string;
+  /** On-chain available credit at violationBlock (stringified) — the SP-enforced ceiling signal. */
+  availableCredit: string;
   /** On-chain debt at violationBlock (stringified). */
   debt: string;
   /** Block all rule inputs were pinned to. */
   violationBlock: number;
+  /**
+   * Block HASH of `violationBlock` (LOW): committing to the finalized block's hash — not just its
+   * number — makes the content-address reorg-evidence. A reorg that rewrites `violationBlock` would
+   * change this hash, so evidenceHash cannot silently point at re-written history. Two nodes reading
+   * the same finalized number still agree (a finalized block's hash is a deterministic function of
+   * its number), so this stays cross-node deterministic and wall-clock-free.
+   */
+  violationBlockHash: string;
+  /** SP #329 SlashLevel bound into the slash preimages — part of the slash-critical identity. */
+  slashLevel: number;
+  /** Registry the credit limit / reputation were read from (checksummed). */
+  registry: string;
+  /** SuperPaymaster the availableCredit was read from (checksummed). */
+  superPaymaster: string;
+  /** DVTValidator the slash proposal/queue/execute target (checksummed). */
+  dvtValidator: string;
+  /** xPNTs token the operator debt was read from (checksummed). */
+  apntsToken: string;
 }
 
 /** Deterministic JSON with recursively sorted keys — a stable content-address preimage. */

--- a/src/modules/audit/proof-archive.ts
+++ b/src/modules/audit/proof-archive.ts
@@ -15,6 +15,17 @@ import { ethers } from "ethers";
  * populated in increment 2 when the multi-node co-sign lands (see AuditService).
  */
 
+/**
+ * Proof-schema version bound into every proofHash (finding-1). BUMP this whenever the
+ * `ProofIdentity` shape (the content-address preimage) changes, so a mixed-version fleet produces
+ * DIFFERENT proofHashes and the co-sign responder can refuse with an EXPLICIT, diagnosable version
+ * mismatch instead of a silent hash divergence that quietly loses quorum. Version 2 widened the
+ * identity (availableCredit / slashLevel / source contract addresses) and — in this increment —
+ * DROPPED `violationBlockHash` from the hash (finding-2). All DVT nodes MUST run the same version:
+ * deploy/upgrade the fleet atomically, never a rolling partial upgrade.
+ */
+export const PROOF_SCHEMA_VERSION = 2;
+
 export interface EvidenceSource {
   /** Where the observation came from: an on-chain `view` read or a decoded `event`. */
   type: "view" | "event";
@@ -44,12 +55,12 @@ export interface Evidence {
    */
   violationBlock: number;
   /**
-   * Block HASH of `violationBlock` (finding-3). Pinning the irreversible slash to a
-   * finalized block's hash — not just its number — makes the evidence reorg-safe: a
-   * reorg that rewrites `violationBlock` would change this hash, so the justification
-   * cannot be silently invalidated. Now ALSO part of the content-address identity (LOW):
-   * a finalized block's hash is a deterministic function of its number, so two nodes
-   * reading the same finalized number still derive the same proofHash.
+   * Block HASH of `violationBlock`, kept for HUMAN forensics ONLY. Deliberately NOT part of the
+   * content-address identity (finding-2): reorg-safety already comes from pinning `violationBlock`
+   * to a FINALIZED block (it won't reorg), so hashing the header in was redundant and only added a
+   * liveness risk — a non-archive node cannot read an old block's header and would then be unable to
+   * reproduce the proofHash. Recording it here (not in ProofIdentity) keeps the forensic trail
+   * without gating co-sign on a historical-header read.
    */
   violationBlockHash?: string;
   /**
@@ -148,6 +159,12 @@ export interface SlashProof {
  * proofHash. This is what makes the archive content-addressed and cross-node de-duplicating.
  */
 export interface ProofIdentity {
+  /**
+   * Proof-schema version (finding-1) — the FIRST field of the identity, bound into proofHash so a
+   * version bump changes the content-address. Lets the co-sign responder diagnose a mixed-version
+   * fleet (explicit refusal) instead of silently computing a divergent hash.
+   */
+  proofSchemaVersion: number;
   chainId: number;
   operator: string;
   /** Rule id, e.g. "credit-over-limit". */
@@ -158,16 +175,13 @@ export interface ProofIdentity {
   availableCredit: string;
   /** On-chain debt at violationBlock (stringified). */
   debt: string;
-  /** Block all rule inputs were pinned to. */
-  violationBlock: number;
   /**
-   * Block HASH of `violationBlock` (LOW): committing to the finalized block's hash — not just its
-   * number — makes the content-address reorg-evidence. A reorg that rewrites `violationBlock` would
-   * change this hash, so evidenceHash cannot silently point at re-written history. Two nodes reading
-   * the same finalized number still agree (a finalized block's hash is a deterministic function of
-   * its number), so this stays cross-node deterministic and wall-clock-free.
+   * Block all rule inputs were pinned to. Reorg-safety comes SOLELY from this being a FINALIZED
+   * block (finding-2): a finalized block won't reorg, so the economic reads pinned to it are stable
+   * and fully content-address the evidence WITHOUT hashing the block header — which a non-archive
+   * node cannot read, so hashing it in only risked liveness.
    */
-  violationBlockHash: string;
+  violationBlock: number;
   /** SP #329 SlashLevel bound into the slash preimages — part of the slash-critical identity. */
   slashLevel: number;
   /** Registry the credit limit / reputation were read from (checksummed). */
@@ -197,7 +211,9 @@ function stableStringify(value: unknown): string {
  * Content-address a detection: keccak256 over the canonical (sorted-key) serialization
  * of its ON-CHAIN identity. Deterministic and wall-clock-free — the same on-chain
  * violation always yields the same hash, which is what makes the archive tamper-evident,
- * de-duplicating, and stable across nodes/ticks.
+ * de-duplicating, and stable across nodes/ticks. Reorg-safety comes from the finality-pinned
+ * `violationBlock` (a finalized block won't reorg), NOT from hashing the block header — so a
+ * non-archive node that cannot read an old header can still reproduce this hash (finding-2).
  */
 export function computeProofHash(identity: ProofIdentity): string {
   return ethers.keccak256(ethers.toUtf8Bytes(stableStringify(identity)));

--- a/src/modules/audit/slash-consensus.spec.ts
+++ b/src/modules/audit/slash-consensus.spec.ts
@@ -2,9 +2,13 @@ import { ethers } from "ethers";
 import {
   SlashLevel,
   QUEUE_SLASH_TAG,
+  MAX_VALIDATORS,
   PendingSlotCoSigner,
+  CoSignRequest,
   buildQueueMessageHash,
   buildExecuteMessageHash,
+  buildSignerMask,
+  recomputeMessageHash,
   encodeProof,
 } from "./slash-consensus.js";
 
@@ -84,10 +88,111 @@ describe("slash-consensus primitives (SP #329)", () => {
     expect(sig).toBe(sigG2);
   });
 
-  it("PendingSlotCoSigner fails closed: coSign throws the deferred-slot error", async () => {
+  it("PendingSlotCoSigner fails closed: coSign(req) throws the disarmed error", async () => {
     const coSigner = new PendingSlotCoSigner();
-    await expect(coSigner.coSign("0x" + "00".repeat(32))).rejects.toThrow(
-      /quorum co-sign deferred.*registerBLSPublicKey.*24h timelock/s
-    );
+    const req: CoSignRequest = {
+      step: "queue",
+      operator: OPERATOR,
+      slashLevel: SlashLevel.MINOR,
+      epoch: 1,
+      chainId: CHAIN_ID,
+      messageHash: "0x" + "00".repeat(32),
+    };
+    await expect(coSigner.coSign(req)).rejects.toThrow(/quorum co-sign deferred.*disarmed/s);
+  });
+
+  // ── buildSignerMask: PINNED bit convention (slot s → bit s-1) ────────────────────
+  describe("buildSignerMask (slot s → bit s-1)", () => {
+    it("matches the pinned reference values", () => {
+      expect(buildSignerMask([1, 2, 3])).toBe(7n);
+      expect(buildSignerMask([1, 2])).toBe(3n);
+      expect(buildSignerMask([1, 3])).toBe(5n);
+      expect(buildSignerMask([2, 3])).toBe(6n);
+      expect(buildSignerMask([1])).toBe(1n);
+      expect(buildSignerMask([13])).toBe(1n << 12n);
+    });
+
+    it("is order-independent and de-duplicates slots", () => {
+      expect(buildSignerMask([3, 1, 2])).toBe(7n);
+      expect(buildSignerMask([2, 2, 3, 3, 1])).toBe(7n);
+    });
+
+    it("empty slot list → 0n", () => {
+      expect(buildSignerMask([])).toBe(0n);
+    });
+
+    it("rejects slot <= 0", () => {
+      expect(() => buildSignerMask([0])).toThrow(/out of range/);
+      expect(() => buildSignerMask([-1])).toThrow(/out of range/);
+    });
+
+    it(`rejects slot > MAX_VALIDATORS (${MAX_VALIDATORS})`, () => {
+      expect(() => buildSignerMask([MAX_VALIDATORS + 1])).toThrow(/out of range/);
+      expect(() => buildSignerMask([1, 2, 99])).toThrow(/out of range/);
+    });
+
+    it("rejects a non-integer slot", () => {
+      expect(() => buildSignerMask([1.5])).toThrow(/out of range/);
+    });
+  });
+
+  // ── recomputeMessageHash: ONE code path for requester + responders ───────────────
+  describe("recomputeMessageHash", () => {
+    it("queue step === buildQueueMessageHash", () => {
+      const req: CoSignRequest = {
+        step: "queue",
+        operator: OPERATOR,
+        slashLevel: SlashLevel.MINOR,
+        epoch: 1_700_000,
+        chainId: CHAIN_ID,
+        evidenceHash: EVIDENCE_HASH,
+        messageHash: "0x00",
+      };
+      expect(recomputeMessageHash(req)).toBe(
+        buildQueueMessageHash(OPERATOR, SlashLevel.MINOR, 1_700_000, CHAIN_ID)
+      );
+    });
+
+    it("execute step === buildExecuteMessageHash", () => {
+      const req: CoSignRequest = {
+        step: "execute",
+        operator: OPERATOR,
+        slashLevel: SlashLevel.MINOR,
+        epoch: 1_700_000,
+        chainId: CHAIN_ID,
+        proposalId: "42",
+        evidenceHash: EVIDENCE_HASH,
+        messageHash: "0x00",
+      };
+      expect(recomputeMessageHash(req)).toBe(
+        buildExecuteMessageHash(42n, OPERATOR, SlashLevel.MINOR, 1_700_000, CHAIN_ID, EVIDENCE_HASH)
+      );
+    });
+
+    it("execute step without proposalId → throws", () => {
+      const req: CoSignRequest = {
+        step: "execute",
+        operator: OPERATOR,
+        slashLevel: SlashLevel.MINOR,
+        epoch: 1,
+        chainId: CHAIN_ID,
+        evidenceHash: EVIDENCE_HASH,
+        messageHash: "0x00",
+      };
+      expect(() => recomputeMessageHash(req)).toThrow(/proposalId/);
+    });
+
+    it("execute step without evidenceHash → throws", () => {
+      const req: CoSignRequest = {
+        step: "execute",
+        operator: OPERATOR,
+        slashLevel: SlashLevel.MINOR,
+        epoch: 1,
+        chainId: CHAIN_ID,
+        proposalId: "7",
+        messageHash: "0x00",
+      };
+      expect(() => recomputeMessageHash(req)).toThrow(/evidenceHash/);
+    });
   });
 });

--- a/src/modules/audit/slash-consensus.spec.ts
+++ b/src/modules/audit/slash-consensus.spec.ts
@@ -11,6 +11,7 @@ import {
   recomputeMessageHash,
   encodeProof,
 } from "./slash-consensus.js";
+import { PROOF_SCHEMA_VERSION } from "./proof-archive.js";
 
 const OPERATOR = ethers.getAddress("0x" + "12".repeat(20));
 const EVIDENCE_HASH = "0x" + "cd".repeat(32);
@@ -91,6 +92,7 @@ describe("slash-consensus primitives (SP #329)", () => {
   it("PendingSlotCoSigner fails closed: coSign(req) throws the disarmed error", async () => {
     const coSigner = new PendingSlotCoSigner();
     const req: CoSignRequest = {
+      proofSchemaVersion: PROOF_SCHEMA_VERSION,
       step: "queue",
       operator: OPERATOR,
       slashLevel: SlashLevel.MINOR,
@@ -140,6 +142,7 @@ describe("slash-consensus primitives (SP #329)", () => {
   describe("recomputeMessageHash", () => {
     it("queue step === buildQueueMessageHash", () => {
       const req: CoSignRequest = {
+        proofSchemaVersion: PROOF_SCHEMA_VERSION,
         step: "queue",
         operator: OPERATOR,
         slashLevel: SlashLevel.MINOR,
@@ -155,6 +158,7 @@ describe("slash-consensus primitives (SP #329)", () => {
 
     it("execute step === buildExecuteMessageHash", () => {
       const req: CoSignRequest = {
+        proofSchemaVersion: PROOF_SCHEMA_VERSION,
         step: "execute",
         operator: OPERATOR,
         slashLevel: SlashLevel.MINOR,
@@ -171,6 +175,7 @@ describe("slash-consensus primitives (SP #329)", () => {
 
     it("execute step without proposalId → throws", () => {
       const req: CoSignRequest = {
+        proofSchemaVersion: PROOF_SCHEMA_VERSION,
         step: "execute",
         operator: OPERATOR,
         slashLevel: SlashLevel.MINOR,
@@ -184,6 +189,7 @@ describe("slash-consensus primitives (SP #329)", () => {
 
     it("execute step without evidenceHash → throws", () => {
       const req: CoSignRequest = {
+        proofSchemaVersion: PROOF_SCHEMA_VERSION,
         step: "execute",
         operator: OPERATOR,
         slashLevel: SlashLevel.MINOR,

--- a/src/modules/audit/slash-consensus.ts
+++ b/src/modules/audit/slash-consensus.ts
@@ -133,6 +133,13 @@ export function buildSignerMask(slots: number[]): bigint {
  * `messageHash`) and to independently re-confirm the underlying violation before signing.
  */
 export interface CoSignRequest {
+  /**
+   * Proof-schema version (finding-1) = proof-archive `PROOF_SCHEMA_VERSION`. The responder REFUSES
+   * to co-sign a request whose version differs from its own — an EXPLICIT, diagnosable refusal for a
+   * mixed-version fleet, instead of a silent proofHash divergence that quietly loses quorum. Does
+   * NOT affect the on-chain messageHash (recomputeMessageHash ignores it); it only gates co-sign.
+   */
+  proofSchemaVersion: number;
   /** Which slash step this request co-signs: the 5-field queue preimage or 8-field execute. */
   step: "queue" | "execute";
   /** Operator being slashed (checksummed address). */

--- a/src/modules/audit/slash-consensus.ts
+++ b/src/modules/audit/slash-consensus.ts
@@ -89,31 +89,136 @@ export function encodeProof(signerMask: bigint, sigG2: string): string {
 }
 
 /**
- * The quorum co-sign seam. Given a messageHash, an implementation gathers enough peer BLS
- * signatures to meet the slash-level threshold, aggregates them into a single G2 signature,
- * and returns the aggregate together with the signerMask bitmap (bit i set ⇔ SP validator
- * slot i contributed). AuditService injects this so the two-step orchestration is fully
- * unit-testable now, ahead of the real gossip aggregator.
+ * On-chain validator-set capacity (BLSAggregator.MAX_VALIDATORS). signerMask bits are indexed
+ * `[0, MAX_VALIDATORS)`; the contract rejects any `signerMask >> MAX_VALIDATORS != 0`, so a slot
+ * must live in `[1, MAX_VALIDATORS]`. Kept in sync with the on-chain constant (verify against
+ * BLSAggregator.sol before changing).
  */
-export interface IQuorumCoSigner {
-  coSign(messageHash: string): Promise<{ signerMask: bigint; sigG2: string }>;
+export const MAX_VALIDATORS = 13;
+
+/**
+ * Build the on-chain `signerMask` bitmap from a list of 1-indexed validator slots.
+ *
+ * PINNED CONVENTION (BLSAggregator.sol `_reconstructPkAgg` / `verify`): slot `s` (1-indexed)
+ * maps to bit `s-1` (0-indexed) — the contract iterates `for slot 1..MAX_VALIDATORS` and
+ * includes the validator at `slot` iff `((signerMask >> (slot-1)) & 1) == 1`. So:
+ *   buildSignerMask([1,2,3]) === 7n   (1<<0 | 1<<1 | 1<<2)
+ *   buildSignerMask([1,2])   === 3n
+ *   buildSignerMask([1,3])   === 5n
+ *   buildSignerMask([2,3])   === 6n
+ *
+ * Slots are de-duplicated (a slot contributes at most one bit). A non-integer, `<= 0`, or
+ * `> MAX_VALIDATORS` slot is REJECTED (throws) rather than silently masked — an out-of-range
+ * bit would be rejected on-chain (`SlotOutOfRange`) and must never reach a submitted proof.
+ */
+export function buildSignerMask(slots: number[]): bigint {
+  let mask = 0n;
+  const seen = new Set<number>();
+  for (const slot of slots) {
+    if (!Number.isInteger(slot) || slot <= 0 || slot > MAX_VALIDATORS) {
+      throw new Error(
+        `buildSignerMask: slot ${slot} out of range — must be an integer in [1, ${MAX_VALIDATORS}]`
+      );
+    }
+    if (seen.has(slot)) continue;
+    seen.add(slot);
+    mask |= 1n << BigInt(slot - 1);
+  }
+  return mask;
 }
 
 /**
- * Default (deferred) co-signer. The real multi-node gossip BLS aggregation — collect peer
- * signatures over the messageHash, build the signerMask by SP-assigned validator slot, and
- * aggregate into sigG2 — needs SuperPaymaster to hand out slots via registerBLSPublicKey,
- * which is gated behind a 24h timelock. Until then every co-sign fails closed, so the audit
- * still FILES + ARCHIVES the proposal but never sends a queue/execute that would revert.
- *
- * TODO(inc-2 live): real gossip aggregator once SP assigns slots.
+ * A structured slash co-sign request. Carries EVERY field a peer needs to recompute the
+ * on-chain messageHash from first principles (so a responder NEVER trusts the requester's
+ * `messageHash`) and to independently re-confirm the underlying violation before signing.
+ */
+export interface CoSignRequest {
+  /** Which slash step this request co-signs: the 5-field queue preimage or 8-field execute. */
+  step: "queue" | "execute";
+  /** Operator being slashed (checksummed address). */
+  operator: string;
+  /** SP #329 SlashLevel (WARNING=0, MINOR=1, MAJOR=2). */
+  slashLevel: number;
+  /** Deterministic slash epoch = the finalized violationBlock. */
+  epoch: number;
+  /** Chain the slash targets (bound into both preimages — cross-chain replay guard). */
+  chainId: number;
+  /** Real on-chain proposal id (decimal string). REQUIRED for the execute step. */
+  proposalId?: string;
+  /** Content-addressed proofHash bound into the execute preimage (`evidenceHash`). */
+  evidenceHash?: string;
+  /** The requester's computed messageHash — a responder MUST recompute + match, never trust. */
+  messageHash: string;
+}
+
+/**
+ * Recompute the on-chain messageHash for a co-sign request — the ONE code path both the
+ * requester and every responder use, so a byte-for-byte agreement is structural, not trusted.
+ * Dispatches to buildQueueMessageHash (queue) / buildExecuteMessageHash (execute). Throws when
+ * the execute step is missing its `proposalId`/`evidenceHash` (a peer then refuses to sign).
+ */
+export function recomputeMessageHash(req: CoSignRequest): string {
+  if (req.step === "queue") {
+    return buildQueueMessageHash(req.operator, req.slashLevel, req.epoch, req.chainId);
+  }
+  if (req.step === "execute") {
+    if (req.proposalId === undefined || req.proposalId === null || req.proposalId === "") {
+      throw new Error("recomputeMessageHash: execute step requires a proposalId");
+    }
+    if (typeof req.evidenceHash !== "string" || req.evidenceHash.length === 0) {
+      throw new Error("recomputeMessageHash: execute step requires an evidenceHash");
+    }
+    return buildExecuteMessageHash(
+      BigInt(req.proposalId),
+      req.operator,
+      req.slashLevel,
+      req.epoch,
+      req.chainId,
+      req.evidenceHash
+    );
+  }
+  throw new Error(
+    `recomputeMessageHash: unknown step "${String((req as { step?: unknown }).step)}"`
+  );
+}
+
+/**
+ * A peer-side violation re-confirmation. Given a co-sign request, an armed node independently
+ * re-reads the operator's on-chain state pinned at `epoch` (= violationBlock) and re-derives the
+ * content-address. `confirmed` is true only when this node's OWN rule fires on that block; the
+ * returned `proofHash` is compared against `req.evidenceHash` for the execute step (the
+ * "innocent-operator" defense — a substituted operator yields a different proofHash). Any RPC
+ * error / indeterminate read resolves to `{ confirmed: false, proofHash: null }` (fail-closed).
+ */
+export type CoSignVerifier = (
+  req: CoSignRequest
+) => Promise<{ confirmed: boolean; proofHash: string | null }>;
+
+/**
+ * The quorum co-sign seam. Given a structured request, an implementation gathers enough peer BLS
+ * signatures to meet the slash-level threshold, aggregates them into a single G2 signature, and
+ * returns the aggregate together with the signerMask bitmap (bit `s-1` set ⇔ SP validator slot
+ * `s` contributed). AuditService injects this so the two-step orchestration is fully
+ * unit-testable and the live gossip aggregator can drop in behind the same interface.
+ */
+export interface IQuorumCoSigner {
+  coSign(req: CoSignRequest): Promise<{ signerMask: bigint; sigG2: string }>;
+}
+
+/** DI token for the injected quorum co-signer (factory-provided in AuditModule). */
+export const QUORUM_COSIGNER = "QUORUM_COSIGNER";
+
+/**
+ * Default (disarmed) co-signer. Used whenever `AUDIT_EXECUTE_SLASH` is off: the audit still
+ * FILES + ARCHIVES the proposal, but every co-sign fails closed so no queue/execute that would
+ * revert (or over-slash) is ever submitted. The live gossip aggregator (GossipQuorumCoSigner) is
+ * substituted by the AuditModule factory only when the node is explicitly armed.
  */
 export class PendingSlotCoSigner implements IQuorumCoSigner {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async coSign(_messageHash: string): Promise<{ signerMask: bigint; sigG2: string }> {
+  async coSign(_req: CoSignRequest): Promise<{ signerMask: bigint; sigG2: string }> {
     throw new Error(
-      "quorum co-sign deferred — gossip BLS aggregation needs SP validator slots " +
-        "(registerBLSPublicKey, pending 24h timelock)"
+      "quorum co-sign deferred — node is disarmed (AUDIT_EXECUTE_SLASH!=true); " +
+        "the live gossip BLS aggregator is only wired on an armed node"
     );
   }
 }

--- a/src/modules/blockchain/blockchain.service.spec.ts
+++ b/src/modules/blockchain/blockchain.service.spec.ts
@@ -1,3 +1,4 @@
+import { jest } from "@jest/globals";
 import { ethers } from "ethers";
 import {
   BlockchainService,
@@ -97,5 +98,162 @@ describe("owner-auth cross-repo interface invariant", () => {
   it("is NOT the standard ERC-1271 isValidSignature magic (0x1626ba7e)", () => {
     // Guards against a silent revert to standard ERC-1271, which would accept the wrong accounts.
     expect(OWNER_AUTH_MAGIC).not.toBe(ethers.id("isValidSignature(bytes32,bytes)").slice(0, 10));
+  });
+});
+
+/**
+ * HIGH 2 (Codex): the irreversible slash writes (queueSlashWithProof / executeWithProof) must run a
+ * STATIC-CALL preflight with the EXACT args first. A deterministic revert (bad signerMask, sigG2,
+ * threshold, proposal state, wrong address) must THROW before any gas is spent — never become a
+ * PAID on-chain revert — and the real tx must broadcast ONLY when the simulation passes.
+ */
+const DVT_VALIDATOR = "0x" + "44".repeat(20);
+const EPOCH = 999;
+const PROOF = "0x" + "ab".repeat(32);
+
+/** A BlockchainService with a truthy wallet + a provider exposing getFeeData (for bumpedFees). */
+function makeWriterService(): BlockchainService {
+  const config = { get: (_k: string) => undefined } as any;
+  const svc = new BlockchainService(config);
+  (svc as any).wallet = { address: "0x" + "99".repeat(20) };
+  (svc as any).provider = {
+    getFeeData: async () => ({ maxFeePerGas: 10n, maxPriorityFeePerGas: 2n }),
+  };
+  return svc;
+}
+
+/**
+ * Install a mock contract on `svc` (via the `buildContract` seam) whose `method` has a `.staticCall`
+ * that throws/resolves and whose plain call returns a tx with `receipt`. Returns the send spy.
+ */
+function installMockContract(
+  svc: BlockchainService,
+  method: string,
+  opts: { staticReverts?: boolean; receipt?: any } = {}
+): ReturnType<typeof jest.fn> {
+  const receipt = opts.receipt ?? { status: 1, blockNumber: 1, logs: [] };
+  const send = jest.fn(async () => ({ hash: "0xTXHASH", wait: async () => receipt }));
+  (send as any).staticCall = jest.fn(async () => {
+    if (opts.staticReverts) throw new Error("execution reverted: PreflightFailed");
+  });
+  (svc as any).buildContract = () => ({ [method]: send }) as any;
+  return send;
+}
+
+describe("BlockchainService.queueSlashWithProof static-call preflight (HIGH 2)", () => {
+  it("static call REVERTS → throws (preflight) and NEVER broadcasts the real tx", async () => {
+    const svc = makeWriterService();
+    const send = installMockContract(svc, "queueSlashWithProof", { staticReverts: true });
+    await expect(svc.queueSlashWithProof(DVT_VALIDATOR, OPERATOR, 1, EPOCH, PROOF)).rejects.toThrow(
+      /preflight \(staticCall\) reverted/
+    );
+    expect(send).not.toHaveBeenCalled(); // no gas spent — the send fn was never invoked
+  });
+
+  it("static call OK → proceeds and broadcasts the real tx (returns its hash)", async () => {
+    const svc = makeWriterService();
+    const send = installMockContract(svc, "queueSlashWithProof");
+    const hash = await svc.queueSlashWithProof(DVT_VALIDATOR, OPERATOR, 1, EPOCH, PROOF);
+    expect(hash).toBe("0xTXHASH");
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("BlockchainService.executeSlashWithProof static-call preflight (HIGH 2)", () => {
+  it("static call REVERTS → throws (preflight) and NEVER broadcasts the irreversible slash", async () => {
+    const svc = makeWriterService();
+    const send = installMockContract(svc, "executeWithProof", { staticReverts: true });
+    await expect(
+      svc.executeSlashWithProof(DVT_VALIDATOR, 7n, [], [], EPOCH, PROOF)
+    ).rejects.toThrow(/preflight \(staticCall\) reverted/);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("static call OK → proceeds and broadcasts the slash tx", async () => {
+    const svc = makeWriterService();
+    const send = installMockContract(svc, "executeWithProof");
+    const hash = await svc.executeSlashWithProof(DVT_VALIDATOR, 7n, [], [], EPOCH, PROOF);
+    expect(hash).toBe("0xTXHASH");
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * MEDIUM 3 (Codex): createProposalWithEvidence must accept a ProposalCreated log ONLY when it was
+ * emitted BY the DVTValidator it called AND its args match this proposal's operator + level.
+ * A log from a different address, operator, or level must be IGNORED (proposalId → null), so the
+ * evidence is never bound to someone else's proposal id.
+ */
+const PC_IFACE = new ethers.Interface([
+  "event ProposalCreated(uint256 indexed id, address indexed operator, uint8 level)",
+]);
+
+function proposalCreatedLog(address: string, id: bigint, operator: string, level: number) {
+  const e = PC_IFACE.encodeEventLog("ProposalCreated", [id, operator, level]);
+  return { address, topics: e.topics, data: e.data };
+}
+
+/** Install a mock contract on `svc` whose createProposal returns a tx whose receipt carries `logs`. */
+function installCreateContract(svc: BlockchainService, logs: any[]): void {
+  const send = jest.fn(async () => ({
+    hash: "0xPROP",
+    wait: async () => ({ status: 1, blockNumber: 1, logs }),
+  }));
+  (svc as any).buildContract = () => ({ createProposal: send }) as any;
+}
+
+describe("BlockchainService.createProposalWithEvidence ProposalCreated verification (MEDIUM 3)", () => {
+  const EVIDENCE = "0x" + "cd".repeat(32);
+
+  it("accepts a ProposalCreated from the SAME validator with matching operator + level", async () => {
+    const svc = makeWriterService();
+    installCreateContract(svc, [proposalCreatedLog(DVT_VALIDATOR, 42n, OPERATOR, 1)]);
+    const res = await svc.createProposalWithEvidence(
+      DVT_VALIDATOR,
+      OPERATOR,
+      1,
+      "reason",
+      EVIDENCE
+    );
+    expect(res.proposalId).toBe(42n);
+  });
+
+  it("IGNORES a ProposalCreated emitted by a DIFFERENT contract address → proposalId null", async () => {
+    const svc = makeWriterService();
+    installCreateContract(svc, [proposalCreatedLog("0x" + "55".repeat(20), 42n, OPERATOR, 1)]);
+    const res = await svc.createProposalWithEvidence(
+      DVT_VALIDATOR,
+      OPERATOR,
+      1,
+      "reason",
+      EVIDENCE
+    );
+    expect(res.proposalId).toBeNull();
+  });
+
+  it("IGNORES a ProposalCreated for a DIFFERENT operator → proposalId null", async () => {
+    const svc = makeWriterService();
+    installCreateContract(svc, [proposalCreatedLog(DVT_VALIDATOR, 42n, OTHER_OPERATOR, 1)]);
+    const res = await svc.createProposalWithEvidence(
+      DVT_VALIDATOR,
+      OPERATOR,
+      1,
+      "reason",
+      EVIDENCE
+    );
+    expect(res.proposalId).toBeNull();
+  });
+
+  it("IGNORES a ProposalCreated for a DIFFERENT level → proposalId null", async () => {
+    const svc = makeWriterService();
+    installCreateContract(svc, [proposalCreatedLog(DVT_VALIDATOR, 42n, OPERATOR, 2)]);
+    const res = await svc.createProposalWithEvidence(
+      DVT_VALIDATOR,
+      OPERATOR,
+      1,
+      "reason",
+      EVIDENCE
+    );
+    expect(res.proposalId).toBeNull();
   });
 });

--- a/src/modules/blockchain/blockchain.service.spec.ts
+++ b/src/modules/blockchain/blockchain.service.spec.ts
@@ -257,3 +257,61 @@ describe("BlockchainService.createProposalWithEvidence ProposalCreated verificat
     expect(res.proposalId).toBeNull();
   });
 });
+
+/**
+ * FINDING 1: getSlotForValidator scans slots 1..maxSlots for the one bound to an operator EOA. The
+ * scan is now parallelized (Promise.all over getValidatorAtSlot) and must still return the LOWEST
+ * matching slot, and null when the operator holds no slot or the address is malformed.
+ */
+describe("BlockchainService.getSlotForValidator (finding-1 parallel scan)", () => {
+  const BLS_AGG = ethers.getAddress("0x" + "aa".repeat(20));
+
+  /** A service whose getValidatorAtSlot resolves from a slot→address map (counting reads). */
+  function makeSlotService(slotMap: Record<number, string>): {
+    svc: BlockchainService;
+    reads: () => number;
+  } {
+    const config = { get: (_k: string) => undefined } as any;
+    const svc = new BlockchainService(config);
+    let reads = 0;
+    (svc as any).getValidatorAtSlot = async (
+      _addr: string,
+      slot: number
+    ): Promise<string | null> => {
+      reads++;
+      return slotMap[slot] ?? null;
+    };
+    return { svc, reads: () => reads };
+  }
+
+  it("returns the correct 1-indexed slot when the operator is registered", async () => {
+    const operator = ethers.getAddress("0x" + "12".repeat(20));
+    const { svc } = makeSlotService({ 3: operator });
+    expect(await svc.getSlotForValidator(BLS_AGG, operator, 13)).toBe(3);
+  });
+
+  it("returns null when the operator holds NO slot", async () => {
+    const operator = ethers.getAddress("0x" + "12".repeat(20));
+    const { svc } = makeSlotService({ 1: ethers.getAddress("0x" + "34".repeat(20)) });
+    expect(await svc.getSlotForValidator(BLS_AGG, operator, 13)).toBeNull();
+  });
+
+  it("returns null for a malformed operator address (never scans)", async () => {
+    const { svc, reads } = makeSlotService({ 1: ethers.getAddress("0x" + "12".repeat(20)) });
+    expect(await svc.getSlotForValidator(BLS_AGG, "not-an-address", 13)).toBeNull();
+    expect(reads()).toBe(0);
+  });
+
+  it("returns the LOWEST matching slot when the operator appears at multiple slots", async () => {
+    const operator = ethers.getAddress("0x" + "12".repeat(20));
+    const { svc } = makeSlotService({ 2: operator, 5: operator });
+    expect(await svc.getSlotForValidator(BLS_AGG, operator, 13)).toBe(2);
+  });
+
+  it("scans every slot exactly once (parallel Promise.all over 1..maxSlots)", async () => {
+    const operator = ethers.getAddress("0x" + "12".repeat(20));
+    const { svc, reads } = makeSlotService({ 4: operator });
+    expect(await svc.getSlotForValidator(BLS_AGG, operator, 7)).toBe(4);
+    expect(reads()).toBe(7); // all 7 slots issued (parallel), none skipped
+  });
+});

--- a/src/modules/blockchain/blockchain.service.spec.ts
+++ b/src/modules/blockchain/blockchain.service.spec.ts
@@ -315,3 +315,67 @@ describe("BlockchainService.getSlotForValidator (finding-1 parallel scan)", () =
     expect(reads()).toBe(7); // all 7 slots issued (parallel), none skipped
   });
 });
+
+/**
+ * FINDING 3: getRegisteredSlot resolves a node's OWN slot in ONE getBLSPublicKey(operatorEoa) read
+ * (the on-chain call returns the validator's slot + isActive directly) — no 1..maxSlots scan.
+ * Returns the slot when ACTIVE and >= 1; null when inactive/unregistered, out of range, malformed,
+ * or the read reverts.
+ */
+describe("BlockchainService.getRegisteredSlot (finding-3 O(1) own-slot)", () => {
+  const BLS_AGG = ethers.getAddress("0x" + "aa".repeat(20));
+  const OP = ethers.getAddress("0x" + "12".repeat(20));
+  const CODER = ethers.AbiCoder.defaultAbiCoder();
+  const RET = ["tuple(bytes32,bytes32,bytes32,bytes32)", "uint8", "bool"];
+  const PK = [
+    "0x" + "11".repeat(32),
+    "0x" + "22".repeat(32),
+    "0x" + "33".repeat(32),
+    "0x" + "44".repeat(32),
+  ];
+
+  /** A service whose provider.call returns an ABI-encoded getBLSPublicKey tuple (or throws). */
+  function makeService(call: () => Promise<string>): BlockchainService {
+    const config = { get: (_k: string) => undefined } as any;
+    const svc = new BlockchainService(config);
+    (svc as any).provider = { call };
+    return svc;
+  }
+
+  it("returns the 1-indexed slot for an ACTIVE registered validator (one read)", async () => {
+    let calls = 0;
+    const svc = makeService(async () => {
+      calls++;
+      return CODER.encode(RET, [PK, 5, true]);
+    });
+    expect(await svc.getRegisteredSlot(BLS_AGG, OP)).toBe(5);
+    expect(calls).toBe(1); // O(1): a single getBLSPublicKey read, no slot scan
+  });
+
+  it("returns null when the validator is INACTIVE (revoked)", async () => {
+    const svc = makeService(async () => CODER.encode(RET, [PK, 5, false]));
+    expect(await svc.getRegisteredSlot(BLS_AGG, OP)).toBeNull();
+  });
+
+  it("returns null when the returned slot is 0 (unregistered / no slot)", async () => {
+    const svc = makeService(async () => CODER.encode(RET, [PK, 0, true]));
+    expect(await svc.getRegisteredSlot(BLS_AGG, OP)).toBeNull();
+  });
+
+  it("returns null when the on-chain read reverts (fail-closed)", async () => {
+    const svc = makeService(async () => {
+      throw new Error("execution reverted");
+    });
+    expect(await svc.getRegisteredSlot(BLS_AGG, OP)).toBeNull();
+  });
+
+  it("returns null for a malformed operator EOA WITHOUT any read", async () => {
+    let calls = 0;
+    const svc = makeService(async () => {
+      calls++;
+      return CODER.encode(RET, [PK, 5, true]);
+    });
+    expect(await svc.getRegisteredSlot(BLS_AGG, "not-an-address")).toBeNull();
+    expect(calls).toBe(0);
+  });
+});

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -466,6 +466,38 @@ export class BlockchainService {
   }
 
   /**
+   * Contract factory seam. All wallet-signed write paths (createProposal, queue/execute slash) build
+   * their `ethers.Contract` through this one method so a test can override it to inject a mock —
+   * `ethers` is an ESM namespace (read-only) and cannot be spied on directly. Production behaviour is
+   * exactly `new ethers.Contract(...)`.
+   */
+  protected buildContract(
+    address: string,
+    abi: ethers.InterfaceAbi,
+    runner: ethers.ContractRunner
+  ): ethers.Contract {
+    return new ethers.Contract(address, abi, runner);
+  }
+
+  /**
+   * Block hash of a SPECIFIC historical block number, or `null` when it cannot be read. Used by the
+   * co-sign responder to re-derive the content-address of a violation pinned at `epoch`
+   * (violationBlockHash is part of ProofIdentity, LOW): a responder that cannot read the exact block
+   * hash fails closed (cannot reproduce the requester's proofHash → refuses to co-sign).
+   */
+  async getBlockHash(blockNumber: number): Promise<string | null> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+    try {
+      const b = await this.provider.getBlock(blockNumber);
+      return b?.hash ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * The block an irreversible slash is justified against — a FINALIZED (fallback: safe) block,
    * returned as `{ number, hash }` (finding-3). Pinning the slash evidence to a finalized block,
    * and recording its HASH, makes the justification reorg-safe: a reorg that rewrites the chain
@@ -818,7 +850,7 @@ export class BlockchainService {
       "event ProposalCreated(uint256 indexed id, address indexed operator, uint8 level)",
     ];
     const iface = new ethers.Interface(abi);
-    const contract = new ethers.Contract(dvtValidatorAddress, abi, this.wallet);
+    const contract = this.buildContract(dvtValidatorAddress, abi, this.wallet);
     const fees = await bumpedFees(this.provider);
     const tx: ethers.TransactionResponse = await contract.createProposal(
       operator,
@@ -840,13 +872,21 @@ export class BlockchainService {
     let proposalId: bigint | null = null;
     for (const log of receipt.logs) {
       try {
+        // MEDIUM 3 (Codex): only trust a ProposalCreated emitted BY the DVTValidator we called AND
+        // matching THIS proposal's operator + level. A decodable log from another contract, or one
+        // whose args disagree, must NEVER be mistaken for our proposal id (a wrong id would bind the
+        // evidence to someone else's proposal and later make executeWithProof slash the wrong thing).
+        if (ethers.getAddress(log.address) !== ethers.getAddress(dvtValidatorAddress)) continue;
         const parsed = iface.parseLog({ topics: [...log.topics], data: log.data });
-        if (parsed && parsed.name === "ProposalCreated") {
-          proposalId = BigInt(parsed.args.id ?? parsed.args[0]);
-          break;
-        }
+        if (!parsed || parsed.name !== "ProposalCreated") continue;
+        const evOperator = parsed.args.operator ?? parsed.args[1];
+        const evLevel = parsed.args.level ?? parsed.args[2];
+        if (ethers.getAddress(evOperator) !== ethers.getAddress(operator)) continue;
+        if (Number(evLevel) !== level) continue;
+        proposalId = BigInt(parsed.args.id ?? parsed.args[0]);
+        break;
       } catch {
-        // Not a ProposalCreated log (or from another contract) — skip.
+        // Not a ProposalCreated log from this validator (or from another contract) — skip.
       }
     }
     if (proposalId === null) {
@@ -925,7 +965,7 @@ export class BlockchainService {
       "event ProposalCreated(uint256 indexed id, address indexed operator, uint8 level)",
     ];
     const iface = new ethers.Interface(abi);
-    const contract = new ethers.Contract(dvtValidatorAddress, abi, this.wallet);
+    const contract = this.buildContract(dvtValidatorAddress, abi, this.wallet);
     const fees = await bumpedFees(this.provider);
     const tx: ethers.TransactionResponse = await contract.createProposal(
       operator,
@@ -946,13 +986,21 @@ export class BlockchainService {
     let proposalId: bigint | null = null;
     for (const log of receipt.logs) {
       try {
+        // MEDIUM 3 (Codex): only trust a ProposalCreated emitted BY the DVTValidator we called AND
+        // matching THIS proposal's operator + level. A decodable log from another contract, or one
+        // whose args disagree, must NEVER be mistaken for our proposal id (a wrong id would bind the
+        // evidence to someone else's proposal and later make executeWithProof slash the wrong thing).
+        if (ethers.getAddress(log.address) !== ethers.getAddress(dvtValidatorAddress)) continue;
         const parsed = iface.parseLog({ topics: [...log.topics], data: log.data });
-        if (parsed && parsed.name === "ProposalCreated") {
-          proposalId = BigInt(parsed.args.id ?? parsed.args[0]);
-          break;
-        }
+        if (!parsed || parsed.name !== "ProposalCreated") continue;
+        const evOperator = parsed.args.operator ?? parsed.args[1];
+        const evLevel = parsed.args.level ?? parsed.args[2];
+        if (ethers.getAddress(evOperator) !== ethers.getAddress(operator)) continue;
+        if (Number(evLevel) !== level) continue;
+        proposalId = BigInt(parsed.args.id ?? parsed.args[0]);
+        break;
       } catch {
-        // Not a ProposalCreated log (or from another contract) — skip.
+        // Not a ProposalCreated log from this validator (or from another contract) — skip.
       }
     }
     if (proposalId === null) {
@@ -987,7 +1035,20 @@ export class BlockchainService {
     const abi = [
       "function queueSlashWithProof(address operator, uint8 slashLevel, uint256 epoch, bytes proof) external",
     ];
-    const contract = new ethers.Contract(dvtValidatorAddress, abi, this.wallet);
+    const contract = this.buildContract(dvtValidatorAddress, abi, this.wallet);
+    // STATIC-CALL PREFLIGHT (Codex HIGH 2): simulate the EXACT call first. Any deterministic
+    // mismatch (bad signerMask, sigG2 encoding, DST, on-chain threshold, stale slot mapping, wrong
+    // address, proposal state) reverts HERE — before spending a single wei of gas — so the audit's
+    // try/catch degrades to file+archive instead of eating a PAID on-chain revert. Only a passing
+    // simulation lets the real, irreversible tx broadcast.
+    try {
+      await contract.queueSlashWithProof.staticCall(operator, slashLevel, epoch, proof);
+    } catch (err: unknown) {
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `queueSlashWithProof preflight (staticCall) reverted — NOT broadcasting: ${reason}`
+      );
+    }
     const fees = await bumpedFees(this.provider);
     const tx: ethers.TransactionResponse = await contract.queueSlashWithProof(
       operator,
@@ -1030,7 +1091,18 @@ export class BlockchainService {
     const abi = [
       "function executeWithProof(uint256 id, address[] repUsers, uint256[] newScores, uint256 epoch, bytes proof) external",
     ];
-    const contract = new ethers.Contract(dvtValidatorAddress, abi, this.wallet);
+    const contract = this.buildContract(dvtValidatorAddress, abi, this.wallet);
+    // STATIC-CALL PREFLIGHT (Codex HIGH 2): simulate the EXACT execute call first so any
+    // deterministic revert (signerMask/sigG2/threshold/proposal-state mismatch) surfaces BEFORE the
+    // irreversible slash tx spends gas. Only a passing simulation lets the real tx broadcast.
+    try {
+      await contract.executeWithProof.staticCall(id, repUsers, newScores, epoch, proof);
+    } catch (err: unknown) {
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `executeWithProof preflight (staticCall) reverted — NOT broadcasting: ${reason}`
+      );
+    }
     const fees = await bumpedFees(this.provider);
     const tx: ethers.TransactionResponse = await contract.executeWithProof(
       id,

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -587,6 +587,99 @@ export class BlockchainService {
     return false;
   }
 
+  // ── BLSAggregator slot registry (inc-2 live gossip co-sign) ────────────────────
+  //
+  // The authoritative slot→validator→BLS-key mapping the quorum co-sign binds against. Slot is
+  // 1-indexed in [1, MAX_VALIDATORS]; signerMask bit `s-1` ⇔ slot `s` (see BLSAggregator.sol
+  // `_reconstructPkAgg`). All reads are best-effort → `null` on revert/absence (fail-closed at
+  // the caller: an unresolvable slot/key means "cannot bind" → refuse to count that signature).
+
+  /**
+   * BLSAggregator.validatorAtSlot(slot) — the validator address bound to a 1-indexed slot.
+   * Returns the checksummed address, or `null` when the slot is empty (zero address) or the read
+   * reverts.
+   */
+  async getValidatorAtSlot(blsAggregatorAddress: string, slot: number): Promise<string | null> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+    const abi = ["function validatorAtSlot(uint8 slot) view returns (address)"];
+    const contract = new ethers.Contract(blsAggregatorAddress, abi, this.provider);
+    try {
+      const addr: string = await contract.validatorAtSlot(slot);
+      if (!addr || addr === ethers.ZeroAddress) return null;
+      return ethers.getAddress(addr);
+    } catch (error: any) {
+      this.logger.warn(
+        `validatorAtSlot(${slot}) failed on ${blsAggregatorAddress}: ${error.message}`
+      );
+      return null;
+    }
+  }
+
+  /**
+   * The active BLS G1 public key registered at a slot, as its uncompressed EIP-2537 128-byte
+   * encoding (0x-hex, lowercase) — the concatenation of the on-chain BLS.G1Point words
+   * `x_a || x_b || y_a || y_b`, byte-identical to `BlsService.encodePublicKeyToEIP2537`. Resolves
+   * the slot's validator (validatorAtSlot) then reads BLSAggregator.getBLSPublicKey(validator).
+   * Returns `null` when the slot is empty, the key is inactive (revoked), or the read reverts.
+   * The requester uses this to bind a peer's returned slot to the exact on-chain key.
+   */
+  async getBlsPublicKeyAtSlot(blsAggregatorAddress: string, slot: number): Promise<string | null> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+    const validator = await this.getValidatorAtSlot(blsAggregatorAddress, slot);
+    if (!validator) return null;
+    const abi = [
+      "function getBLSPublicKey(address validator) view returns (tuple(bytes32 x_a, bytes32 x_b, bytes32 y_a, bytes32 y_b) publicKey, uint8 slot, bool isActive)",
+    ];
+    const contract = new ethers.Contract(blsAggregatorAddress, abi, this.provider);
+    try {
+      const res = await contract.getBLSPublicKey(validator);
+      const pk = res.publicKey ?? res[0];
+      const isActive = res.isActive ?? res[2];
+      if (!isActive) return null;
+      const words = [
+        pk.x_a ?? pk[0],
+        pk.x_b ?? pk[1],
+        pk.y_a ?? pk[2],
+        pk.y_b ?? pk[3],
+      ] as string[];
+      if (words.some(w => typeof w !== "string")) return null;
+      const hex = "0x" + words.map(w => w.slice(2)).join("");
+      return hex.toLowerCase();
+    } catch (error: any) {
+      this.logger.warn(
+        `getBLSPublicKey(${validator}) failed on ${blsAggregatorAddress}: ${error.message}`
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Scan slots `1..maxSlots` for the one bound to `operatorEoa` (checksum-compared), returning its
+   * 1-indexed slot or `null` when the operator holds no slot. A node whose operator is at no slot
+   * MUST refuse to participate in the quorum co-sign (fail-closed).
+   */
+  async getSlotForValidator(
+    blsAggregatorAddress: string,
+    operatorEoa: string,
+    maxSlots: number
+  ): Promise<number | null> {
+    let target: string;
+    try {
+      target = ethers.getAddress(operatorEoa);
+    } catch {
+      return null;
+    }
+    for (let slot = 1; slot <= maxSlots; slot++) {
+      const v = await this.getValidatorAtSlot(blsAggregatorAddress, slot);
+      if (v && v === target) return slot;
+    }
+    return null;
+  }
+
   /** Runtime bytecode at `address` ("0x" when there's no contract). Used for a fail-closed
    *  bootstrap existence check before the audit poll trusts an address. */
   async getCode(address: string, blockTag?: number): Promise<string> {

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -705,9 +705,15 @@ export class BlockchainService {
     } catch {
       return null;
     }
-    for (let slot = 1; slot <= maxSlots; slot++) {
-      const v = await this.getValidatorAtSlot(blsAggregatorAddress, slot);
-      if (v && v === target) return slot;
+    // Parallelize the slot scan (was a serial RPC per slot): issue all validatorAtSlot(1..maxSlots)
+    // reads at once, then pick the LOWEST-indexed slot that matches. Each getValidatorAtSlot already
+    // fails closed to null on revert/absence, so a bad address / empty slot never matches.
+    const slots = Array.from({ length: Math.max(0, maxSlots) }, (_, i) => i + 1);
+    const validators = await Promise.all(
+      slots.map(slot => this.getValidatorAtSlot(blsAggregatorAddress, slot))
+    );
+    for (let i = 0; i < validators.length; i++) {
+      if (validators[i] && validators[i] === target) return slots[i];
     }
     return null;
   }

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -480,24 +480,6 @@ export class BlockchainService {
   }
 
   /**
-   * Block hash of a SPECIFIC historical block number, or `null` when it cannot be read. Used by the
-   * co-sign responder to re-derive the content-address of a violation pinned at `epoch`
-   * (violationBlockHash is part of ProofIdentity, LOW): a responder that cannot read the exact block
-   * hash fails closed (cannot reproduce the requester's proofHash → refuses to co-sign).
-   */
-  async getBlockHash(blockNumber: number): Promise<string | null> {
-    if (!this.provider) {
-      throw new Error("Blockchain provider not configured");
-    }
-    try {
-      const b = await this.provider.getBlock(blockNumber);
-      return b?.hash ?? null;
-    } catch {
-      return null;
-    }
-  }
-
-  /**
    * The block an irreversible slash is justified against — a FINALIZED (fallback: safe) block,
    * returned as `{ number, hash }` (finding-3). Pinning the slash evidence to a finalized block,
    * and recording its HASH, makes the justification reorg-safe: a reorg that rewrites the chain
@@ -684,6 +666,45 @@ export class BlockchainService {
     } catch (error: any) {
       this.logger.warn(
         `getBLSPublicKey(${validator}) failed on ${blsAggregatorAddress}: ${error.message}`
+      );
+      return null;
+    }
+  }
+
+  /**
+   * O(1) own-slot lookup (finding-3): BLSAggregator.getBLSPublicKey(validator) returns the
+   * validator's (publicKey, slot, isActive) in a SINGLE read, so a node resolves its OWN registered
+   * slot directly from its operator EOA — no 1..maxSlots scan. Returns the 1-indexed `slot` when the
+   * validator is ACTIVE and `slot >= 1`; `null` when unregistered/inactive, the slot is out of
+   * range, the EOA is malformed, or the read reverts (fail-closed).
+   */
+  async getRegisteredSlot(
+    blsAggregatorAddress: string,
+    operatorEoa: string
+  ): Promise<number | null> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+    let validator: string;
+    try {
+      validator = ethers.getAddress(operatorEoa);
+    } catch {
+      return null;
+    }
+    const abi = [
+      "function getBLSPublicKey(address validator) view returns (tuple(bytes32 x_a, bytes32 x_b, bytes32 y_a, bytes32 y_b) publicKey, uint8 slot, bool isActive)",
+    ];
+    const contract = new ethers.Contract(blsAggregatorAddress, abi, this.provider);
+    try {
+      const res = await contract.getBLSPublicKey(validator);
+      const isActive = res.isActive ?? res[2];
+      if (!isActive) return null;
+      const slot = Number(res.slot ?? res[1]);
+      if (!Number.isInteger(slot) || slot < 1) return null;
+      return slot;
+    } catch (error: any) {
+      this.logger.warn(
+        `getRegisteredSlot(${validator}) failed on ${blsAggregatorAddress}: ${error.message}`
       );
       return null;
     }

--- a/src/modules/gossip/gossip-cosign.spec.ts
+++ b/src/modules/gossip/gossip-cosign.spec.ts
@@ -400,3 +400,118 @@ describe("GossipService co-sign collector: validate + dedupKey", () => {
     expect(() => (svc as any).handleCoSignResponse(respMsg("late", 9, true))).not.toThrow();
   });
 });
+
+/**
+ * FINDING 3 (per-connection anti-DoS): the global `maxValidations` budget can be exhausted by ONE
+ * malicious peer flooding distinct bogus responses (varying signerNodeId/slot/sig) before honest
+ * peers' responses arrive → honest signers dropped (liveness). signerNodeId/from is
+ * attacker-controlled; the CONNECTION (ws) is the un-forgeable identity, so validations are capped
+ * per connection. The global cap + exact-dedup remain as backstops; a response with no ws (direct
+ * test injection) skips only the per-connection check.
+ */
+describe("GossipService co-sign collector: per-connection cap (finding-3)", () => {
+  const flush = () => new Promise(r => setTimeout(r, 0));
+  const bySlot = (r: CoSignResponsePayload) => r.slot;
+
+  function respMsg(nodeId: string, slot: number, ok: boolean, requestId: string): GossipMessage {
+    return {
+      type: "cosign-response",
+      from: nodeId,
+      data: {
+        requestId,
+        slot,
+        signerNodeId: nodeId,
+        signerPublicKey: "0xpk",
+        signatureCompact: "0xsig",
+        messageHash: "0xhash",
+        ok,
+      } as any,
+      timestamp: Date.now(),
+      ttl: 0,
+      messageId: `resp-${nodeId}-${slot}`,
+      version: 0,
+    };
+  }
+
+  it("one flooding connection is capped at perConnCap and CANNOT crowd out honest signers on OTHER connections", async () => {
+    const svc = buildService();
+    let floodValidations = 0;
+    const validate = async (r: CoSignResponsePayload) => {
+      if (String(r.signerNodeId).startsWith("bad-")) floodValidations++;
+      return (r as any).ok === true;
+    };
+    const promise = (svc as any).requestCoSignatures(reqPayload({ requestId: "req-conn" }), {
+      threshold: 2,
+      timeoutMs: 1000,
+      validate,
+      dedupKey: bySlot,
+      perConnCap: 4,
+    }) as Promise<CoSignResponsePayload[]>;
+    let settled = false;
+    void promise.then(() => (settled = true));
+
+    const wsFlood = {} as any; // one attacker connection
+
+    // Flooder sends 10 DISTINCT bogus responses on ONE connection → only perConnCap (4) validate.
+    for (let i = 0; i < 10; i++) {
+      (svc as any).handleCoSignResponse(respMsg(`bad-${i}`, i + 1, false, "req-conn"), wsFlood);
+    }
+    await flush();
+    expect(floodValidations).toBe(4); // per-connection cap enforced — NOT all 10
+    expect(settled).toBe(false); // bogus never counted → still waiting for honest signers
+
+    // Honest peers on OTHER connections still validate + count to the threshold (not crowded out).
+    (svc as any).handleCoSignResponse(respMsg("good-1", 11, true, "req-conn"), {} as any);
+    (svc as any).handleCoSignResponse(respMsg("good-2", 12, true, "req-conn"), {} as any);
+    const responses = await promise;
+    expect(responses).toHaveLength(2);
+    expect(responses.map(r => r.slot).sort((a, b) => a - b)).toEqual([11, 12]);
+  });
+
+  it("exact-dedup still fires FIRST (identical resends on one ws validate at most once)", async () => {
+    const svc = buildService();
+    let validateCalls = 0;
+    const validate = async () => {
+      validateCalls++;
+      return false;
+    };
+    const promise = (svc as any).requestCoSignatures(reqPayload({ requestId: "req-exact" }), {
+      threshold: 3,
+      timeoutMs: 20,
+      validate,
+      dedupKey: bySlot,
+      perConnCap: 4,
+    }) as Promise<CoSignResponsePayload[]>;
+    const ws = {} as any;
+    for (let i = 0; i < 10; i++) {
+      (svc as any).handleCoSignResponse(respMsg("flood", 5, false, "req-exact"), ws);
+    }
+    await flush();
+    expect(validateCalls).toBe(1); // exact-dedup collapsed the 10 identical resends
+    await promise;
+  });
+
+  it("a response with NO ws still respects the global maxValidations cap", async () => {
+    const svc = buildService();
+    let validateCalls = 0;
+    const validate = async () => {
+      validateCalls++;
+      return false;
+    };
+    const promise = (svc as any).requestCoSignatures(reqPayload({ requestId: "req-nows" }), {
+      threshold: 3,
+      timeoutMs: 20,
+      validate,
+      dedupKey: bySlot,
+      maxValidations: 5,
+      perConnCap: 4,
+    }) as Promise<CoSignResponsePayload[]>;
+    // 20 distinct responses injected with NO ws → per-connection check skipped, global cap bounds.
+    for (let i = 0; i < 20; i++) {
+      (svc as any).handleCoSignResponse(respMsg(`n-${i}`, (i % 12) + 1, false, "req-nows"));
+    }
+    await flush();
+    expect(validateCalls).toBeLessThanOrEqual(5); // global cap still enforced without a ws
+    await promise;
+  });
+});

--- a/src/modules/gossip/gossip-cosign.spec.ts
+++ b/src/modules/gossip/gossip-cosign.spec.ts
@@ -229,3 +229,123 @@ describe("GossipService co-sign transport", () => {
     await new Promise(r => setTimeout(r, 10)); // let the timers clear
   });
 });
+
+/**
+ * MEDIUM 1 (Codex): the collector counts ONLY validated responses toward the threshold and dedups
+ * by an app-supplied key (the co-signer keys by on-chain slot) — so one connected peer cannot flood
+ * bogus responses with distinct signer ids, crowd out honest signers, and force a premature
+ * under-threshold resolution.
+ */
+describe("GossipService co-sign collector: validate + dedupKey", () => {
+  const flush = () => new Promise(r => setTimeout(r, 0));
+  const bySlot = (r: CoSignResponsePayload) => r.slot;
+  const validateOk = async (r: CoSignResponsePayload) => (r as any).ok === true;
+
+  function respMsg(nodeId: string, slot: number, ok: boolean, requestId = "req-V"): GossipMessage {
+    return {
+      type: "cosign-response",
+      from: nodeId,
+      data: {
+        requestId,
+        slot,
+        signerNodeId: nodeId,
+        signerPublicKey: "0xpk",
+        signatureCompact: "0xsig",
+        messageHash: "0xhash",
+        ok,
+      } as any,
+      timestamp: Date.now(),
+      ttl: 0,
+      messageId: `resp-${nodeId}-${slot}`,
+      version: 0,
+    };
+  }
+
+  it("bogus responses that fail validation do NOT count and cannot crowd out honest signers", async () => {
+    const svc = buildService();
+    const promise = (svc as any).requestCoSignatures(reqPayload({ requestId: "req-V" }), {
+      threshold: 2,
+      timeoutMs: 1000,
+      validate: validateOk,
+      dedupKey: bySlot,
+    }) as Promise<CoSignResponsePayload[]>;
+    let settled = false;
+    void promise.then(() => (settled = true));
+
+    // One peer floods 3 bogus responses with DISTINCT signer ids + slots → none validate.
+    (svc as any).handleCoSignResponse(respMsg("bad-1", 5, false));
+    (svc as any).handleCoSignResponse(respMsg("bad-2", 6, false));
+    (svc as any).handleCoSignResponse(respMsg("bad-3", 7, false));
+    await flush();
+    expect(settled).toBe(false); // still waiting — bogus never counted
+
+    // Two honest, valid, distinct-slot responses → resolves with EXACTLY those.
+    (svc as any).handleCoSignResponse(respMsg("good-1", 1, true));
+    (svc as any).handleCoSignResponse(respMsg("good-2", 2, true));
+    const responses = await promise;
+    expect(responses).toHaveLength(2);
+    expect(responses.map(r => r.slot).sort((a, b) => a - b)).toEqual([1, 2]);
+  });
+
+  it("resolves EARLY once enough validated unique-slot responses arrive (before timeout)", async () => {
+    const svc = buildService();
+    const promise = (svc as any).requestCoSignatures(reqPayload({ requestId: "req-V" }), {
+      threshold: 2,
+      timeoutMs: 5000, // long — must resolve on validated count, not timeout
+      validate: validateOk,
+      dedupKey: bySlot,
+    }) as Promise<CoSignResponsePayload[]>;
+    (svc as any).handleCoSignResponse(respMsg("a", 1, true));
+    (svc as any).handleCoSignResponse(respMsg("b", 2, true));
+    const responses = await promise;
+    expect(responses).toHaveLength(2);
+  });
+
+  it("resolves on TIMEOUT with the validated partial set", async () => {
+    const svc = buildService();
+    const promise = (svc as any).requestCoSignatures(reqPayload({ requestId: "req-V" }), {
+      threshold: 3,
+      timeoutMs: 20,
+      validate: validateOk,
+      dedupKey: bySlot,
+    }) as Promise<CoSignResponsePayload[]>;
+    (svc as any).handleCoSignResponse(respMsg("a", 1, true));
+    (svc as any).handleCoSignResponse(respMsg("bad", 2, false)); // dropped
+    const responses = await promise;
+    // Threshold 3 never met (only 1 valid) → resolves on timeout with the single validated response.
+    expect(responses).toHaveLength(1);
+    expect(responses[0].slot).toBe(1);
+  });
+
+  it("the SAME slot from two distinct nodes counts ONCE (dedup by slot)", async () => {
+    const svc = buildService();
+    const promise = (svc as any).requestCoSignatures(reqPayload({ requestId: "req-V" }), {
+      threshold: 2,
+      timeoutMs: 20,
+      validate: validateOk,
+      dedupKey: bySlot,
+    }) as Promise<CoSignResponsePayload[]>;
+    // Two DISTINCT nodes both claim slot 2 (valid sigs) → deduped to one → threshold 2 NOT met.
+    (svc as any).handleCoSignResponse(respMsg("node-2a", 2, true));
+    (svc as any).handleCoSignResponse(respMsg("node-2b", 2, true));
+    const responses = await promise; // resolves on timeout with the single unique slot
+    expect(responses).toHaveLength(1);
+    expect(responses[0].slot).toBe(2);
+  });
+
+  it("a validated response arriving AFTER resolution is safely ignored (no leak / no throw)", async () => {
+    const svc = buildService();
+    const promise = (svc as any).requestCoSignatures(reqPayload({ requestId: "req-V" }), {
+      threshold: 1,
+      timeoutMs: 1000,
+      validate: validateOk,
+      dedupKey: bySlot,
+    }) as Promise<CoSignResponsePayload[]>;
+    (svc as any).handleCoSignResponse(respMsg("a", 1, true));
+    const responses = await promise;
+    expect(responses).toHaveLength(1);
+    // Pending entry cleaned up → a late response is a no-op (no throw, nothing counted).
+    expect((svc as any).pendingCoSign.has("req-V")).toBe(false);
+    expect(() => (svc as any).handleCoSignResponse(respMsg("late", 9, true))).not.toThrow();
+  });
+});

--- a/src/modules/gossip/gossip-cosign.spec.ts
+++ b/src/modules/gossip/gossip-cosign.spec.ts
@@ -1,0 +1,231 @@
+import { GossipService } from "./gossip.service.js";
+import type {
+  CoSignRequestPayload,
+  CoSignResponsePayload,
+  GossipMessage,
+} from "./gossip.interfaces.js";
+
+/**
+ * inc-2-live — gossip co-sign TRANSPORT tests. The gossip service is a dumb point-to-point
+ * carrier: it invokes the registered handler and relays its reply, routes responses by requestId,
+ * mints a FRESH messageId per send, and sends with ttl=0 (never flood-propagated). ZERO slash
+ * logic lives here. We drive the private handlers directly with a fake ws to avoid a live server.
+ */
+
+const CONFIG: Record<string, string> = { PORT: "3000" };
+function makeConfig() {
+  return { get: (k: string) => CONFIG[k] } as any;
+}
+function makeNodeService(nodeId = "self-node") {
+  return { getNodeState: () => ({ nodeId, publicKey: "0xpub" }) } as any;
+}
+
+/** A minimal ws that records every JSON message sent to it. */
+function fakeWs() {
+  const sent: GossipMessage[] = [];
+  return {
+    sent,
+    readyState: 1, // WebSocket.OPEN
+    send(data: string) {
+      sent.push(JSON.parse(data));
+    },
+  };
+}
+
+function buildService(nodeId = "self-node"): GossipService {
+  const svc = new GossipService(makeConfig(), makeNodeService(nodeId));
+  // nodeState.version is read when composing messages — the constructor already initialized it.
+  return svc;
+}
+
+function reqPayload(overrides: Partial<CoSignRequestPayload> = {}): CoSignRequestPayload {
+  return {
+    step: "queue",
+    operator: "0x" + "12".repeat(20),
+    slashLevel: 1,
+    epoch: 10,
+    chainId: 11155111,
+    messageHash: "0x" + "ab".repeat(32),
+    requestId: "req-1",
+    requesterNodeId: "requester",
+    ...overrides,
+  };
+}
+
+describe("GossipService co-sign transport", () => {
+  it("handleCoSignRequest invokes the registered handler and replies on the SAME ws (ttl=0)", async () => {
+    const svc = buildService();
+    const response: CoSignResponsePayload = {
+      requestId: "req-1",
+      slot: 2,
+      signerNodeId: "self-node",
+      signerPublicKey: "0xpk",
+      signatureCompact: "0xsig",
+      messageHash: reqPayload().messageHash,
+    };
+    let received: CoSignRequestPayload | null = null;
+    svc.registerCoSignHandler(async payload => {
+      received = payload;
+      return response;
+    });
+
+    const ws = fakeWs();
+    const message: GossipMessage = {
+      type: "cosign-request",
+      from: "requester",
+      data: reqPayload(),
+      timestamp: Date.now(),
+      ttl: 0,
+      messageId: "m-1",
+      version: 0,
+    };
+    (svc as any).handleCoSignRequest(ws, message);
+    // handler is async → let the microtask reply.
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(received).not.toBeNull();
+    expect(ws.sent).toHaveLength(1);
+    expect(ws.sent[0].type).toBe("cosign-response");
+    expect(ws.sent[0].ttl).toBe(0); // directed reply, never propagated
+    expect(ws.sent[0].data).toEqual(response);
+  });
+
+  it("a null handler return (refusal) sends NOTHING (silent fail-closed)", async () => {
+    const svc = buildService();
+    svc.registerCoSignHandler(async () => null);
+    const ws = fakeWs();
+    (svc as any).handleCoSignRequest(ws, {
+      type: "cosign-request",
+      from: "requester",
+      data: reqPayload(),
+      timestamp: Date.now(),
+      ttl: 0,
+      messageId: "m-1",
+      version: 0,
+    });
+    await new Promise(r => setTimeout(r, 0));
+    expect(ws.sent).toHaveLength(0);
+  });
+
+  it("no registered handler (disarmed node) → request silently refused", () => {
+    const svc = buildService();
+    const ws = fakeWs();
+    (svc as any).handleCoSignRequest(ws, {
+      type: "cosign-request",
+      from: "requester",
+      data: reqPayload(),
+      timestamp: Date.now(),
+      ttl: 0,
+      messageId: "m-1",
+      version: 0,
+    });
+    expect(ws.sent).toHaveLength(0);
+  });
+
+  it("requestCoSignatures resolves at threshold and dedups by signerNodeId", async () => {
+    const svc = buildService();
+    // No connections → broadcast is a no-op; we inject responses directly.
+    const payload = reqPayload({ requestId: "req-A" });
+    const promise = (svc as any).requestCoSignatures(payload, { threshold: 2, timeoutMs: 5000 });
+
+    const mk = (nodeId: string, slot: number): GossipMessage => ({
+      type: "cosign-response",
+      from: nodeId,
+      data: {
+        requestId: "req-A",
+        slot,
+        signerNodeId: nodeId,
+        signerPublicKey: "0xpk",
+        signatureCompact: "0xsig",
+        messageHash: payload.messageHash,
+      },
+      timestamp: Date.now(),
+      ttl: 0,
+      messageId: `resp-${nodeId}`,
+      version: 0,
+    });
+
+    (svc as any).handleCoSignResponse(mk("node-2", 2));
+    (svc as any).handleCoSignResponse(mk("node-2", 2)); // duplicate node → deduped
+    (svc as any).handleCoSignResponse(mk("node-3", 3)); // reaches threshold 2
+
+    const responses = (await promise) as CoSignResponsePayload[];
+    expect(responses).toHaveLength(2);
+    expect(responses.map(r => r.signerNodeId).sort()).toEqual(["node-2", "node-3"]);
+  });
+
+  it("requestCoSignatures resolves on TIMEOUT with the partial set", async () => {
+    const svc = buildService();
+    const payload = reqPayload({ requestId: "req-T" });
+    const promise = (svc as any).requestCoSignatures(payload, { threshold: 3, timeoutMs: 20 });
+    (svc as any).handleCoSignResponse({
+      type: "cosign-response",
+      from: "node-2",
+      data: {
+        requestId: "req-T",
+        slot: 2,
+        signerNodeId: "node-2",
+        signerPublicKey: "0xpk",
+        signatureCompact: "0xsig",
+        messageHash: payload.messageHash,
+      },
+      timestamp: Date.now(),
+      ttl: 0,
+      messageId: "resp-2",
+      version: 0,
+    });
+    const responses = (await promise) as CoSignResponsePayload[];
+    // Threshold (3) never met → resolved on timeout with the single partial response.
+    expect(responses).toHaveLength(1);
+  });
+
+  it("requestCoSignatures with threshold<=0 resolves immediately (empty set)", async () => {
+    const svc = buildService();
+    const responses = (await (svc as any).requestCoSignatures(reqPayload({ requestId: "req-0" }), {
+      threshold: 0,
+      timeoutMs: 5000,
+    })) as CoSignResponsePayload[];
+    expect(responses).toEqual([]);
+  });
+
+  it("a response for an unknown/expired requestId is ignored", async () => {
+    const svc = buildService();
+    // No pending request registered → must be a safe no-op (no throw).
+    expect(() =>
+      (svc as any).handleCoSignResponse({
+        type: "cosign-response",
+        from: "node-2",
+        data: {
+          requestId: "does-not-exist",
+          slot: 2,
+          signerNodeId: "node-2",
+          signerPublicKey: "0xpk",
+          signatureCompact: "0xsig",
+          messageHash: "0x00",
+        },
+        timestamp: Date.now(),
+        ttl: 0,
+        messageId: "resp-x",
+        version: 0,
+      })
+    ).not.toThrow();
+  });
+
+  it("each requestCoSignatures send mints a FRESH messageId (retries are not history-deduped)", async () => {
+    const svc = buildService();
+    const sentIds: string[] = [];
+    // Capture broadcast messageIds.
+    (svc as any).broadcastMessage = (m: GossipMessage) => sentIds.push(m.messageId);
+    void (svc as any).requestCoSignatures(reqPayload({ requestId: "r1" }), {
+      threshold: 1,
+      timeoutMs: 5,
+    });
+    void (svc as any).requestCoSignatures(reqPayload({ requestId: "r2" }), {
+      threshold: 1,
+      timeoutMs: 5,
+    });
+    expect(sentIds).toHaveLength(2);
+    expect(sentIds[0]).not.toBe(sentIds[1]); // fresh uuid per send
+    await new Promise(r => setTimeout(r, 10)); // let the timers clear
+  });
+});

--- a/src/modules/gossip/gossip-cosign.spec.ts
+++ b/src/modules/gossip/gossip-cosign.spec.ts
@@ -4,6 +4,7 @@ import type {
   CoSignResponsePayload,
   GossipMessage,
 } from "./gossip.interfaces.js";
+import { PROOF_SCHEMA_VERSION } from "../audit/proof-archive.js";
 
 /**
  * inc-2-live — gossip co-sign TRANSPORT tests. The gossip service is a dumb point-to-point
@@ -40,6 +41,7 @@ function buildService(nodeId = "self-node"): GossipService {
 
 function reqPayload(overrides: Partial<CoSignRequestPayload> = {}): CoSignRequestPayload {
   return {
+    proofSchemaVersion: PROOF_SCHEMA_VERSION,
     step: "queue",
     operator: "0x" + "12".repeat(20),
     slashLevel: 1,

--- a/src/modules/gossip/gossip-cosign.spec.ts
+++ b/src/modules/gossip/gossip-cosign.spec.ts
@@ -287,6 +287,57 @@ describe("GossipService co-sign collector: validate + dedupKey", () => {
     expect(responses.map(r => r.slot).sort((a, b) => a - b)).toEqual([1, 2]);
   });
 
+  it("MEDIUM 1: EXACT resends are dropped BEFORE validate + total validations are capped", async () => {
+    const svc = buildService();
+    let validateCalls = 0;
+    const countingValidate = async (r: CoSignResponsePayload) => {
+      validateCalls++;
+      return (r as any).ok === true;
+    };
+    const promise = (svc as any).requestCoSignatures(reqPayload({ requestId: "req-cap" }), {
+      threshold: 3,
+      timeoutMs: 20,
+      validate: countingValidate,
+      dedupKey: bySlot,
+      maxValidations: 5,
+    }) as Promise<CoSignResponsePayload[]>;
+
+    // Same peer resends the IDENTICAL bogus response 10× → validate runs at most ONCE for it.
+    for (let i = 0; i < 10; i++) {
+      (svc as any).handleCoSignResponse(respMsg("flood", 5, false, "req-cap"));
+    }
+    await flush();
+    expect(validateCalls).toBe(1); // exact-dedup collapsed the 10 resends to a single validate
+
+    // Distinct bogus responses beyond the cap are dropped without validating.
+    for (let i = 0; i < 20; i++) {
+      (svc as any).handleCoSignResponse(respMsg(`d-${i}`, (i % 12) + 1, false, "req-cap"));
+    }
+    await flush();
+    expect(validateCalls).toBeLessThanOrEqual(5); // maxValidations cap enforced
+    await promise; // times out (never reached threshold) — bogus flood never formed a quorum
+  });
+
+  it("MEDIUM 1: a bogus early claim on a slot does NOT poison the honest signer's real response", async () => {
+    const svc = buildService();
+    const promise = (svc as any).requestCoSignatures(reqPayload({ requestId: "req-poison" }), {
+      threshold: 1,
+      timeoutMs: 1000,
+      validate: validateOk,
+      dedupKey: bySlot,
+    }) as Promise<CoSignResponsePayload[]>;
+
+    // Attacker claims slot 2 FIRST with a bogus (invalid) response → fails validate, not counted.
+    (svc as any).handleCoSignResponse(respMsg("attacker", 2, false, "req-poison"));
+    await flush();
+    // The HONEST dvt2 then sends its real slot-2 response → still validates + counts (no poisoning).
+    (svc as any).handleCoSignResponse(respMsg("dvt2", 2, true, "req-poison"));
+    const responses = await promise;
+    expect(responses).toHaveLength(1);
+    expect(responses[0].slot).toBe(2);
+    expect(responses[0].signerNodeId).toBe("dvt2");
+  });
+
   it("resolves EARLY once enough validated unique-slot responses arrive (before timeout)", async () => {
     const svc = buildService();
     const promise = (svc as any).requestCoSignatures(reqPayload({ requestId: "req-V" }), {

--- a/src/modules/gossip/gossip.interfaces.ts
+++ b/src/modules/gossip/gossip.interfaces.ts
@@ -1,5 +1,7 @@
+import type { CoSignRequest } from "../audit/slash-consensus.js";
+
 export interface GossipMessage {
-  type: "gossip" | "sync" | "heartbeat" | "join" | "leave";
+  type: "gossip" | "sync" | "heartbeat" | "join" | "leave" | "cosign-request" | "cosign-response";
   from: string;
   to?: string; // Optional: for directed messages
   data: any;
@@ -7,6 +9,36 @@ export interface GossipMessage {
   ttl: number; // Time to live for message propagation
   messageId: string; // Unique message identifier
   version: number; // Version for conflict resolution
+}
+
+/**
+ * DVT Phase 2 (目标2, inc-2 live) — slash quorum co-sign transport payloads.
+ *
+ * The gossip layer is a DUMB point-to-point transport for these: it carries the request to
+ * peers and routes their responses back by `requestId`, and runs ZERO slash logic (no rule
+ * evaluation, no signing, no verification). All safety lives in the registered handler
+ * (GossipQuorumCoSigner) — the gossip service only invokes it and relays its reply.
+ */
+export interface CoSignRequestPayload extends CoSignRequest {
+  /** Correlation id, distinct from the gossip `messageId` (which is fresh per send). */
+  requestId: string;
+  /** The requesting node's id (for logging / observability only — never trusted). */
+  requesterNodeId: string;
+}
+
+export interface CoSignResponsePayload {
+  /** Echoes the request's correlation id so the requester can route this reply. */
+  requestId: string;
+  /** The signer's 1-indexed on-chain validator slot. */
+  slot: number;
+  /** The responding node's id. */
+  signerNodeId: string;
+  /** The signer's 48-byte compressed G1 public key (0x-hex). */
+  signerPublicKey: string;
+  /** The signer's 96-byte compressed G2 signature over hashToCurve(messageHash) (0x-hex). */
+  signatureCompact: string;
+  /** The messageHash the responder recomputed and actually signed. */
+  messageHash: string;
 }
 
 export interface PeerInfo {

--- a/src/modules/gossip/gossip.service.ts
+++ b/src/modules/gossip/gossip.service.ts
@@ -57,12 +57,20 @@ export class GossipService implements OnModuleInit, OnModuleDestroy {
     | ((payload: CoSignRequestPayload) => Promise<CoSignResponsePayload | null>)
     | null = null;
 
-  /** In-flight co-sign requests this node originated, keyed by requestId (correlation id). */
+  /**
+   * In-flight co-sign requests this node originated, keyed by requestId (correlation id). Only
+   * responses that pass the optional async `validate` are counted, and they are deduped by the
+   * optional `dedupKey` (the co-signer keys by on-chain slot) — so a single connected peer cannot
+   * crowd out honest signers with multiple bogus responses and force a premature under-threshold
+   * resolution (MEDIUM 1). `validated` holds the accepted, deduped responses.
+   */
   private pendingCoSign = new Map<
     string,
     {
-      responses: Map<string, CoSignResponsePayload>;
+      validated: Map<string | number, CoSignResponsePayload>;
       threshold: number;
+      validate?: (resp: CoSignResponsePayload) => Promise<boolean>;
+      dedupKey?: (resp: CoSignResponsePayload) => string | number;
       finish: () => void;
       timer: NodeJS.Timeout | null;
     }
@@ -555,28 +563,42 @@ export class GossipService implements OnModuleInit, OnModuleDestroy {
 
   /**
    * Broadcast a co-sign request to all connected peers and collect their responses, keyed by
-   * `requestId`. Resolves early once `threshold` DISTINCT signer nodes have replied (dedup by
-   * signerNodeId), or on `timeoutMs` with whatever partial set arrived. Always clears the timer
-   * and the pending entry. `threshold <= 0` resolves immediately with an empty set (the caller
-   * needs no peer signatures beyond its own self-contribution).
+   * `requestId`. Resolves early once `threshold` VALIDATED, unique-`dedupKey` responses have
+   * arrived, or on `timeoutMs` with whatever validated partial set accrued. Always clears the timer
+   * and the pending entry (no leak). `threshold <= 0` resolves immediately with an empty set (the
+   * caller needs no peer signatures beyond its own self-contribution).
+   *
+   * MEDIUM 1 (Codex): the optional `validate` counts ONLY cryptographically/on-chain-valid
+   * responses toward the threshold, and `dedupKey` (the co-signer keys by on-chain slot) collapses
+   * duplicates — so one connected peer cannot flood many bogus responses with distinct signer ids,
+   * crowd out honest signers, and force a premature under-threshold resolution. Absent `validate`,
+   * every response counts (legacy transport behaviour); absent `dedupKey`, responses dedup by
+   * `signerNodeId`.
    */
   async requestCoSignatures(
     payload: CoSignRequestPayload,
-    opts: { threshold: number; timeoutMs: number }
+    opts: {
+      threshold: number;
+      timeoutMs: number;
+      validate?: (resp: CoSignResponsePayload) => Promise<boolean>;
+      dedupKey?: (resp: CoSignResponsePayload) => string | number;
+    }
   ): Promise<CoSignResponsePayload[]> {
     return new Promise<CoSignResponsePayload[]>(resolve => {
-      const responses = new Map<string, CoSignResponsePayload>();
+      const validated = new Map<string | number, CoSignResponsePayload>();
       let done = false;
       const finish = () => {
         if (done) return;
         done = true;
         if (entry.timer) clearTimeout(entry.timer);
         this.pendingCoSign.delete(payload.requestId);
-        resolve(Array.from(responses.values()));
+        resolve(Array.from(validated.values()));
       };
       const entry = {
-        responses,
+        validated,
         threshold: opts.threshold,
+        validate: opts.validate,
+        dedupKey: opts.dedupKey,
         finish,
         timer: null as NodeJS.Timeout | null,
       };
@@ -631,16 +653,47 @@ export class GossipService implements OnModuleInit, OnModuleDestroy {
       });
   }
 
-  /** Route a co-sign response back to the originating requestCoSignatures collector. */
+  /**
+   * Route a co-sign response back to the originating requestCoSignatures collector. A late,
+   * duplicate, or cross-requestId response whose collector already resolved is ignored (the pending
+   * entry is gone). When a `validate` is configured the response is counted ONLY after it passes
+   * (async) — so a bogus response never contributes toward the threshold (MEDIUM 1).
+   */
   private handleCoSignResponse(message: GossipMessage): void {
     const payload = message.data as CoSignResponsePayload;
     if (!payload || typeof payload.requestId !== "string") return;
     if (typeof payload.signerNodeId !== "string") return;
     const pending = this.pendingCoSign.get(payload.requestId);
     if (!pending) return; // unknown / already-resolved request → ignore
-    // Dedup by signer node id: a peer replying twice does not double-count toward threshold.
-    pending.responses.set(payload.signerNodeId, payload);
-    if (pending.responses.size >= pending.threshold) {
+    if (pending.validate) {
+      // Validate asynchronously; count ONLY on success. Failures (invalid sig / bad on-chain
+      // binding) or validator errors are silently dropped and never reach the threshold.
+      void pending
+        .validate(payload)
+        .then(ok => {
+          if (ok) this.countValidatedResponse(payload.requestId, payload);
+        })
+        .catch(() => {
+          /* validator threw → treat as invalid, drop */
+        });
+    } else {
+      this.countValidatedResponse(payload.requestId, payload);
+    }
+  }
+
+  /**
+   * Record a VALIDATED co-sign response toward its collector's threshold, deduped by `dedupKey`
+   * (default: signerNodeId). Re-reads the pending entry so a response whose validation finished
+   * AFTER the collector already resolved (timeout / threshold reached) is safely ignored. Resolves
+   * the collector once enough unique-key validated responses have accrued.
+   */
+  private countValidatedResponse(requestId: string, payload: CoSignResponsePayload): void {
+    const pending = this.pendingCoSign.get(requestId);
+    if (!pending) return; // collector already finished/cleaned, or cross-requestId → ignore
+    const key = pending.dedupKey ? pending.dedupKey(payload) : payload.signerNodeId;
+    if (pending.validated.has(key)) return; // dedup: same slot/node counts once
+    pending.validated.set(key, payload);
+    if (pending.validated.size >= pending.threshold) {
       pending.finish();
     }
   }

--- a/src/modules/gossip/gossip.service.ts
+++ b/src/modules/gossip/gossip.service.ts
@@ -14,6 +14,8 @@ import {
   GossipConfig,
   GossipStats,
   MessageHistory,
+  CoSignRequestPayload,
+  CoSignResponsePayload,
 } from "./gossip.interfaces.js";
 import { GossipWhitelistValidator } from "./gossip-whitelist-validator.js";
 
@@ -45,6 +47,26 @@ export class GossipService implements OnModuleInit, OnModuleDestroy {
     gossipRounds: 0,
     lastGossipTime: null,
   };
+
+  /**
+   * DVT slash quorum co-sign (inc-2 live). A single registered handler re-verifies + signs an
+   * incoming request; the gossip service stays ignorant of AuditService (one-way DI). Null when
+   * this node is disarmed → every request is silently refused (fail-closed).
+   */
+  private coSignHandler:
+    | ((payload: CoSignRequestPayload) => Promise<CoSignResponsePayload | null>)
+    | null = null;
+
+  /** In-flight co-sign requests this node originated, keyed by requestId (correlation id). */
+  private pendingCoSign = new Map<
+    string,
+    {
+      responses: Map<string, CoSignResponsePayload>;
+      threshold: number;
+      finish: () => void;
+      timer: NodeJS.Timeout | null;
+    }
+  >();
 
   constructor(
     private configService: ConfigService,
@@ -319,6 +341,14 @@ export class GossipService implements OnModuleInit, OnModuleDestroy {
         this.handleHeartbeatMessage(message);
         break;
 
+      case "cosign-request":
+        this.handleCoSignRequest(ws, message);
+        break;
+
+      case "cosign-response":
+        this.handleCoSignResponse(message);
+        break;
+
       default:
         console.log(`Unknown gossip message type: ${message.type}`);
     }
@@ -502,6 +532,116 @@ export class GossipService implements OnModuleInit, OnModuleDestroy {
       peer.lastSeen = new Date();
       peer.status = "active";
       peer.heartbeatCount++;
+    }
+  }
+
+  // ── DVT slash quorum co-sign transport (inc-2 live) ─────────────────────────────
+  //
+  // POINT-TO-POINT only: co-sign messages are sent with ttl=0 so handleGossipMessage NEVER
+  // flood-propagates them, and each carries a FRESH messageId (correlation is the separate
+  // requestId) so the history-dedup can't drop a legitimate retry. The gossip service runs
+  // ZERO slash logic — it invokes the registered handler and relays the reply, nothing more.
+
+  /**
+   * Register the single co-sign handler (GossipQuorumCoSigner.verifyAndSign). Keeps the gossip
+   * service decoupled from AuditService: it only knows "call this to get a signed response or a
+   * null refusal". A disarmed node never registers one → all requests are silently refused.
+   */
+  registerCoSignHandler(
+    fn: (payload: CoSignRequestPayload) => Promise<CoSignResponsePayload | null>
+  ): void {
+    this.coSignHandler = fn;
+  }
+
+  /**
+   * Broadcast a co-sign request to all connected peers and collect their responses, keyed by
+   * `requestId`. Resolves early once `threshold` DISTINCT signer nodes have replied (dedup by
+   * signerNodeId), or on `timeoutMs` with whatever partial set arrived. Always clears the timer
+   * and the pending entry. `threshold <= 0` resolves immediately with an empty set (the caller
+   * needs no peer signatures beyond its own self-contribution).
+   */
+  async requestCoSignatures(
+    payload: CoSignRequestPayload,
+    opts: { threshold: number; timeoutMs: number }
+  ): Promise<CoSignResponsePayload[]> {
+    return new Promise<CoSignResponsePayload[]>(resolve => {
+      const responses = new Map<string, CoSignResponsePayload>();
+      let done = false;
+      const finish = () => {
+        if (done) return;
+        done = true;
+        if (entry.timer) clearTimeout(entry.timer);
+        this.pendingCoSign.delete(payload.requestId);
+        resolve(Array.from(responses.values()));
+      };
+      const entry = {
+        responses,
+        threshold: opts.threshold,
+        finish,
+        timer: null as NodeJS.Timeout | null,
+      };
+      this.pendingCoSign.set(payload.requestId, entry);
+
+      if (opts.threshold <= 0) {
+        finish();
+        return;
+      }
+      entry.timer = setTimeout(finish, opts.timeoutMs);
+
+      const message: GossipMessage = {
+        type: "cosign-request",
+        from: this.getNodeId(),
+        data: payload,
+        timestamp: Date.now(),
+        ttl: 0, // point-to-point — never flood-propagated
+        messageId: uuidv4(), // fresh per send so history-dedup never drops a retry
+        version: this.nodeState.version,
+      };
+      this.broadcastMessage(message);
+    });
+  }
+
+  /**
+   * Handle an incoming co-sign request: hand it to the registered handler and, if the handler
+   * returns a signed response (non-null), reply on the SAME socket. A null return (refusal) is a
+   * silent, fail-closed no-op. No propagation — this is a directed request/response.
+   */
+  private handleCoSignRequest(ws: WebSocket, message: GossipMessage): void {
+    const handler = this.coSignHandler;
+    if (!handler) return; // disarmed / no handler → silent fail-closed refusal
+    const payload = message.data as CoSignRequestPayload;
+    void handler(payload)
+      .then(resp => {
+        if (resp === null) return; // handler refused → silent
+        const reply: GossipMessage = {
+          type: "cosign-response",
+          from: this.getNodeId(),
+          to: message.from,
+          data: resp,
+          timestamp: Date.now(),
+          ttl: 0, // directed reply — never propagated
+          messageId: uuidv4(),
+          version: this.nodeState.version,
+        };
+        this.sendMessage(ws, reply);
+        this.stats.messagesSent++;
+      })
+      .catch(error => {
+        console.error("Co-sign request handler error:", error);
+      });
+  }
+
+  /** Route a co-sign response back to the originating requestCoSignatures collector. */
+  private handleCoSignResponse(message: GossipMessage): void {
+    const payload = message.data as CoSignResponsePayload;
+    if (!payload || typeof payload.requestId !== "string") return;
+    if (typeof payload.signerNodeId !== "string") return;
+    const pending = this.pendingCoSign.get(payload.requestId);
+    if (!pending) return; // unknown / already-resolved request → ignore
+    // Dedup by signer node id: a peer replying twice does not double-count toward threshold.
+    pending.responses.set(payload.signerNodeId, payload);
+    if (pending.responses.size >= pending.threshold) {
+      pending.finish();
     }
   }
 

--- a/src/modules/gossip/gossip.service.ts
+++ b/src/modules/gossip/gossip.service.ts
@@ -81,6 +81,14 @@ export class GossipService implements OnModuleInit, OnModuleDestroy {
       seenExact: Set<string>;
       validationsStarted: number;
       maxValidations: number;
+      // finding-3 (per-connection anti-DoS): a single compromised/known peer flooding distinct bogus
+      // responses (varying signerNodeId/slot/sig) could consume the whole global `maxValidations`
+      // budget before honest peers' responses arrive → honest signers dropped. signerNodeId/from is
+      // attacker-controlled, so we rate-limit by the CONNECTION (ws) — the real, un-forgeable
+      // identity. Each connection gets at most `perConnCap` validations; the global cap + exact-dedup
+      // remain as backstops. Responses injected with no ws (tests) skip only the per-connection check.
+      perConn: Map<WebSocket, number>;
+      perConnCap: number;
     }
   >();
 
@@ -362,7 +370,7 @@ export class GossipService implements OnModuleInit, OnModuleDestroy {
         break;
 
       case "cosign-response":
-        this.handleCoSignResponse(message);
+        this.handleCoSignResponse(message, ws);
         break;
 
       default:
@@ -592,6 +600,10 @@ export class GossipService implements OnModuleInit, OnModuleDestroy {
       dedupKey?: (resp: CoSignResponsePayload) => string | number;
       /** Hard cap on validate() calls per request (flood backstop). Default 64. */
       maxValidations?: number;
+      /** Per-connection cap on validate() calls (finding-3). A legit peer holds ONE slot, so ~1
+       *  response; 4 leaves margin for retries while stopping one peer from exhausting the global
+       *  budget. Default 4. */
+      perConnCap?: number;
     }
   ): Promise<CoSignResponsePayload[]> {
     return new Promise<CoSignResponsePayload[]>(resolve => {
@@ -614,6 +626,8 @@ export class GossipService implements OnModuleInit, OnModuleDestroy {
         seenExact: new Set<string>(),
         validationsStarted: 0,
         maxValidations: Math.max(1, opts.maxValidations ?? 64),
+        perConn: new Map<WebSocket, number>(),
+        perConnCap: Math.max(1, opts.perConnCap ?? 4),
       };
       this.pendingCoSign.set(payload.requestId, entry);
 
@@ -671,8 +685,14 @@ export class GossipService implements OnModuleInit, OnModuleDestroy {
    * duplicate, or cross-requestId response whose collector already resolved is ignored (the pending
    * entry is gone). When a `validate` is configured the response is counted ONLY after it passes
    * (async) — so a bogus response never contributes toward the threshold (MEDIUM 1).
+   *
+   * `ws` is the SOURCE connection (finding-3). It is the un-forgeable per-peer identity used to
+   * rate-limit validations per connection so one flooding peer cannot exhaust the global budget and
+   * crowd out honest signers arriving on other connections. It is optional: tests inject responses
+   * directly with no ws, in which case only the per-connection check is skipped (global cap +
+   * exact-dedup still apply).
    */
-  private handleCoSignResponse(message: GossipMessage): void {
+  private handleCoSignResponse(message: GossipMessage, ws?: WebSocket): void {
     const payload = message.data as CoSignResponsePayload;
     if (!payload || typeof payload.requestId !== "string") return;
     if (typeof payload.signerNodeId !== "string") return;
@@ -687,7 +707,12 @@ export class GossipService implements OnModuleInit, OnModuleDestroy {
       const exactKey = `${payload.signerNodeId}|${payload.slot}|${payload.signatureCompact}`;
       if (pending.seenExact.has(exactKey)) return;
       pending.seenExact.add(exactKey);
+      // finding-3: PER-CONNECTION cap. A single connection cannot start more than `perConnCap`
+      // validations, so a flooder on one ws can't consume the whole global budget before honest
+      // peers' responses (on OTHER connections) are validated. Skipped when ws is absent (tests).
+      if (ws && (pending.perConn.get(ws) ?? 0) >= pending.perConnCap) return;
       if (pending.validationsStarted >= pending.maxValidations) return;
+      if (ws) pending.perConn.set(ws, (pending.perConn.get(ws) ?? 0) + 1);
       pending.validationsStarted++;
       // Validate asynchronously; count ONLY on success. Failures (invalid sig / bad on-chain
       // binding) or validator errors are silently dropped and never reach the threshold.

--- a/src/modules/gossip/gossip.service.ts
+++ b/src/modules/gossip/gossip.service.ts
@@ -73,6 +73,14 @@ export class GossipService implements OnModuleInit, OnModuleDestroy {
       dedupKey?: (resp: CoSignResponsePayload) => string | number;
       finish: () => void;
       timer: NodeJS.Timeout | null;
+      // MEDIUM 1 (Codex R2) — bound validation work against a response flood without letting a
+      // peer poison a slot: skip EXACT resends before the async validate (identical response adds
+      // nothing), and cap the total number of validations started per request. Post-validate slot
+      // dedup (in `validated`) still decides the quorum, so an early bogus slot claim can never
+      // suppress the honest signer's real response for that slot.
+      seenExact: Set<string>;
+      validationsStarted: number;
+      maxValidations: number;
     }
   >();
 
@@ -582,6 +590,8 @@ export class GossipService implements OnModuleInit, OnModuleDestroy {
       timeoutMs: number;
       validate?: (resp: CoSignResponsePayload) => Promise<boolean>;
       dedupKey?: (resp: CoSignResponsePayload) => string | number;
+      /** Hard cap on validate() calls per request (flood backstop). Default 64. */
+      maxValidations?: number;
     }
   ): Promise<CoSignResponsePayload[]> {
     return new Promise<CoSignResponsePayload[]>(resolve => {
@@ -601,6 +611,9 @@ export class GossipService implements OnModuleInit, OnModuleDestroy {
         dedupKey: opts.dedupKey,
         finish,
         timer: null as NodeJS.Timeout | null,
+        seenExact: new Set<string>(),
+        validationsStarted: 0,
+        maxValidations: Math.max(1, opts.maxValidations ?? 64),
       };
       this.pendingCoSign.set(payload.requestId, entry);
 
@@ -666,6 +679,16 @@ export class GossipService implements OnModuleInit, OnModuleDestroy {
     const pending = this.pendingCoSign.get(payload.requestId);
     if (!pending) return; // unknown / already-resolved request → ignore
     if (pending.validate) {
+      // MEDIUM 1 (Codex R2): bound validation work BEFORE the expensive async validate.
+      // (a) Drop EXACT resends (same signer/slot/signature) — identical, adds nothing, and this
+      //     keys on the FULL response so it can never poison a slot the honest signer will claim.
+      // (b) Cap total validations per request as a flood backstop. Honest signers (≤ slot count)
+      //     fit far under the cap; a compromised peer spamming distinct bogus responses is bounded.
+      const exactKey = `${payload.signerNodeId}|${payload.slot}|${payload.signatureCompact}`;
+      if (pending.seenExact.has(exactKey)) return;
+      pending.seenExact.add(exactKey);
+      if (pending.validationsStarted >= pending.maxValidations) return;
+      pending.validationsStarted++;
       // Validate asynchronously; count ONLY on success. Failures (invalid sig / bad on-chain
       // binding) or validator errors are silently dropped and never reach the threshold.
       void pending


### PR DESCRIPTION
## CC-13 inc-2-live — real gossip BLS quorum co-signer

SP completed the on-chain prerequisites (Seeder CC-13): `applyBLSAggregator` + `addValidator×3` + `registerBLSPublicKey×3`, slots **dvt1=1 / dvt2=2 / dvt3=3** on BLSAggregator `0xF51c…8B13` / DVTValidator `0x568b1486…`. This replaces the `PendingSlotCoSigner` stub (which threw) with the **real gossip-based BLS quorum co-signer** that drives on-chain GToken slashing — the last piece of 目标2.

**Still default-off** (`AUDIT_EXECUTE_SLASH`). The stub remains the wiring default when disarmed.

### The safety model (this executes real slashes)
A node NEVER blindly signs a hash a peer sends. Each armed node independently:
1. re-derives the `messageHash` from the **structured** `CoSignRequest` (never trusts the requester's hash),
2. **independently re-runs the credit-over-limit audit** at the deterministic `epoch` block and reconstructs the `proofHash`, and for the execute step requires **`proofHash === evidenceHash`** (a substituted/innocent operator yields a different proofHash → refusal),
3. resolves its own on-chain slot, then signs — **fail-closed on any doubt** (not-armed / not-watchlisted / hash-mismatch / unconfirmed / no-slot / RPC error → refuse).

The requester validates **every** response before counting it: recompute+match hash, **cryptographic BLS verify**, **on-chain slot→key binding** (uncompressed EIP-2537 compare + non-zero validator), dedup by slot. **Strict threshold** (WARNING 2/3, MINOR/MAJOR 3/3) — under-threshold → **throw**, never submitting a proof that would revert.

### signerMask convention — PINNED
Verified against `BLSAggregator.sol:772` (`for slot 1..MAX: if ((signerMask >> (slot-1)) & 1)`): **slot `s` → bit `s-1`**. `buildSignerMask([1,2,3]) = 7n`. One tested helper.

### Files
- **NEW** `gossip-quorum-cosigner.ts` (+ spec, 20 tests) — responder `verifyAndSign` + requester `coSign`.
- **NEW** `gossip-cosign.spec.ts` (8 transport tests).
- `slash-consensus.ts` — structured `CoSignRequest` seam, `buildSignerMask`/`recomputeMessageHash`, `MAX_VALIDATORS=13`, `QUORUM_COSIGNER` token.
- `gossip.{interfaces,service}.ts` — `cosign-request/response` (point-to-point, ttl 0, `requestId` correlation, fresh `messageId`); transport only, zero slash logic.
- `blockchain.service.ts` — `getValidatorAtSlot` / `getBlsPublicKeyAtSlot` / `getSlotForValidator`.
- `audit.service.ts` — structured call sites + `verifyViolationForCoSign` responder verifier; `audit.module.ts` factory provider (armed→real, disarmed→stub); `configuration.ts` co-sign knobs.

### Tests: 291/291 (+28). type-check / build / lint clean.

### Confirmable ONLY against the 3 live deployed nodes
- The produced `signerMask` + 256B `sigG2` accepted by the real `BLSAggregator.verifyAndExecute` pairing (EIP-2537 precompiles) + `DVTValidator.queue/executeWithProof`.
- Real 3-node gossip agreement/latency; each node reconstructing the identical `messageHash`/`proofHash`/`epoch`.
- `getBLSPublicKey` live ABI tuple shape; `getBlsPublicKeyAtSlot` uncompressed equality vs live registered keys.

Refs #163, CC-13.
