### PR TITLE
feat: KMS-TEE custody mode 接入(X-Signer-Token + docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@
 **v1.1.0**）—— 一套 ERC-4337
 BLS 签名基础设施：链下签名聚合服务 + 链上验证合约，作为账户的「独立第二因子」防 owner-key 被盗。
 
+### 🔑 BLS 密钥托管模式 / Key Custody(独立 vs KMS 合并）
+
+DVT 的 BLS 共签私钥有两种托管方式，**同一个二进制、`RUST_SIGNER_URL` 一个 env 切换**，不强绑定 KMS：
+
+| 模式 | BLS 私钥在哪 | 抗提取 | 自启 | 配置 |
+|---|---|---|---|---|
+| **独立(keystore)** | EIP-2335 keystore(盘上加密 + 手动密码) | 盘窃安全；攻破运行中 DVT 可从 RAM 挖 | ❌ 断电需重输密码 | `RUST_SIGNER_URL` 不设(默认) |
+| **KMS-TEE 合并** | AirAccount KMS 的 TEE(**永不出 TEE**) | **强(= KMS 级，攻破 DVT 也挖不到)** | ✅ 无需密码 | `RUST_SIGNER_URL=http://127.0.0.1:3100` |
+
+- **只跑 DVT、不跑 KMS 的社区** → **独立 keystore 模式**(默认，零 KMS 依赖)。
+- **同板跑 [AirAccount KMS](https://github.com/AAStarCommunity/AirAccount) + DVT 的社区** → **KMS-TEE 模式**：DVT 验完 owner-auth 后调 KMS 内部 signer(`127.0.0.1:3100`，仅本地、不经公网)只取签名，私钥全程不出 TEE、断电自启不用重输密码。签名与 keystore 模式**字节一致**(同 blst / @noble / DST)，链上 validator 无差别。接入见 AirAccount `kms/docs/dvt-tee-bls-custody-design.md`。
+
 ### 📘 aNode DVT 运维 & 快速上手
 
 - **运维手册（启动/监控/停止/恢复/报错/修复 + 生产 aNode 启动步骤）** →

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -61,6 +61,11 @@ export default () => {
     // falls back to Node signing unless RUST_SIGNER_REQUIRED=true (then it fails closed).
     rustSignerUrl: process.env.RUST_SIGNER_URL || undefined,
     rustSignerRequired: process.env.RUST_SIGNER_REQUIRED === "true",
+    // KMS-TEE custody mode: when the Rust signer is AirAccount KMS (127.0.0.1:3100)
+    // and KMS has KMS_BLS_SIGNER_TOKEN set, /sign requires this shared secret in the
+    // X-Signer-Token header so only this DVT process (not any co-located process) can
+    // invoke the TEE signer. Unset = no header sent (backward-compatible).
+    rustSignerToken: process.env.RUST_SIGNER_TOKEN || undefined,
 
     // Operator alerting → aastar-monitor Telegram bot (#100). Opt-in; fire-and-forget
     // (never blocks signing/relaying). Distinct from NOTIFY_* (which alerts end users).

--- a/src/modules/bls/bls.service.ts
+++ b/src/modules/bls/bls.service.ts
@@ -163,9 +163,16 @@ export class BlsService {
     node: NodeKeyPair
   ): Promise<SignatureResult> {
     const url = `${base.replace(/\/+$/, "")}/sign`;
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    // KMS-TEE mode: attach the shared secret when configured so a KMS signer with
+    // KMS_BLS_SIGNER_TOKEN set accepts this request (and rejects other local processes).
+    const signerToken = this.configService?.get<string>("rustSignerToken");
+    if (signerToken) {
+      headers["X-Signer-Token"] = signerToken;
+    }
     const response = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers,
       body: JSON.stringify({ user_op_hash: userOpHash, node_id: node.nodeId }),
     });
     if (!response.ok) {


### PR DESCRIPTION
## 概述
DVT 接入 AirAccount KMS 的 TEE BLS 托管(Variant B,AAStarCommunity/AirAccount#153 已合并)。**不强绑定** —— `RUST_SIGNER_URL` 一个 env 切换 keystore/KMS-TEE 模式。

## 改动(很小)
- **README**:BLS 密钥托管两模式表(独立 keystore / KMS-TEE 合并)
- **`configuration.ts`**:加 `rustSignerToken`(env `RUST_SIGNER_TOKEN`)
- **`bls.service.ts` `signViaRust`**:KMS signer 设了 `KMS_BLS_SIGNER_TOKEN` 时,注入 `X-Signer-Token` header,使**只有本 DVT 进程**能调 TEE signer(Codex High#2 修复的 DVT 侧)。unset 时不发 header,**向后兼容 v1.9.0**。

## 契约(KMS 侧已就绪)
`127.0.0.1:3100 POST /sign {node_id,user_op_hash}` → `{signature(EIP-2537 256B),signature_compact,public_key}`,与 aastar-bls-signer 一致,已 @noble golden 验字节兼容。

## 发布
merge 后发 **v1.10.0**,供 AirAccount `airaccount-node` 合并版 bundle。

参考:AirAccount `kms/docs/dvt-tee-bls-custody-design.md`