### PR TITLE
fix(lint): restore eslint under v10 — @eslint/js dep + 2 new default-error rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "ws": "^8.21.0"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@jest/globals": "^30.4.1",
         "@types/express": "^5.0.6",
         "@types/jest": "^30.0.0",
@@ -896,6 +897,27 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmmirror.com/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "picomatch": "4.0.4"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@jest/globals": "^30.4.1",
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -251,7 +251,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       toCheck.push(["AUDIT_GTOKEN_STAKING_ADDRESS", this.gtokenStakingAddress]);
     }
     for (const [name, addr] of toCheck) {
-      let code = "0x";
+      let code: string;
       try {
         code = await this.blockchainService.getCode(addr);
       } catch (err: unknown) {
@@ -1339,7 +1339,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     recentDetections: AuditDetection[];
     archivedProofCount: number;
   }> {
-    let archivedProofCount = 0;
+    let archivedProofCount: number;
     try {
       archivedProofCount = await this.archive.count();
     } catch {

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -1117,7 +1117,8 @@ export class BlockchainService {
     } catch (err: unknown) {
       const reason = err instanceof Error ? err.message : String(err);
       throw new Error(
-        `queueSlashWithProof preflight (staticCall) reverted — NOT broadcasting: ${reason}`
+        `queueSlashWithProof preflight (staticCall) reverted — NOT broadcasting: ${reason}`,
+        { cause: err }
       );
     }
     // DRY-RUN (AUDIT_DRY_RUN): the preflight above ran against the REAL contract and passed, proving
@@ -1183,7 +1184,8 @@ export class BlockchainService {
     } catch (err: unknown) {
       const reason = err instanceof Error ? err.message : String(err);
       throw new Error(
-        `executeWithProof preflight (staticCall) reverted — NOT broadcasting: ${reason}`
+        `executeWithProof preflight (staticCall) reverted — NOT broadcasting: ${reason}`,
+        { cause: err }
       );
     }
     // DRY-RUN (AUDIT_DRY_RUN): the preflight above simulated the EXACT irreversible slash against the

--- a/src/modules/gossip/gossip-validator.ts
+++ b/src/modules/gossip/gossip-validator.ts
@@ -147,7 +147,7 @@ export class GossipEndpointValidator {
     try {
       url = new URL(endpoint);
     } catch (error) {
-      throw new Error(`Invalid URL format: ${endpoint}`);
+      throw new Error(`Invalid URL format: ${endpoint}`, { cause: error });
     }
 
     // Validate protocol

--- a/src/modules/gossip/gossip-whitelist-validator.ts
+++ b/src/modules/gossip/gossip-whitelist-validator.ts
@@ -41,7 +41,7 @@ export class GossipWhitelistValidator {
     try {
       url = new URL(endpoint);
     } catch (error) {
-      throw new Error(`Invalid URL format: ${endpoint}`);
+      throw new Error(`Invalid URL format: ${endpoint}`, { cause: error });
     }
 
     // Validate protocol

--- a/src/modules/node/node.service.ts
+++ b/src/modules/node/node.service.ts
@@ -53,7 +53,7 @@ export class NodeService implements OnModuleInit {
     try {
       state = JSON.parse(readFileSync(this.nodeStateFilePath, "utf8"));
     } catch (error: any) {
-      throw new Error(`Failed to load node state: ${error.message}`);
+      throw new Error(`Failed to load node state: ${error.message}`, { cause: error });
     }
     this.nodeState = this.resolvePrivateKey(state);
   }
@@ -114,7 +114,7 @@ export class NodeService implements OnModuleInit {
       }
       writeFileSync(this.nodeStateFilePath, JSON.stringify(toWrite, null, 2), "utf8");
     } catch (error: any) {
-      throw new Error(`Failed to save node state: ${error.message}`);
+      throw new Error(`Failed to save node state: ${error.message}`, { cause: error });
     }
   }
 


### PR DESCRIPTION
## 背景
#150 把 eslint 9→10（大版本）合入 master。合并后 master 上暴露两个 breakage（PR CI 各自绿、合并后才显现）：

### 1. `@eslint/js` 模块找不到 → lint:check 整个崩溃
`eslint.config.js` `import js from "@eslint/js"`，eslint 9 会传递带入该包，**eslint 10 不再传递** → `ERR_MODULE_NOT_FOUND`。
**修复**：显式加 `@eslint/js@^10.0.1` devDependency（它版本号独立于 eslint，当前线是 10.0.1，不是 10.6.0）。

### 2. eslint 10 把两条规则提升为默认 error
- **`preserve-caught-error`（6 处）**：catch 内抛新 Error 未带 `cause` → 加 `{ cause }`。位置：blockchain queue/execute staticCall 预检、gossip URL 校验器 ×2、node_state load/save。**非行为变更**：抛出类型 + 消息不变（403-only sign gate 与 staticCall 预检契约不动），`cause` 仅补元数据。
- **`no-useless-assignment`（2 处）**：audit.service 里 `code` / `archivedProofCount` 的死初始值（后续无条件重新赋值）→ 删初始值。

## 验证
- `lint:check` **0 errors**（18 条 pre-existing warnings 不变）
- type-check + build + format:check 干净
- **364/364** 测试全绿

Claude-Session: https://claude.ai/code/session_01JrdmiUk4A258FmhDSKn9aj