### PR TITLE
feat(CC-22 KMS-TEE): key-less node_state boot for merged TEE-custody mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,20 @@ BLS 签名基础设施：链下签名聚合服务 + 链上验证合约，作为�
 
 ### 🔑 BLS 密钥托管模式 / Key Custody(独立 vs KMS 合并）
 
-DVT 的 BLS 共签私钥有两种托管方式，**同一个二进制、`RUST_SIGNER_URL` 一个 env 切换**，不强绑定 KMS：
+DVT 的 BLS 共签私钥有两种托管方式，**同一个二进制、`RUST_SIGNER_URL`
+一个 env 切换**，不强绑定 KMS：
 
-| 模式 | BLS 私钥在哪 | 抗提取 | 自启 | 配置 |
-|---|---|---|---|---|
-| **独立(keystore)** | EIP-2335 keystore(盘上加密 + 手动密码) | 盘窃安全；攻破运行中 DVT 可从 RAM 挖 | ❌ 断电需重输密码 | `RUST_SIGNER_URL` 不设(默认) |
-| **KMS-TEE 合并** | AirAccount KMS 的 TEE(**永不出 TEE**) | **强(= KMS 级，攻破 DVT 也挖不到)** | ✅ 无需密码 | `RUST_SIGNER_URL=http://127.0.0.1:3100` |
+| 模式               | BLS 私钥在哪                           | 抗提取                               | 自启              | 配置                                    |
+| ------------------ | -------------------------------------- | ------------------------------------ | ----------------- | --------------------------------------- |
+| **独立(keystore)** | EIP-2335 keystore(盘上加密 + 手动密码) | 盘窃安全；攻破运行中 DVT 可从 RAM 挖 | ❌ 断电需重输密码 | `RUST_SIGNER_URL` 不设(默认)            |
+| **KMS-TEE 合并**   | AirAccount KMS 的 TEE(**永不出 TEE**)  | **强(= KMS 级，攻破 DVT 也挖不到)**  | ✅ 无需密码       | `RUST_SIGNER_URL=http://127.0.0.1:3100` |
 
 - **只跑 DVT、不跑 KMS 的社区** → **独立 keystore 模式**(默认，零 KMS 依赖)。
-- **同板跑 [AirAccount KMS](https://github.com/AAStarCommunity/AirAccount) + DVT 的社区** → **KMS-TEE 模式**：DVT 验完 owner-auth 后调 KMS 内部 signer(`127.0.0.1:3100`，仅本地、不经公网)只取签名，私钥全程不出 TEE、断电自启不用重输密码。签名与 keystore 模式**字节一致**(同 blst / @noble / DST)，链上 validator 无差别。接入见 AirAccount `kms/docs/dvt-tee-bls-custody-design.md`。
+- **同板跑 [AirAccount KMS](https://github.com/AAStarCommunity/AirAccount) +
+  DVT 的社区** →
+  **KMS-TEE 模式**：DVT 验完 owner-auth 后调 KMS 内部 signer(`127.0.0.1:3100`，仅本地、不经公网)只取签名，私钥全程不出 TEE、断电自启不用重输密码。签名与 keystore 模式**字节一致**(同 blst
+  / @noble / DST)，链上 validator 无差别。接入见 AirAccount
+  `kms/docs/dvt-tee-bls-custody-design.md`。
 
 ### 📘 aNode DVT 运维 & 快速上手
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@
 **v1.1.0**）—— 一套 ERC-4337
 BLS 签名基础设施：链下签名聚合服务 + 链上验证合约，作为账户的「独立第二因子」防 owner-key 被盗。
 
+### 🔑 BLS 密钥托管模式 / Key Custody(独立 vs KMS 合并）
+
+DVT 的 BLS 共签私钥有两种托管方式，**同一个二进制、`RUST_SIGNER_URL` 一个 env 切换**，不强绑定 KMS：
+
+| 模式 | BLS 私钥在哪 | 抗提取 | 自启 | 配置 |
+|---|---|---|---|---|
+| **独立(keystore)** | EIP-2335 keystore(盘上加密 + 手动密码) | 盘窃安全；攻破运行中 DVT 可从 RAM 挖 | ❌ 断电需重输密码 | `RUST_SIGNER_URL` 不设(默认) |
+| **KMS-TEE 合并** | AirAccount KMS 的 TEE(**永不出 TEE**) | **强(= KMS 级，攻破 DVT 也挖不到)** | ✅ 无需密码 | `RUST_SIGNER_URL=http://127.0.0.1:3100` |
+
+- **只跑 DVT、不跑 KMS 的社区** → **独立 keystore 模式**(默认，零 KMS 依赖)。
+- **同板跑 [AirAccount KMS](https://github.com/AAStarCommunity/AirAccount) + DVT 的社区** → **KMS-TEE 模式**：DVT 验完 owner-auth 后调 KMS 内部 signer(`127.0.0.1:3100`，仅本地、不经公网)只取签名，私钥全程不出 TEE、断电自启不用重输密码。签名与 keystore 模式**字节一致**(同 blst / @noble / DST)，链上 validator 无差别。接入见 AirAccount `kms/docs/dvt-tee-bls-custody-design.md`。
+
 ### 📘 aNode DVT 运维 & 快速上手
 
 - **运维手册（启动/监控/停止/恢复/报错/修复 + 生产 aNode 启动步骤）** →

--- a/deploy/imx93/README.md
+++ b/deploy/imx93/README.md
@@ -140,9 +140,9 @@ same seam.
   KMS `BlsGenKey` seals the key + returns the pubkey → write `node_state.json`
   with that `publicKey` and `nodeId = keccak256(EIP-2537 pubkey)`, then register
   on-chain (`registerWithProof`).
-- **Anti-abuse stays on the DVT host** (owner-auth `isValidOwnerAuth` eth_call
+- **Anti-abuse stays on the DVT host** (owner-auth `isValidOwnerAuth` eth*call
   is a host job — the TA can't reach the chain). The TEE only raises single-node
-  key _extraction_ resistance to KMS level; the load-bearing security is the
+  key \_extraction* resistance to KMS level; the load-bearing security is the
   threshold (≥3 independent nodes) + on-chain owner-auth. Slot-resolution and
   the queue/execute tx sender still use the **operator EOA
   (`ETH_PRIVATE_KEY`)**, a separate k1 key — that stays on host.

--- a/deploy/imx93/README.md
+++ b/deploy/imx93/README.md
@@ -118,12 +118,41 @@ ln -sfn /opt/aastar-dvt/releases/<old-version> /opt/aastar-dvt/current
 systemctl restart aastar-dvt@node1
 ```
 
+## KMS-TEE merged mode (BLS key sealed in the TEE, CC-22)
+
+When DVT runs **alongside KMS on the board**, the DVT's BLS key can live in the
+KMS OP-TEE TA and never touch disk (AirAccount `dvt-tee-bls-custody`, Variant
+B). This reuses the SAME `RUST_SIGNER_URL` seam below — the KMS host exposes an
+internal `/sign` endpoint (`127.0.0.1`, not public) that implements the signer
+contract
+`POST /sign {user_op_hash, node_id} → {signature, signature_compact, public_key}`
+(blst `min_pk`, DST `BLS_SIG_…_POP_`, EIP-2537 — byte-identical,
+golden-verified). DVT signs by **node_id only**, so no private key is needed on
+the DVT side — including the inc-2-live slash co-sign, which routes through the
+same seam.
+
+- **Node env**: `RUST_SIGNER_URL=http://127.0.0.1:<kms-port>` **and**
+  `RUST_SIGNER_REQUIRED=true` (fail-closed — never fall back to local signing;
+  there is no local key to fall back to).
+- **`node_state.json` is key-less**: `{ nodeId, publicKey }` only — NO
+  `privateKey`/`keystore`. The node boots on this ONLY when both env vars above
+  are set (otherwise it fails closed). Provision it from the TEE-generated key:
+  KMS `BlsGenKey` seals the key + returns the pubkey → write `node_state.json`
+  with that `publicKey` and `nodeId = keccak256(EIP-2537 pubkey)`, then register
+  on-chain (`registerWithProof`).
+- **Anti-abuse stays on the DVT host** (owner-auth `isValidOwnerAuth` eth_call
+  is a host job — the TA can't reach the chain). The TEE only raises single-node
+  key _extraction_ resistance to KMS level; the load-bearing security is the
+  threshold (≥3 independent nodes) + on-chain owner-auth. Slot-resolution and
+  the queue/execute tx sender still use the **operator EOA
+  (`ETH_PRIVATE_KEY`)**, a separate k1 key — that stays on host.
+
 ## Optional: hybrid Rust signer (faster BLS on ARM)
 
 Delegate BLS signing to a local Rust signer (byte-identical output —
 golden-vector verified — and faster on the A55). Fully optional: if the signer
-is down the DVT falls back to in-process Node signing. Best fit for this
-constrained board.
+is down the DVT falls back to in-process Node signing (UNLESS
+`RUST_SIGNER_REQUIRED=true`). Best fit for this constrained board.
 
 ```bash
 # (on your Mac) cross-build the arm64 signer — no Docker, uses cargo-zigbuild:

--- a/src/modules/node/node.keystore.spec.ts
+++ b/src/modules/node/node.keystore.spec.ts
@@ -169,4 +169,44 @@ describe("NodeService — EIP-2335 keystore load (#5)", () => {
       }
     );
   });
+
+  it("KMS-TEE F3: registerOnChain derives EIP-2537 from publicKey (no privateKey.substring crash)", async () => {
+    // Real compressed G1 pubkey (dvt1) so bls.G1.Point.fromHex works; NO privateKey (key in TEE).
+    const PUB =
+      "0x8067dfd1f98fd1258c0eed3886d234f81eea9371b595a1a278a49c71f8f5eda74639fa043948f7fc0ee3e6b8ec9b8555";
+    const dir = mkdtempSync(join(tmpdir(), "ks-"));
+    const file = join(dir, "node_state.json");
+    writeFileSync(file, JSON.stringify({ nodeId: "0x1f5e", nodeName: "dvt1", publicKey: PUB }));
+    let registeredWith: string | null = null;
+    const blockchain = {
+      isConfigured: () => true,
+      checkNodeRegistration: async () => false,
+      registerNodeOnChain: async (_addr: string, _id: string, eip2537: string) => {
+        registeredWith = eip2537;
+        return "0xtx";
+      },
+    } as any;
+    const blsReal = { encodePublicKeyToEIP2537: (pt: any) => "0x" + "11".repeat(4) } as any;
+    const config = {
+      get: (k: string) =>
+        k === "rustSignerUrl"
+          ? "http://127.0.0.1:3100"
+          : k === "rustSignerRequired"
+            ? true
+            : k === "validatorContractAddress"
+              ? "0xval"
+              : undefined,
+    } as unknown as ConfigService;
+    const svc = new NodeService(blsReal, blockchain, config);
+    (svc as any).nodeStateFilePath = file;
+    (svc as any).contractAddress = "0xval";
+    try {
+      (svc as any).loadExistingNodeState(); // keyless boot OK
+      const res = await svc.registerOnChain(); // must NOT crash on undefined privateKey
+      expect(res.success).toBe(true);
+      expect(registeredWith).toBe("0x" + "11".repeat(4)); // derived from the provisioned pubkey
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/modules/node/node.keystore.spec.ts
+++ b/src/modules/node/node.keystore.spec.ts
@@ -108,4 +108,65 @@ describe("NodeService — EIP-2335 keystore load (#5)", () => {
       }
     );
   });
+
+  // ── KMS-TEE (merged) mode: key-less node_state, BLS key sealed in the TEE ──────────
+  const withStateCfg = (
+    state: object,
+    cfg: Record<string, unknown>,
+    fn: (svc: NodeService) => void
+  ) => {
+    const dir = mkdtempSync(join(tmpdir(), "ks-"));
+    const file = join(dir, "node_state.json");
+    writeFileSync(file, JSON.stringify(state));
+    const config = { get: (k: string) => cfg[k] } as unknown as ConfigService;
+    const svc = new NodeService({} as any, {} as any, config);
+    (svc as any).nodeStateFilePath = file;
+    try {
+      fn(svc);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  };
+  const keylessState = () => ({
+    nodeId: "0x1",
+    nodeName: "n",
+    publicKey: "0xabcd",
+    description: "d",
+  });
+
+  it("KMS-TEE: key-less node_state boots when RUST_SIGNER_URL + RUST_SIGNER_REQUIRED=true", () => {
+    withStateCfg(
+      keylessState(),
+      { rustSignerUrl: "http://127.0.0.1:3100", rustSignerRequired: true },
+      svc => {
+        expect(() => (svc as any).loadExistingNodeState()).not.toThrow();
+        expect((svc as any).nodeState.privateKey).toBeUndefined(); // key stays in the TEE
+        expect((svc as any).nodeState.publicKey).toBe("0xabcd");
+      }
+    );
+  });
+
+  it("KMS-TEE: key-less node_state FAILS CLOSED without RUST_SIGNER_REQUIRED (could not sign)", () => {
+    withStateCfg(keylessState(), { rustSignerUrl: "http://127.0.0.1:3100" }, svc => {
+      expect(() => (svc as any).loadExistingNodeState()).toThrow(
+        /neither a keystore nor a plaintext privateKey/
+      );
+    });
+    // and with neither url nor required set
+    withStateCfg(keylessState(), {}, svc => {
+      expect(() => (svc as any).loadExistingNodeState()).toThrow(
+        /neither a keystore nor a plaintext privateKey/
+      );
+    });
+  });
+
+  it("KMS-TEE: delegated but NO publicKey → throws (pubkey still needed for nodeId/announce)", () => {
+    withStateCfg(
+      { nodeId: "0x1", nodeName: "n", description: "d" },
+      { rustSignerUrl: "http://127.0.0.1:3100", rustSignerRequired: true },
+      svc => {
+        expect(() => (svc as any).loadExistingNodeState()).toThrow(/still needs the publicKey/);
+      }
+    );
+  });
 });

--- a/src/modules/node/node.service.ts
+++ b/src/modules/node/node.service.ts
@@ -76,7 +76,28 @@ export class NodeService implements OnModuleInit {
       state.privateKey = "0x" + Buffer.from(secret).toString("hex");
       this.logger.log("BLS key loaded from encrypted keystore (EIP-2335)");
     } else if (!state.privateKey) {
-      throw new Error("node_state.json has neither a keystore nor a plaintext privateKey");
+      // Merged (KMS-TEE) mode: the BLS private key lives in the KMS TEE and NEVER touches disk.
+      // A key-less node_state.json (nodeId + publicKey only) is valid ONLY when signing is BOTH
+      // delegated (RUST_SIGNER_URL set) AND required (RUST_SIGNER_REQUIRED=true → never a local
+      // fallback) — every signature is produced by the remote TEE signer, addressed by node_id.
+      // The publicKey must still be present so nodeId derivation / gossip announcements work.
+      const delegatedAndRequired =
+        !!this.configService.get<string>("rustSignerUrl") &&
+        this.configService.get<boolean>("rustSignerRequired") === true;
+      if (!delegatedAndRequired) {
+        throw new Error(
+          "node_state.json has neither a keystore nor a plaintext privateKey " +
+            "(a key-less node_state is only valid in KMS-TEE mode: RUST_SIGNER_URL + RUST_SIGNER_REQUIRED=true)"
+        );
+      }
+      if (!state.publicKey) {
+        throw new Error(
+          "node_state.json has no privateKey and no publicKey — KMS-TEE (delegated) mode still needs the publicKey"
+        );
+      }
+      this.logger.log(
+        "BLS private key delegated to the remote TEE signer (RUST_SIGNER_REQUIRED) — no local key on disk (KMS-TEE mode)"
+      );
     }
     return state;
   }

--- a/src/modules/node/node.service.ts
+++ b/src/modules/node/node.service.ts
@@ -171,15 +171,25 @@ export class NodeService implements OnModuleInit {
       // Perform actual registration
       this.logger.log(`Registering node ${this.nodeState.nodeId} on-chain...`);
 
-      // Convert 48-byte public key to 128-byte EIP2537 format for contract registration
-      const privateKeyHex = this.nodeState.privateKey.substring(2);
-      const privateKeyBytes = new Uint8Array(privateKeyHex.length / 2);
-      for (let i = 0; i < privateKeyHex.length; i += 2) {
-        privateKeyBytes[i / 2] = parseInt(privateKeyHex.substr(i, 2), 16);
+      // Derive the 128-byte EIP-2537 public key for on-chain registration. In KMS-TEE (keyless)
+      // mode there is NO local privateKey (it's sealed in the TEE), so decompress the publicKey the
+      // TEE already provisioned into node_state.json instead of re-deriving from a private key
+      // (clestons/Codex F3 — privateKey.substring(2) would crash on undefined here).
+      const { bls, sigs } = await import("../../utils/bls.util.js");
+      let publicKeyPoint: unknown;
+      if (this.nodeState.privateKey) {
+        const privateKeyHex = this.nodeState.privateKey.substring(2);
+        const privateKeyBytes = new Uint8Array(privateKeyHex.length / 2);
+        for (let i = 0; i < privateKeyHex.length; i += 2) {
+          privateKeyBytes[i / 2] = parseInt(privateKeyHex.substr(i, 2), 16);
+        }
+        publicKeyPoint = sigs.getPublicKey(privateKeyBytes);
+      } else {
+        if (!this.nodeState.publicKey) {
+          throw new Error("Cannot register: node_state has neither a privateKey nor a publicKey");
+        }
+        publicKeyPoint = bls.G1.Point.fromHex(this.nodeState.publicKey.replace(/^0x/, ""));
       }
-
-      const { sigs } = await import("../../utils/bls.util.js");
-      const publicKeyPoint = sigs.getPublicKey(privateKeyBytes);
       const eip2537PublicKey = this.blsService.encodePublicKeyToEIP2537(publicKeyPoint);
 
       const txHash = await this.blockchainService.registerNodeOnChain(


### PR DESCRIPTION
Enables the AirAccount KMS **dvt-tee-bls-custody (Variant B)** merged deployment: the DVT BLS key is sealed in the OP-TEE TA and never touches disk. Reuses DVT's existing `RUST_SIGNER_URL` seam (DVT signs by `node_id` — `{user_op_hash, node_id} → {signature, signature_compact, public_key}`), so runtime signing (incl. the inc-2-live slash co-sign via `signDerivedHash`) works with the TEE with **no signing-code change**.

**The one required change**: `node.service.resolvePrivateKey` now boots a **key-less** `node_state.json` (nodeId + publicKey only) — but ONLY when `RUST_SIGNER_URL` is set AND `RUST_SIGNER_REQUIRED=true` (fully delegated + fail-closed). Otherwise still fails closed; publicKey still required. Verified signViaNode fallback is unreachable when required (no local key needed).

+3 tests, imx93 README documents merged mode + TEE provisioning. 348/348, clean. Refs CC-22.