### PR TITLE
chore(release): v1.11.0 — DVT autonomous audit → slash-consensus (目标2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yetanotheraa-validator",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Production-ready BLS signature validation infrastructure for ERC-4337 account abstraction",
   "main": "dist/main.js",
   "type": "module",


### PR DESCRIPTION
纯版本号 bump 1.10.0 → 1.11.0,收口 v1.10.0(X-Signer-Token)之后合入的全部内容。

## 本版内容
- **#181** AUDIT_DRY_RUN 审计模块:credit-over-limit 检测 → gossip 3-of-3 BLS quorum 共签(signerMask=7)→ 两步链上 slash(queue→createProposal→execute)+ staticCall 预检 + over-slash guard + finality-gated 证据 + proofHash 寻址归档。
- **#180** KMS-TEE keyless node_state 启动。
- **#184** eslint v10 工具链修复。
- **#144–150** 依赖 bump。

## 端到端验证(3 个真 Sepolia 节点)
- **dry-run**:staticCall 被真 verifyAndExecute 接受,零真罚。
- **Stage 3 真罚**:queue `0x18cb61a5` + execute `0x59981070` → `SlashExecuted(proposalId 3, Bob, level 1 MINOR)` + `ReputationUpdated→0`。

## ⚠️ 已知问题(release note 待决)
Stage 3 真跑暴露一个缺陷:武装模式下 **createProposal 未去重** —— 3 节点 × 多次重试各自广播,本次造出 6 个提案(id 1-6)只执行 id 3,留 5 个孤儿提案。dry-run 用 staticCall 掩盖了它。建议 v1.11.0 发布前或紧随的补丁修复(见会话报告)。

详见 `docs/RELEASE_TEST_CHECKLIST.md`。

Claude-Session: https://claude.ai/code/session_01JrdmiUk4A258FmhDSKn9aj