### PR TITLE
chore(release): v1.10.0 — X-Signer-Token(KMS-TEE 合并模式)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yetanotheraa-validator",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Production-ready BLS signature validation infrastructure for ERC-4337 account abstraction",
   "main": "dist/main.js",
   "type": "module",


### PR DESCRIPTION
## v1.10.0
X-Signer-Token(#182)已 merge,bump 版本发布,供 AirAccount `airaccount-node` 合并版引用。

- KMS-TEE 模式:`RUST_SIGNER_TOKEN` → `X-Signer-Token` header,只有本 DVT 进程能调 KMS TEE signer。
- 向后兼容 v1.9.0(unset 时不发 header)。

merge 后 tag `v1.10.0`。