### PR TITLE
fix(#163 audit): armed mode files NO orphan proposal when queue co-sign aborts

### DIFF
--- a/docs/RELEASE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_TEST_CHECKLIST.md
@@ -110,6 +110,39 @@ RPC every tick. The node's RPC MUST provide:
 
 ---
 
+## Double-slash residuals (armed real-slash — read before flipping `AUDIT_DRY_RUN=false` in prod)
+
+The DVT over-slash guard (`getRecentSlashExecuted` incl. `OperatorSlashed`, +
+event-reconstructed `isSlashPending`, + the during-cooldown "learning" scan for
+in-flight keys) prevents same-node and the common cross-node double-slash. Two
+residuals it can only PARTIALLY cover (surfaced by an 8-round adversarial
+review):
+
+1. **Fresh-node / long-offline window** — a node with no in-memory state and no
+   local durable slashed marker, started after a peer's `SlashExecuted` /
+   `OperatorSlashed` has aged out of `AUDIT_SLASH_LOOKBACK_BLOCKS`, can read
+   "clear" for a still-sustained violation and slash again. **Mitigation
+   (operational):** size `AUDIT_SLASH_LOOKBACK_BLOCKS` to cover the worst-case
+   node restart/offline horizon (bounded by the RPC's `eth_getLogs` cap — use a
+   provider whose cap exceeds that horizon), or seed/share the durable slashed
+   journal across the fleet.
+
+2. **Different-epoch concurrent slash — needs an SP contract change
+   (@repo:sp).** `epoch = violationBlock`, and the BLSAggregator queue replay
+   guard keys on `operator + slashLevel + epoch + chainid`. Two nodes that
+   observe the same sustained violation at DIFFERENT finalized blocks produce
+   DIFFERENT queue hashes, so both can queue; if one lands after the other
+   executed and cleared `_pendingSlash`, it re-sets pending and executes a
+   SECOND slash. The DVT over-slash guard mitigates but cannot authoritatively
+   close a cross-node contract race. **Authoritative fix (SuperPaymaster):**
+   `executeSlashWithBLS` must carry the same slash cooldown its owner path
+   already has — `slashOperator` enforces `_slashCd[operator]` (24h) but
+   `executeSlashWithBLS` does NOT — or make the queue/replay guard coarse
+   (`operator + slashLevel`, dropping `epoch`). Tracked with @repo:sp on the
+   Cooperation-Center board.
+
+---
+
 ## Regression table — the 5 real-env failures the drill caught (unit tests could not)
 
 | #   | Failure                                                                                                                                                   | Fix                                                                                                     | Now covered by                                                 |

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -1285,6 +1285,40 @@ describe("AuditService", () => {
     expect((await svc.getStatus()).recentDetections[0].executeTx).toBe("0xEXECUTETX"); // slash completed
   });
 
+  it("Codex-High: a cooldown-suppressed tick does NOT clobber the carried-forward proposalId (reuse survives)", async () => {
+    // tick 1 queues + creates proposal 5 (durably persisted) then execute fails → cooldown KEPT
+    // (post-queue throttle). tick 2 falls WITHIN cooldown so the orchestrator is not called; the
+    // finalization must NOT overwrite the carried-forward proposalId with null — else a later crash
+    // loses it and the resume files a fresh orphan proposal.
+    const archive = makeArchive();
+    const blockchain = overLimitBlockchain({
+      getRecentSlashExecuted: async () => false,
+      isSlashPending: async () => false, // tick 1 is a normal (non-resume) queue
+      queueSlashWithProof: async () => "0xQUEUE",
+      createProposalWithEvidence: async () => ({ txHash: "0xP", proposalId: 5n }),
+      executeSlashWithProof: async () => {
+        throw new Error("execute reverted");
+      },
+    });
+    // Fixed clock → tick 2 is WITHIN the default cooldown.
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true }),
+      archive,
+      clockAt(1_700_000_000_000),
+      makeCoSigner()
+    );
+
+    await svc.tick(); // queue + create (proposalId 5 persisted) + execute fails
+    expect(archive.records[0].proposalId).toBe("5");
+    expect(archive.records[0].queueTx).toBeDefined();
+    expect(archive.records[0].executeTx).toBeUndefined();
+
+    await svc.tick(); // within cooldown → suppressed; the carried proposalId MUST survive
+    expect(archive.records[0].proposalId).toBe("5"); // not clobbered to null
+    expect(archive.records[0].queueTx).toBeDefined(); // queue marker also preserved
+  });
+
   it("Codex-Critical: a RESTARTED process (empty in-memory retry state) resumes an archived incomplete slash via on-chain pending", async () => {
     // The full crash-restart hole: process A queues (pending on-chain) then dies before execute. A
     // FRESH process B — empty coSignRetryKeys / cooldown / proposedStableKeys — sharing only the

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -1415,6 +1415,56 @@ describe("AuditService", () => {
     expect(creates).toBe(2); // FRESH proposal (7) filed — the stale id 3 was cleared, not reused
   });
 
+  it("Codex-High: a peer completing the slash DURING cooldown is learned in-window → no double-slash after the event scrolls out", async () => {
+    // The cooldown must throttle the ATTEMPT, not LEARNING. This node attempts, backs off; a peer
+    // executes during the backoff. If assessSlashState were skipped throughout cooldown, the peer's
+    // SlashExecuted/OperatorSlashed would scroll out of the head-window before the next scan and this
+    // node would file a SECOND slash for the same sustained violation. Scanning during cooldown (while
+    // in-flight) records the durable marker while the event is still in-window → no double-slash.
+    const archive = makeArchive();
+    let curBlock = 1000;
+    let peerExecBlock: number | null = null;
+    let queues = 0;
+    const blockchain = overLimitBlockchain({
+      // Model the head-window: the peer's executed event is visible only within lookback (9) blocks.
+      getRecentSlashExecuted: async () => peerExecBlock !== null && curBlock - peerExecBlock <= 9,
+      isSlashPending: async () => false,
+      queueSlashWithProof: async () => {
+        queues++;
+        return "0xQUEUE";
+      },
+      createProposalWithEvidence: async () => ({ txHash: "0xP", proposalId: 4n }),
+      executeSlashWithProof: async () => {
+        throw new Error("this node's execute fails");
+      },
+    });
+    blockchain.getBlockNumber = async () => curBlock;
+    let now = 1_700_000_000_000;
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true, auditCooldownMs: 20_000, auditSlashLookbackBlocks: 9 }),
+      archive,
+      () => now,
+      makeCoSigner()
+    );
+
+    await svc.tick(); // block 1000: this node queues (1) + create + execute fails → in-flight, cooldown set
+    expect(queues).toBe(1);
+
+    // A PEER executes at block 1002, still within this node's cooldown → the in-flight scan records the
+    // durable marker WHILE the event is in-window.
+    peerExecBlock = 1002;
+    curBlock = 1002;
+    now += 5_000; // within cooldown
+    await svc.tick();
+
+    // The event scrolls OUT of the window and cooldown expires. The durable marker prevents a fresh slash.
+    curBlock = 1020;
+    now += 25_000;
+    await svc.tick();
+    expect(queues).toBe(1); // still 1 — no double-slash even though the peer's event is now out-of-window
+  });
+
   it("Codex-Critical: a RESTARTED process (empty in-memory retry state) resumes an archived incomplete slash via on-chain pending", async () => {
     // The full crash-restart hole: process A queues (pending on-chain) then dies before execute. A
     // FRESH process B — empty coSignRetryKeys / cooldown / proposedStableKeys — sharing only the

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -1198,7 +1198,12 @@ describe("AuditService", () => {
     expect(order.filter(o => o === "execute")).toHaveLength(2);
   });
 
-  it("Finding 4: an on-chain isSlashPending=true short-circuits queue/create/execute (durable cross-restart guard)", async () => {
+  it("Finding 4: on-chain pending (isSlashPending=true) RESUMES — skips the queue, completes createProposal + execute", async () => {
+    // Codex-Critical fix: a `pending` operator is an INCOMPLETE slash (queued on-chain but not yet
+    // executed — the queuing node crashed/RPC-failed, or a peer queued it), NOT an already-slashed
+    // one. It must be RESUMED, not skipped: re-queuing would replay-guard revert, so skip Step 1 and
+    // go straight to createProposal + execute. Skipping it (the old behavior) left the operator
+    // pending (withdraw-locked) yet never slashed — the stuck-pending liveness bug.
     const order: string[] = [];
     const blockchain = recordingBlockchain(order, { isSlashPending: async () => true });
     const archive = makeArchive();
@@ -1210,10 +1215,62 @@ describe("AuditService", () => {
       makeCoSigner()
     );
     await svc.tick();
-    // Already pending on-chain → NO on-chain writes this tick; evidence still archived.
-    expect(order).toEqual([]);
+    // RESUME: no queue (replay-guard would revert), but createProposal + execute COMPLETE the slash.
+    expect(order).toEqual(["create", "execute"]);
     expect(archive.records).toHaveLength(1);
-    expect(archive.records[0].proposalIdNote).toMatch(/over-slash guard/);
+    expect(archive.records[0].executeTx).toBe("0xEXECUTETX");
+    // The co-signer ran ONCE — only over the execute preimage (no queue co-sign on the resume path).
+    const status = await svc.getStatus();
+    expect(status.recentDetections[0].queueTx).toBeNull();
+    expect(status.recentDetections[0].executeTx).toBe("0xEXECUTETX");
+  });
+
+  it("Codex-Critical: queue confirms but execute fails → retried next tick and RESUMED to completion (no stuck-pending, no re-queue)", async () => {
+    // The full liveness path: a slash whose queue landed but whose execute failed must NOT be marked
+    // handled — the operator is pending (withdraw-locked) but not slashed. Next tick it is detected as
+    // pending and RESUMED (skip re-queue → complete createProposal + execute).
+    const order: string[] = [];
+    let executeAttempts = 0;
+    let pending = false; // becomes true once the queue lands on-chain
+    const blockchain = overLimitBlockchain({
+      getRecentSlashExecuted: async () => false, // never EXECUTED in this mock (resume keys off pending)
+      isSlashPending: async () => pending,
+      queueSlashWithProof: async () => {
+        order.push("queue");
+        pending = true; // queue pre-flag now set on-chain
+        return "0xQUEUE";
+      },
+      createProposalWithEvidence: async () => {
+        order.push("create");
+        return { txHash: "0xP", proposalId: 7n };
+      },
+      executeSlashWithProof: async () => {
+        executeAttempts++;
+        order.push("execute");
+        if (executeAttempts === 1) throw new Error("execute reverted (transient RPC)");
+        return "0xEXECUTETX";
+      },
+    });
+    const archive = makeArchive();
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true }),
+      archive,
+      undefined,
+      makeCoSigner()
+    );
+
+    // Tick 1: queue + create land, execute THROWS → executeTx null → NOT marked handled, retry armed.
+    await svc.tick();
+    expect(order).toEqual(["queue", "create", "execute"]);
+    expect((await svc.getStatus()).recentDetections[0].executeTx).toBeNull();
+
+    // Tick 2: operator now pending on-chain (queue landed) → RESUME: skip queue, create + execute (ok).
+    order.length = 0;
+    await svc.tick();
+    expect(order).toEqual(["create", "execute"]); // NO re-queue — the BLSAggregator replay guard would revert it
+    expect(executeAttempts).toBe(2);
+    expect((await svc.getStatus()).recentDetections[0].executeTx).toBe("0xEXECUTETX"); // slash completed
   });
 
   // ── FINDING 5: archive-before-execute ordering (durable intent precedes the slash) ──

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -1319,6 +1319,49 @@ describe("AuditService", () => {
     expect(archive.records[0].queueTx).toBeDefined(); // queue marker also preserved
   });
 
+  it("Codex-High: after the violationBlock advances, a resume REUSES the coarse pending proposalId (no per-cooldown orphan)", async () => {
+    // proofHash carries violationBlock, so a sustained violation gets a NEW proofHash each finalized-
+    // block advance. The archived-proof reuse (keyed by proofHash) then misses the prior proposal — but
+    // the COARSE (operator|rule) pending-proposal map still holds it, so a later-block resume reuses it
+    // instead of filing a fresh orphan proposal every cooldown window.
+    const archive = makeArchive();
+    let vblock = 1000;
+    let pending = false;
+    let creates = 0;
+    const blockchain = overLimitBlockchain({
+      isSlashPending: async () => pending,
+      queueSlashWithProof: async () => {
+        pending = true;
+        return "0xQUEUE";
+      },
+      createProposalWithEvidence: async () => {
+        creates++;
+        return { txHash: "0xP", proposalId: 8n };
+      },
+      executeSlashWithProof: async () => {
+        throw new Error("execute keeps failing across cooldown windows");
+      },
+    });
+    blockchain.getBlockNumber = async () => vblock; // getViolationBlock delegates to this
+    let now = 1_700_000_000_000;
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true, auditCooldownMs: 20_000 }),
+      archive,
+      () => now,
+      makeCoSigner()
+    );
+
+    await svc.tick(); // block 1000: clear → queue + create (proposal 8) + execute fails
+    expect(creates).toBe(1);
+
+    vblock = 1005; // finalized violationBlock advanced → a NEW proofHash next tick
+    now += 25_000; // past cooldown
+    await svc.tick(); // pending → resume; archived proof for the NEW proofHash is absent, but the
+    // coarse map still holds proposal 8 → REUSED (skip createProposal), execute retried
+    expect(creates).toBe(1); // still 1 — no per-cooldown-window orphan proposal
+  });
+
   it("Codex-Critical: a RESTARTED process (empty in-memory retry state) resumes an archived incomplete slash via on-chain pending", async () => {
     // The full crash-restart hole: process A queues (pending on-chain) then dies before execute. A
     // FRESH process B — empty coSignRetryKeys / cooldown / proposedStableKeys — sharing only the

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -140,6 +140,9 @@ function makeArchive(): IProofArchive & { records: SlashProof[]; slashed: Set<st
     async has(proofHash: string) {
       return records.some(r => r.proofHash === proofHash);
     },
+    async get(proofHash: string) {
+      return records.find(r => r.proofHash === proofHash) ?? null;
+    },
     async count() {
       return records.length;
     },
@@ -698,6 +701,9 @@ describe("AuditService", () => {
       async has(proofHash: string) {
         return records.some(r => r.proofHash === proofHash);
       },
+      async get(proofHash: string) {
+        return records.find(r => r.proofHash === proofHash) ?? null;
+      },
       async count() {
         return records.length;
       },
@@ -1252,23 +1258,29 @@ describe("AuditService", () => {
       },
     });
     const archive = makeArchive();
+    // A mutable clock advanced past cooldownMs between ticks: the post-queue-failure THROTTLE keeps the
+    // cooldown, so tick 2 must be beyond it for the resume to fire (proves both throttle AND resume).
+    let now = 1_700_000_000_000;
     const svc = makeService(
       blockchain,
-      makeConfig({ auditExecuteSlash: true }),
+      makeConfig({ auditExecuteSlash: true, auditCooldownMs: 20_000 }),
       archive,
-      undefined,
+      () => now,
       makeCoSigner()
     );
 
     // Tick 1: queue + create land, execute THROWS → executeTx null → NOT marked handled, retry armed.
     await svc.tick();
     expect(order).toEqual(["queue", "create", "execute"]);
+    now += 25_000; // advance past cooldownMs so the resume is not throttled
     expect((await svc.getStatus()).recentDetections[0].executeTx).toBeNull();
 
-    // Tick 2: operator now pending on-chain (queue landed) → RESUME: skip queue, create + execute (ok).
+    // Tick 2: operator now pending on-chain (queue landed) → RESUME. No re-queue (replay guard would
+    // revert) AND no new createProposal — the archived proposalId from tick 1 is REUSED (High-2: zero
+    // orphan on a same-node resume). Only the execute (previously failed) is retried, now succeeding.
     order.length = 0;
     await svc.tick();
-    expect(order).toEqual(["create", "execute"]); // NO re-queue — the BLSAggregator replay guard would revert it
+    expect(order).toEqual(["execute"]); // reused proposal id (no re-create), no re-queue
     expect(executeAttempts).toBe(2);
     expect((await svc.getStatus()).recentDetections[0].executeTx).toBe("0xEXECUTETX"); // slash completed
   });
@@ -1301,6 +1313,9 @@ describe("AuditService", () => {
       },
       async has(proofHash: string) {
         return records.some(r => r.proofHash === proofHash);
+      },
+      async get(proofHash: string) {
+        return records.find(r => r.proofHash === proofHash) ?? null;
       },
       async count() {
         return records.length;
@@ -1419,13 +1434,34 @@ describe("AuditService", () => {
     expect(archive.records[0].proposalIdNote).toMatch(/over-slash guard/);
   });
 
-  it("HIGH: an INDETERMINATE scan but a KNOWN pending flag (false) still lets the slash proceed", async () => {
-    // Only ONE of the two signals is indeterminate → we still have an authoritative signal, so the
-    // fail-closed backstop does NOT fire and the armed path slashes normally.
+  it("Codex-Critical: an INDETERMINATE executed-scan fails CLOSED even when pending=false (pending≠proof-of-un-slashed)", async () => {
+    // A `pending === false` does NOT prove "never slashed" — a COMPLETED slash also clears
+    // _pendingSlash. So if the executed-event scan is indeterminate (null), we cannot rule out a
+    // prior slash and must NOT fire another. "blocked" → skip. (The old code let pending=false unblock
+    // this and could double-slash.)
     const order: string[] = [];
     const blockchain = recordingBlockchain(order, {
-      getRecentSlashExecuted: async () => null,
-      isSlashPending: async () => false,
+      getRecentSlashExecuted: async () => null, // executed scan INDETERMINATE
+      isSlashPending: async () => false, // determinate "not currently pending" — but that ≠ "not slashed"
+    });
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true }),
+      makeArchive(),
+      undefined,
+      makeCoSigner()
+    );
+    await svc.tick();
+    expect(order).toEqual([]); // fail-closed: NO slash on an unreadable executed-scan
+  });
+
+  it("a DETERMINATE 'not executed' scan with pending unknown (null) still slashes (only pending was flaky)", async () => {
+    // The inverse: the executed scan is DETERMINATE (false = definitively not slashed) and only the
+    // pending reconstruction is indeterminate → we DO have proof it was not executed, so slash.
+    const order: string[] = [];
+    const blockchain = recordingBlockchain(order, {
+      getRecentSlashExecuted: async () => false, // determinate: not executed
+      isSlashPending: async () => null, // pending reconstruction unavailable
     });
     const svc = makeService(
       blockchain,
@@ -1457,6 +1493,9 @@ describe("AuditService", () => {
       },
       async has(proofHash: string) {
         return records.some(r => r.proofHash === proofHash);
+      },
+      async get(proofHash: string) {
+        return records.find(r => r.proofHash === proofHash) ?? null;
       },
       async count() {
         return records.length;
@@ -1720,6 +1759,9 @@ describe("AuditService", () => {
       },
       async has(proofHash: string) {
         return records.some(r => r.proofHash === proofHash);
+      },
+      async get(proofHash: string) {
+        return records.find(r => r.proofHash === proofHash) ?? null;
       },
       async count() {
         return records.length;

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -1362,6 +1362,59 @@ describe("AuditService", () => {
     expect(creates).toBe(1); // still 1 — no per-cooldown-window orphan proposal
   });
 
+  it("Codex-High: a healthy observation clears the coarse pending proposalId — a later pending re-offense files a FRESH proposal (no stale reuse)", async () => {
+    // Stale-id poisoning: node files proposal 3, execute fails (pending id = 3). The operator later
+    // goes HEALTHY (episode over) then RE-OFFENDS and is pending again on a NEW block. The pending id
+    // must have been cleared on the healthy reset, so the resume files a FRESH proposal instead of
+    // reusing the dead id 3 (which would only staticCall-revert and churn retries).
+    const archive = makeArchive();
+    let overLimit = true;
+    let pending = false;
+    let vblock = 1000;
+    let creates = 0;
+    const ids = [3n, 7n];
+    const blockchain = overLimitBlockchain({
+      getDebt: async () => (overLimit ? 400n : 0n),
+      getCreditLimit: async () => 300n,
+      getAvailableCredit: async () => (overLimit ? 0n : 300n),
+      getRecentSlashExecuted: async () => false,
+      isSlashPending: async () => pending,
+      queueSlashWithProof: async () => {
+        pending = true;
+        return "0xQUEUE";
+      },
+      createProposalWithEvidence: async () => ({ txHash: "0xP", proposalId: ids[creates++] }),
+      executeSlashWithProof: async () => {
+        throw new Error("execute fails");
+      },
+    });
+    blockchain.getBlockNumber = async () => vblock;
+    let now = 1_700_000_000_000;
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true, auditCooldownMs: 20_000 }),
+      archive,
+      () => now,
+      makeCoSigner()
+    );
+
+    await svc.tick(); // over-limit: queue + create(3) + execute fails → pending id = 3
+    expect(creates).toBe(1);
+
+    overLimit = false; // HEALTHY → clearCoarseSlashed drops the pending id
+    pending = false;
+    vblock = 1001;
+    now += 25_000;
+    await svc.tick();
+
+    overLimit = true; // RE-OFFENSE on a NEW block, already pending on-chain (peer queued) → resume
+    pending = true;
+    vblock = 1002;
+    now += 25_000;
+    await svc.tick();
+    expect(creates).toBe(2); // FRESH proposal (7) filed — the stale id 3 was cleared, not reused
+  });
+
   it("Codex-Critical: a RESTARTED process (empty in-memory retry state) resumes an archived incomplete slash via on-chain pending", async () => {
     // The full crash-restart hole: process A queues (pending on-chain) then dies before execute. A
     // FRESH process B — empty coSignRetryKeys / cooldown / proposedStableKeys — sharing only the

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -981,6 +981,42 @@ describe("AuditService", () => {
     expect(execArgs[5]).toBe(expectedProof);
   });
 
+  it("executeSlash=true + queue co-sign aborts: files NO orphan proposal (createProposal skipped), no execute", async () => {
+    // Regression for the Stage-3 live-drill orphan-proposal bug: armed mode used to call
+    // createProposalWithEvidence UNCONDITIONALLY, so a transient queue co-sign failure (no peers /
+    // under-threshold / a peer node already queued) spawned an on-chain proposal that Step 3 then
+    // skipped — one orphan per node per retry tick. The fix gates createProposal on a confirmed queue.
+    const order: string[] = [];
+    const blockchain = recordingBlockchain(order);
+    const archive = makeArchive();
+    // A co-signer that ABORTS the queue step (models transient no-peers / under-threshold).
+    const abortingCoSigner: IQuorumCoSigner & { calls: string[] } = {
+      calls: [],
+      async coSign(req: CoSignRequest) {
+        this.calls.push(req.step);
+        throw new Error("gossip co-sign: no gossip peers available to reach quorum");
+      },
+    };
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true }),
+      archive,
+      clockAt(1_700_000_000_000),
+      abortingCoSigner
+    );
+    await svc.tick();
+
+    // NOTHING on-chain: queue co-sign threw before queueSlashWithProof, so no queue tx; and because
+    // the queue never confirmed, NO createProposal (no orphan) and NO execute.
+    expect(order).toEqual([]);
+    expect(abortingCoSigner.calls).toEqual(["queue"]); // only the queue co-sign was attempted
+    // Evidence is still archived (evidence-never-lost) and the violation is flagged for retry.
+    expect(archive.records).toHaveLength(1);
+    const status = await svc.getStatus();
+    expect(status.recentDetections[0].queueTx).toBeNull();
+    expect(status.recentDetections[0].executeTx).toBeNull();
+  });
+
   it("executeSlash=true + real proposalId: execute is bound to that exact id", async () => {
     const order: string[] = [];
     const blockchain = recordingBlockchain(order, {
@@ -1032,11 +1068,11 @@ describe("AuditService", () => {
     const svc = makeService(blockchain, makeConfig({ auditExecuteSlash: true }), archive);
     // The tick must survive the stub's throw (loop never crashes).
     await expect(svc.tick()).resolves.toBeUndefined();
-    // queue co-sign threw (queue skipped) but the proposal was still filed; execute co-sign
-    // also threw (execute skipped) — yet the evidence is archived regardless.
-    expect(order).toEqual(["create"]);
+    // queue co-sign threw (queue skipped) → armed mode files NO proposal (orphan-proposal fix):
+    // no confirmed queue ⇒ no createProposal ⇒ no execute — yet the evidence is archived regardless.
+    expect(order).toEqual([]);
     expect(archive.records).toHaveLength(1);
-    expect(archive.records[0].proposalTx).toBe("0xPROPOSALTX");
+    expect(archive.records[0].proposalTx ?? null).toBeNull();
   });
 
   it("Finding 1 (CRITICAL): a queue tx failure ABORTS the slash — execute is NOT called (two-step safety)", async () => {
@@ -1063,16 +1099,19 @@ describe("AuditService", () => {
       makeCoSigner()
     );
     await expect(svc.tick()).resolves.toBeUndefined();
-    // finding-1: queue reverted (queueTx null) → execute must NOT run even though the proposal
-    // filed and resolved a real id. A slash never executes without a confirmed queue pre-flag.
-    expect(order).toEqual(["queue-fail", "create"]);
+    // finding-1 + orphan-proposal fix: queue reverted (queueTx null) → NO createProposal (no orphan)
+    // and NO execute. A slash never executes without a confirmed queue pre-flag, and armed mode never
+    // files a proposal it cannot execute.
+    expect(order).toEqual(["queue-fail"]);
     expect(executeCalls).toBe(0);
     expect(archive.records).toHaveLength(1);
     const proof = archive.records[0];
-    // No execute tx recorded, and the (resolvable) execute preimage is kept as INTENT only.
+    // No execute tx recorded. createProposal was skipped (queue never confirmed) → no proposalId,
+    // so there is no resolvable execute preimage to record even as INTENT — the whole flow retries.
     expect(proof.executeTx).toBeUndefined();
     expect(proof.messageHash).toBe("0x");
-    expect(proof.intendedExecuteMessageHash).toBeDefined();
+    expect(proof.intendedExecuteMessageHash ?? undefined).toBeUndefined();
+    expect(proof.proposalTx ?? null).toBeNull();
     // The over-slash guard was NOT armed durably (no slash executed).
     expect((archive as any).slashed.size).toBe(0);
     const status = await svc.getStatus();

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -1285,6 +1285,57 @@ describe("AuditService", () => {
     expect((await svc.getStatus()).recentDetections[0].executeTx).toBe("0xEXECUTETX"); // slash completed
   });
 
+  it("Codex-Critical: a RESTARTED process (empty in-memory retry state) resumes an archived incomplete slash via on-chain pending", async () => {
+    // The full crash-restart hole: process A queues (pending on-chain) then dies before execute. A
+    // FRESH process B — empty coSignRetryKeys / cooldown / proposedStableKeys — sharing only the
+    // durable archive must NOT be short-circuited by archive.has; it re-assesses on-chain pending and
+    // RESUMES. (The archive.has fast-skip only applies to a COMPLETED archived slash.)
+    const archive = makeArchive(); // durable, SHARED across the two process lifetimes
+    let pending = false;
+    let executeAttempts = 0;
+    const blockchain = overLimitBlockchain({
+      getRecentSlashExecuted: async () => false,
+      isSlashPending: async () => pending,
+      queueSlashWithProof: async () => {
+        pending = true; // queue pre-flag now set on-chain (survives the "crash")
+        return "0xQUEUE";
+      },
+      createProposalWithEvidence: async () => ({ txHash: "0xP", proposalId: 9n }),
+      executeSlashWithProof: async () => {
+        executeAttempts++;
+        if (executeAttempts === 1) throw new Error("execute reverted, then the process crashed");
+        return "0xEXECUTETX";
+      },
+    });
+
+    // Process lifetime 1: queue + create land (proposalId durably persisted), execute fails → the
+    // archive holds an INCOMPLETE proof (queueTx set, executeTx unset).
+    const svcA = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true }),
+      archive,
+      undefined,
+      makeCoSigner()
+    );
+    await svcA.tick();
+    expect(archive.records).toHaveLength(1);
+    expect(archive.records[0].queueTx).toBeDefined();
+    expect(archive.records[0].executeTx).toBeUndefined();
+
+    // Process lifetime 2 (RESTART): a brand-new service instance (fresh in-memory maps) on the same
+    // durable archive. It must resume to completion, NOT permanently skip on archive.has.
+    const svcB = makeService(
+      blockchain,
+      makeConfig({ auditExecuteSlash: true }),
+      archive,
+      undefined,
+      makeCoSigner()
+    );
+    await svcB.tick();
+    expect(executeAttempts).toBe(2); // svcB completed the slash the crashed svcA left pending
+    expect(archive.records[0].executeTx).toBe("0xEXECUTETX");
+  });
+
   // ── FINDING 5: archive-before-execute ordering (durable intent precedes the slash) ──
   it("Finding 5: the proof is archived (durable intent) BEFORE the irreversible on-chain execute, then updated after", async () => {
     const order: string[] = [];

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -773,17 +773,32 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     // ── DEDUP ─────────────────────────────────────────────────────────────────────
     const stableKey = `${this.chainId}|${v.operator}|${v.rule}|${v.violationBlock}`;
     const coarseKey = this.coarseKey(v.operator, v.rule);
-    // Exact same violation@block already handled (this process, or on disk from a prior run) — UNLESS
-    // a prior attempt's ARMED co-sign aborted transiently (no peers yet): `coSignRetryKeys` bypasses
-    // the dedup so the co-sign is re-attempted even though the evidence is already archived.
-    if (
-      !this.coSignRetryKeys.has(stableKey) &&
-      (this.proposedStableKeys.has(stableKey) || (await this.archive.has(proofHash)))
-    ) {
-      this.logger.debug(
-        `Audit: ${v.operator} ${v.rule}@${v.violationBlock} already proposed (proof ${proofHash}) — skip`
-      );
-      return null;
+    // Exact same violation@block already handled (this process, or on disk from a prior run) — with
+    // TWO bypasses so an incomplete slash is not stranded:
+    //   (a) `coSignRetryKeys` (in-memory): a prior attempt's ARMED co-sign aborted transiently.
+    //   (b) archived INCOMPLETE slash (durable, Codex-Critical crash-restart fix): the archived proof
+    //       has `queueTx` set but no `executeTx` — the operator was queued (pending, withdraw-locked)
+    //       but never slashed. In-memory `coSignRetryKeys` is LOST on a crash, so without this the
+    //       durable `archive.has` short-circuit would permanently skip the block → stuck pending. We
+    //       carry the archived proof so its `proposalId` can be REUSED on the resume (no orphan).
+    // The archived proof (if any) for THIS violation — read once (armed only) so we can (a) detect an
+    // INCOMPLETE slash to resume and (b) REUSE its durably-persisted proposalId on the resume so no
+    // path files a fresh orphan proposal. `incomplete` = queued (queueTx set) but not executed.
+    const archived = this.executeSlash ? await this.archive.get(proofHash) : null;
+    const resumeArchived = archived && archived.queueTx && !archived.executeTx ? archived : null;
+    if (!this.coSignRetryKeys.has(stableKey)) {
+      if (this.proposedStableKeys.has(stableKey) || (await this.archive.has(proofHash))) {
+        if (!resumeArchived) {
+          this.logger.debug(
+            `Audit: ${v.operator} ${v.rule}@${v.violationBlock} already proposed (proof ${proofHash}) — skip`
+          );
+          return null;
+        }
+        this.logger.warn(
+          `Audit: ${v.operator} ${v.rule}@${v.violationBlock} archived INCOMPLETE slash ` +
+            `(queueTx ${resumeArchived.queueTx}, no executeTx) — re-assessing to RESUME across restart`
+        );
+      }
     }
 
     // Build the PRE-execution proof. The real proof.messageHash is the 8-field EXECUTE preimage,
@@ -882,6 +897,12 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       // on-chain step (finding-4): a crash between a confirmed queue/execute tx and the final
       // archive below can no longer lose that tx record — durable state always reflects what was
       // actually submitted.
+      // On the resume path, REUSE the proposalId this node already filed for this evidence (durably
+      // recorded in the archived proof) instead of creating a fresh one — bounds resume to ZERO new
+      // proposals for a same-node retry (Codex High-2: orphan re-explosion). A peer resuming with no
+      // local proposal (null) files one, throttled by the cooldown that a post-queue failure keeps.
+      const resumeProposalId =
+        resume && resumeArchived?.proposalId ? BigInt(resumeArchived.proposalId) : null;
       const res = await this.coordinateQuorumCoSign(
         {
           operator: v.operator,
@@ -891,7 +912,8 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
           evidenceHash: proofHash,
         },
         proof,
-        resume
+        resume,
+        resumeProposalId
       );
       proposalTx = res.proposalTx;
       onchainProposalId = res.proposalId;
@@ -899,15 +921,25 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       executeTx = res.executeTx;
       if (res.queueMessageHash) proof.queueMessageHash = res.queueMessageHash;
       if (res.coSignAborted) {
-        // ROBUSTNESS GAP FIX: the armed queue co-sign failed TRANSIENTLY (no gossip peers yet /
-        // quorum not reached / staticCall reverted) — nothing was slashed, no gas spent. Mark this
-        // block for co-sign RETRY (bypasses the archived-evidence dedup) + clear the coarse cooldown
-        // so the NEXT tick re-attempts, instead of permanently skipping the block (a node that detects
-        // a violation before its gossip mesh is up would otherwise lose that block's slash forever).
+        // An ARMED attempt did not fully execute → mark the block for co-sign RETRY (bypasses the
+        // archived-evidence dedup in-process). Whether to also CLEAR the cooldown depends on how far
+        // it got:
+        //   • queue NEVER landed (queueTx null && not resuming) → pure transient (no gas spent, e.g.
+        //     gossip mesh not up yet) → CLEAR cooldown so the next tick retries IMMEDIATELY.
+        //   • queue DID land (queueTx set) or we were RESUMING → a post-queue failure. KEEP the
+        //     cooldown so the execute retry is THROTTLED to once per cooldownMs — otherwise the resume
+        //     path re-attempts every tick × every node (Codex High-2 orphan/gas explosion).
         this.coSignRetryKeys.add(stableKey);
-        this.lastProposalAt.delete(coarseKey);
+        const queuePreflagLanded = res.queueTx !== null || resume;
+        if (!queuePreflagLanded) {
+          this.lastProposalAt.delete(coarseKey);
+        }
         this.logger.warn(
-          `Audit: ${v.operator} ${v.rule} co-sign aborted (transient) — will retry next tick`
+          `Audit: ${v.operator} ${v.rule} co-sign aborted (${
+            queuePreflagLanded
+              ? "post-queue, cooldown kept — throttled resume"
+              : "transient, cooldown cleared"
+          }) — will retry next tick`
         );
       } else {
         // Co-sign completed (queued / executed / dry-run) → stop retrying this block.
@@ -1101,16 +1133,19 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       pendingIndeterminate = true; // RPC error → unknown
     }
 
-    // (5) CONSERVATIVE fail-closed backstop. Reaching here means NO guard positively confirmed an
-    // existing slash OR pending. If BOTH the executed-event scan and the pending reconstruction were
-    // indeterminate (and there is no durable marker — else we'd have returned above), we have zero
-    // authoritative signal. Fail CLOSED: "blocked" → the caller skips the irreversible slash rather
-    // than risk a double-slash on unreadable chain state. A determinate "not slashed / not pending"
-    // returns "clear" → the normal armed path slashes.
-    if (scanIndeterminate && pendingIndeterminate) {
+    // (5) CONSERVATIVE fail-closed backstop. Reaching here means the operator is NOT already-executed
+    // by any positive signal (1-3) and NOT pending (4). Fail CLOSED whenever the EXECUTED-scan was
+    // indeterminate: a `pending === false` does NOT prove "never slashed" — a *completed* slash also
+    // clears `_pendingSlash`, so if we cannot read the executed events we cannot rule out a prior
+    // slash and must not fire an irreversible one. (Codex-Critical: the earlier `scanIndeterminate &&
+    // pendingIndeterminate` was too weak — a determinate pending=false wrongly unblocked.) A
+    // pendingIndeterminate alone (executed-scan determinate "not executed") is safe to slash. Only a
+    // fully determinate "not executed / not pending" returns "clear".
+    if (scanIndeterminate) {
       this.logger.warn(
-        `Audit: ${operator} slash-state INDETERMINATE (executed-scan + pending-reconstruction both ` +
-          `unavailable, no durable marker) — fails CLOSED, on-chain slash SKIPPED`
+        `Audit: ${operator} slash-state INDETERMINATE (executed-event scan unavailable; ` +
+          `pending=${pendingIndeterminate ? "unknown" : "false"} cannot prove un-slashed) — ` +
+          `fails CLOSED, on-chain slash SKIPPED`
       );
       return "blocked";
     }
@@ -1168,7 +1203,13 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
      * true, Step 1 (queue) is SKIPPED (a re-queue hits the BLSAggregator replay guard and reverts);
      * the flow goes straight to createProposal + execute to complete the slash. Defaults to false.
      */
-    resume = false
+    resume = false,
+    /**
+     * On the resume path, a proposalId this node ALREADY filed for this evidence (from the archived
+     * proof). When provided, Step 2 REUSES it instead of creating a fresh proposal — so a same-node
+     * resume adds ZERO new on-chain proposals (no orphan re-explosion). Null ⇒ Step 2 files one.
+     */
+    resumeProposalId: bigint | null = null
   ): Promise<{
     proposalTx: string | null;
     proposalId: bigint | null;
@@ -1276,7 +1317,14 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     // an ORPHAN proposal that Step 3 then SKIPS — and with N nodes each retrying every tick, one
     // orphan per node per tick. Gating on the queue pre-flag makes only the node(s) that hold it file
     // a proposal they can actually execute.
-    if (!armed || queueTx !== null || resume) {
+    if (resumeProposalId !== null) {
+      // RESUME with a proposal this node already filed — reuse it, file NOTHING new (no orphan).
+      proposalId = resumeProposalId;
+      this.logger.warn(
+        `Audit: ${operator} createProposal REUSED existing proposal id ${resumeProposalId} ` +
+          `(resume) — no new on-chain proposal filed`
+      );
+    } else if (!armed || queueTx !== null || resume) {
       try {
         const res = await this.blockchainService.createProposalWithEvidence(
           this.dvtValidatorAddress,
@@ -1288,6 +1336,14 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
         );
         proposalTx = res.txHash;
         proposalId = res.proposalId;
+        // ARMED only: persist the REAL proposalId durably NOW (before the execute step), so a crash
+        // between createProposal and executeWithProof lets a restarted process REUSE this id on the
+        // resume (no orphan) instead of filing a fresh proposal. File-only has no execute to resume,
+        // and the final archive records the id anyway. Skip the sentinel/no-op dry-run id.
+        if (proof && armed && proposalId !== null && proposalTx !== DRY_RUN_TX_SENTINEL) {
+          proof.proposalId = proposalId.toString();
+          await persistStep();
+        }
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
         this.logger.error(`Audit: ${operator} createProposal failed — ${msg}`);

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -380,6 +380,11 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
    */
   private markCoarseSlashed(coarseKey: string): void {
     this.slashedCoarseKeys.add(coarseKey);
+    // The slash for this coarse condition is EXECUTED (locally, durably, or observed on-chain — incl.
+    // by a PEER). Drop any in-flight proposal id we were holding for reuse: it now points at an
+    // executed proposal, so reusing it on a future pending resume would only staticCall-revert and
+    // churn retries (Codex: stale-id poisoning). A future genuinely-new violation files a fresh one.
+    this.pendingProposalIds.delete(coarseKey);
     if (this.slashedCoarseKeys.size > AuditService.MAX_DEDUP_ENTRIES) {
       const oldest = this.slashedCoarseKeys.values().next().value;
       if (oldest !== undefined) this.slashedCoarseKeys.delete(oldest);
@@ -411,6 +416,10 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
   private async clearCoarseSlashed(operator: string, rule: string): Promise<void> {
     const coarseKey = this.coarseKey(operator, rule);
     this.slashedCoarseKeys.delete(coarseKey);
+    // The operator is HEALTHY again → any in-flight proposal id we held is stale (the episode it
+    // belonged to is over); drop it so a genuinely-new future violation files a fresh proposal rather
+    // than reusing a dead id (Codex: stale-id poisoning on the healthy→re-offend path).
+    this.pendingProposalIds.delete(coarseKey);
     // A healthy read ALWAYS attempts the durable removal, regardless of the current executeSlash
     // setting. A durable marker written by an EARLIER armed run must be cleared even if the node is
     // now running disarmed — otherwise it would survive an armed→disarmed→armed restart cycle and,

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -786,19 +786,26 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     // path files a fresh orphan proposal. `incomplete` = queued (queueTx set) but not executed.
     const archived = this.executeSlash ? await this.archive.get(proofHash) : null;
     const resumeArchived = archived && archived.queueTx && !archived.executeTx ? archived : null;
-    if (!this.coSignRetryKeys.has(stableKey)) {
+    // ARMED + the archived proof did NOT record a completed execute (executeTx unset — includes a
+    // crash BEFORE queueTx was even persisted) → do NOT short-circuit on `archive.has`: fall through
+    // to `assessSlashState`, which reads the AUTHORITATIVE on-chain pending state (durable; survives
+    // this tick's archive overwrite and any crash-before-persist window). Only a COMPLETED archived
+    // slash (executeTx set), or the file-only path, takes the fast dedup skip. (Codex-Critical: the
+    // archived queueTx alone is NOT a safe skip signal — the on-chain flag is.)
+    const armedUnfinished = this.executeSlash && (!archived || !archived.executeTx);
+    if (!this.coSignRetryKeys.has(stableKey) && !armedUnfinished) {
       if (this.proposedStableKeys.has(stableKey) || (await this.archive.has(proofHash))) {
-        if (!resumeArchived) {
-          this.logger.debug(
-            `Audit: ${v.operator} ${v.rule}@${v.violationBlock} already proposed (proof ${proofHash}) — skip`
-          );
-          return null;
-        }
-        this.logger.warn(
-          `Audit: ${v.operator} ${v.rule}@${v.violationBlock} archived INCOMPLETE slash ` +
-            `(queueTx ${resumeArchived.queueTx}, no executeTx) — re-assessing to RESUME across restart`
+        this.logger.debug(
+          `Audit: ${v.operator} ${v.rule}@${v.violationBlock} already proposed (proof ${proofHash}) — skip`
         );
+        return null;
       }
+    }
+    if (resumeArchived) {
+      this.logger.warn(
+        `Audit: ${v.operator} ${v.rule}@${v.violationBlock} archived INCOMPLETE slash ` +
+          `(queueTx ${resumeArchived.queueTx}, no executeTx) — will RESUME if on-chain pending`
+      );
     }
 
     // Build the PRE-execution proof. The real proof.messageHash is the 8-field EXECUTE preimage,
@@ -833,6 +840,17 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       attestations: {},
       createdAt: this.clock(),
     };
+
+    // Carry forward any durable on-chain PROGRESS from a prior incomplete attempt (queue/proposal
+    // landed but execute did not) so this fresh archive.put does NOT overwrite the durable incomplete
+    // marker with nulls — otherwise a crash right after this put would strand the resume (Codex-
+    // Critical overwrite window). Never clobber a real archived value with undefined/null.
+    if (archived) {
+      proof.queueTx = archived.queueTx ?? proof.queueTx;
+      proof.queueMessageHash = archived.queueMessageHash ?? proof.queueMessageHash;
+      proof.proposalTx = archived.proposalTx ?? proof.proposalTx;
+      proof.proposalId = archived.proposalId ?? proof.proposalId;
+    }
 
     // ── ARCHIVE-BEFORE-EXECUTE (finding-5, evidence + intent durable first) ─────────
     // Persist the durable evidence + slash INTENT BEFORE any irreversible on-chain queue/execute,

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -1224,21 +1224,36 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       }
     }
 
-    // ── Step 2: file the proposal (ALWAYS — binds evidenceHash=proofHash) ──────────
-    try {
-      const res = await this.blockchainService.createProposalWithEvidence(
-        this.dvtValidatorAddress,
-        operator,
-        slashLevel,
-        reason,
-        evidenceHash,
-        dryRun
+    // ── Step 2: file the proposal (binds evidenceHash=proofHash) ───────────────────
+    // File-only (NOT armed): the proposal IS the deliverable — always create it.
+    // ARMED: create the proposal ONLY after the queue step CONFIRMED (queueTx !== null,
+    // where a dry-run's DRY_RUN_TX_SENTINEL also counts as confirmed). Creating it when
+    // the queue co-sign aborted (transient no-peers / under-threshold / a PEER node already
+    // queued this operator so our queueSlashWithProof reverts) would spawn an ORPHAN on-chain
+    // proposal that Step 3 then SKIPS (queueTx === null) — and with N nodes each retrying
+    // every tick, one orphan per node per tick. Gating on queueTx makes exactly ONE node —
+    // the one whose queue confirmed — file exactly ONE proposal, which it then executes.
+    if (!armed || queueTx !== null) {
+      try {
+        const res = await this.blockchainService.createProposalWithEvidence(
+          this.dvtValidatorAddress,
+          operator,
+          slashLevel,
+          reason,
+          evidenceHash,
+          dryRun
+        );
+        proposalTx = res.txHash;
+        proposalId = res.proposalId;
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.logger.error(`Audit: ${operator} createProposal failed — ${msg}`);
+      }
+    } else {
+      this.logger.warn(
+        `Audit: ${operator} createProposal SKIPPED — armed queue step did not confirm ` +
+          `(queueTx null); not filing an orphan proposal, will retry next tick`
       );
-      proposalTx = res.txHash;
-      proposalId = res.proposalId;
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      this.logger.error(`Audit: ${operator} createProposal failed — ${msg}`);
     }
 
     // ── Step 3: EXECUTE (ARMED only) — TWO-STEP SAFETY: confirmed queue + real id required ──

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -145,6 +145,16 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
    * that block's slash forever. Cleared once the co-sign completes (queued / executed / dry-run).
    */
   private readonly coSignRetryKeys = new Set<string>();
+  /**
+   * COARSE-key (operator|rule) → the on-chain proposalId of an in-flight (queued, not yet executed)
+   * slash. The proofHash carries `violationBlock`, so a SUSTAINED violation gets a NEW proofHash each
+   * time the finalized block advances — the archived-proof reuse (keyed by proofHash) then misses the
+   * prior proposal and a resume would file a fresh one every cooldown window. This coarse map lets a
+   * later-block resume REUSE the original proposalId (no per-cooldown orphan). Set when createProposal
+   * confirms, cleared when the slash executes. In-memory: a cross-restart cross-block resume falls back
+   * to one fresh (bounded, harmless) proposal; the same-proof archived-incomplete resume still reuses.
+   */
+  private readonly pendingProposalIds = new Map<string, string>();
   /** Hard ceiling on either dedup map's size — a defensive LRU-style cap against unbounded growth. */
   private static readonly MAX_DEDUP_ENTRIES = 10_000;
   /** Bounded ring of the most recent detections, newest first (for GET /audit/status). */
@@ -429,6 +439,11 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     // entry per finalized-block change. Coarse-cap it — the current block re-adds next tick if still
     // aborting, so dropping stale entries never loses a live retry.
     if (this.coSignRetryKeys.size > AuditService.MAX_DEDUP_ENTRIES) this.coSignRetryKeys.clear();
+    // pendingProposalIds is keyed by coarse operator|rule (bounded by watchlist × rules) and clears on
+    // execute; coarse-cap it defensively against operator churn. Dropping an entry only costs one fresh
+    // proposal on the next resume (bounded, harmless) — never a lost slash.
+    if (this.pendingProposalIds.size > AuditService.MAX_DEDUP_ENTRIES)
+      this.pendingProposalIds.clear();
   }
 
   /**
@@ -925,8 +940,12 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       // recorded in the archived proof) instead of creating a fresh one — bounds resume to ZERO new
       // proposals for a same-node retry (Codex High-2: orphan re-explosion). A peer resuming with no
       // local proposal (null) files one, throttled by the cooldown that a post-queue failure keeps.
-      const resumeProposalId =
-        resume && resumeArchived?.proposalId ? BigInt(resumeArchived.proposalId) : null;
+      // Reuse the in-flight proposalId: prefer the SAME-proof archived one, else the COARSE-key map
+      // (which survives a violationBlock advance → proofHash change, so a later-block resume does not
+      // file a fresh orphan proposal every cooldown window).
+      const carriedProposalId =
+        resumeArchived?.proposalId ?? this.pendingProposalIds.get(coarseKey) ?? null;
+      const resumeProposalId = resume && carriedProposalId ? BigInt(carriedProposalId) : null;
       const res = await this.coordinateQuorumCoSign(
         {
           operator: v.operator,
@@ -943,6 +962,15 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       onchainProposalId = res.proposalId;
       queueTx = res.queueTx;
       executeTx = res.executeTx;
+      // Track the in-flight proposal by COARSE key so a later-block resume (proofHash changed as the
+      // finalized violationBlock advanced) reuses this id instead of filing a fresh orphan. Set when a
+      // proposal exists but the slash did NOT execute this tick; clear once it really executes. Dry-run
+      // (executeTx = sentinel) touches neither — the drill is repeatable and writes no durable state.
+      if (onchainProposalId !== null && executeTx === null) {
+        this.pendingProposalIds.set(coarseKey, onchainProposalId.toString());
+      } else if (executeTx !== null && executeTx !== DRY_RUN_TX_SENTINEL) {
+        this.pendingProposalIds.delete(coarseKey);
+      }
       if (res.queueMessageHash) proof.queueMessageHash = res.queueMessageHash;
       if (res.coSignAborted) {
         // An ARMED attempt did not fully execute → mark the block for co-sign RETRY (bypasses the

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -901,11 +901,18 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     let onchainProposalId: bigint | null = null;
     let proposalIdNote: string | undefined;
 
-    // Assess on-chain slash state ONCE (armed + not throttled): drives BOTH the over-slash guard
-    // ("executed"/"blocked" → skip) AND the RESUME path ("pending" → complete an incomplete on-chain
-    // slash without re-queuing). Skipped when within cooldown (throttled) or file-only (never queues).
+    // Assess on-chain slash state: drives the over-slash guard ("executed"/"blocked" → skip), the
+    // RESUME path ("pending"), and — critically — LEARNING that a PEER completed the slash. The
+    // cooldown throttles the ATTEMPT, but it must NOT throttle learning: a node with an IN-FLIGHT slash
+    // (pendingProposalIds / coSignRetryKeys) keeps scanning during its backoff so a peer's
+    // SlashExecuted/OperatorSlashed is recorded (recordCoarseSlashed) WHILE it is still inside the
+    // head-window — otherwise, if AUDIT_SLASH_LOOKBACK_BLOCKS is shorter than the cooldown's block
+    // horizon, the event scrolls out of the window and the post-cooldown scan reads "clear" → a DOUBLE
+    // slash of the same sustained violation (Codex). Only assess for armed nodes; file-only never
+    // queues. `assessSlashState`'s own step-1/2 in-memory/journal checks keep repeat calls cheap.
+    const inFlight = this.pendingProposalIds.has(coarseKey) || this.coSignRetryKeys.has(stableKey);
     const slashState: "executed" | "pending" | "clear" | "blocked" =
-      !withinCooldown && this.executeSlash
+      this.executeSlash && (!withinCooldown || inFlight)
         ? await this.assessSlashState(coarseKey, v.operator, v.slashLevel, v.violationBlock)
         : "clear";
 

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -838,25 +838,40 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     let onchainProposalId: bigint | null = null;
     let proposalIdNote: string | undefined;
 
+    // Assess on-chain slash state ONCE (armed + not throttled): drives BOTH the over-slash guard
+    // ("executed"/"blocked" → skip) AND the RESUME path ("pending" → complete an incomplete on-chain
+    // slash without re-queuing). Skipped when within cooldown (throttled) or file-only (never queues).
+    const slashState: "executed" | "pending" | "clear" | "blocked" =
+      !withinCooldown && this.executeSlash
+        ? await this.assessSlashState(coarseKey, v.operator, v.slashLevel, v.violationBlock)
+        : "clear";
+
     if (withinCooldown) {
       this.logger.debug(
         `Audit: ${v.operator} ${v.rule} within cooldown (${this.clock() - (last as number)}ms < ` +
           `${this.cooldownMs}ms) — attempt suppressed, archiving evidence only`
       );
       proposalIdNote = "id-unresolved: proposal attempt suppressed by cooldown";
-    } else if (
-      this.executeSlash &&
-      (await this.isCoarseAlreadySlashed(coarseKey, v.operator, v.slashLevel, v.violationBlock))
-    ) {
-      // ARMED path OVER-SLASH GUARD (finding-4/5): a slash already executed (in-memory) or is
-      // pending on-chain for this operator+rule → do NOT queue/execute the same ongoing condition
-      // again, even after cooldownMs with an advancing block. Evidence is still archived (above).
+    } else if (slashState === "executed" || slashState === "blocked") {
+      // ARMED path OVER-SLASH GUARD (finding-4/5): a slash already EXECUTED for this operator+rule
+      // ("executed"), or the chain state is unreadable ("blocked" = fail-closed) → do NOT queue/
+      // execute again, even after cooldownMs with an advancing block. Evidence is still archived.
+      // NB: a "pending" (incomplete) slash is NOT handled here — it flows to the RESUME path below.
       this.logger.warn(
-        `Audit: ${v.operator} ${v.rule} already slashed/pending — over-slash guard, on-chain slash SKIPPED`
+        `Audit: ${v.operator} ${v.rule} ${
+          slashState === "executed" ? "already slashed" : "slash-state indeterminate"
+        } — over-slash guard, on-chain slash SKIPPED`
       );
       proposalIdNote =
-        "id-unresolved: operator already slashed/pending for this rule (over-slash guard)";
+        slashState === "executed"
+          ? "id-unresolved: operator already slashed for this rule (over-slash guard)"
+          : "id-unresolved: slash-state indeterminate (over-slash guard fail-closed)";
     } else {
+      // slashState === "clear" (normal full queue→create→execute) OR "pending" (RESUME: an on-chain
+      // queue pre-flag is already set — this node queued on a prior tick then failed pre-execute, or a
+      // peer queued it — so skip the replay-guarded re-queue and go straight to createProposal +
+      // execute to COMPLETE the slash).
+      const resume = slashState === "pending";
       // Arm the cooldown on ATTEMPT (before the result) so a reverting tx still backs off.
       this.lastProposalAt.set(coarseKey, this.clock());
       // UNIFIED proposal filing (finding-6): both the armed (queue → create → execute) and the
@@ -875,7 +890,8 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
           epoch,
           evidenceHash: proofHash,
         },
-        proof
+        proof,
+        resume
       );
       proposalTx = res.proposalTx;
       onchainProposalId = res.proposalId;
@@ -1019,26 +1035,28 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
    * is narrowed to operator + `slashLevel`. A determinate remote read of "not slashed" lets the slash
    * proceed; an indeterminate read (provider error) fails CLOSED per (5) — never "safe to slash".
    */
-  private async isCoarseAlreadySlashed(
+  private async assessSlashState(
     coarseKey: string,
     operator: string,
     slashLevel: number,
     violationBlock: number
-  ): Promise<boolean> {
-    if (this.slashedCoarseKeys.has(coarseKey)) return true;
+  ): Promise<"executed" | "pending" | "clear" | "blocked"> {
+    // (1) In-memory executed marker.
+    if (this.slashedCoarseKeys.has(coarseKey)) return "executed";
 
-    // (2) DURABLE journal — survives a restart within the same process/disk.
+    // (2) DURABLE executed journal — survives a restart within the same process/disk.
     try {
       if (await this.archive.hasSlashed(coarseKey)) {
         this.markCoarseSlashed(coarseKey); // cache in-memory (do not re-write the marker)
-        return true;
+        return "executed";
       }
     } catch {
       // best-effort: journal read error → fall through to the on-chain scan.
     }
 
-    // (3) ON-CHAIN slash-executed events — the authoritative cross-restart guard. A `null` from any
-    // target means that scan was INDETERMINATE (provider error), tracked so (5) can fail closed.
+    // (3) ON-CHAIN slash-EXECUTED events — the authoritative cross-restart DOUBLE-slash guard. A
+    // `null` from any target means that scan was INDETERMINATE (provider error), tracked so (5) can
+    // fail closed.
     let scanIndeterminate = false;
     try {
       // Scan the most-recent `slashLookbackBlocks` at the chain HEAD (where slash events are emitted),
@@ -1054,7 +1072,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
         );
         if (hit === true) {
           await this.recordCoarseSlashed(coarseKey); // persist durable + memory
-          return true;
+          return "executed";
         }
         if (hit === null) scanIndeterminate = true; // provider error on this target — unconfirmable
       }
@@ -1063,57 +1081,66 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       scanIndeterminate = true;
     }
 
-    // (4) Best-effort on-chain pending flag (null/unknown on the current SP).
+    // (4) ON-CHAIN pending flag, reconstructed from SP events (SlashQueued/SlashCancelled/
+    // OperatorSlashed — no getter; SP is EIP-170-capped). CRITICAL: a `pending` operator is NOT
+    // "already slashed" — it is an INCOMPLETE slash (queued on-chain but not yet executed, because
+    // the queuing node crashed/RPC-failed before executing, or a peer queued it). It must be RESUMED
+    // (skip the replay-guarded re-queue, complete createProposal + execute), never SKIPPED — skipping
+    // it was the stuck-pending liveness bug: the operator's withdraw stays locked forever yet the
+    // slash never lands.
     let pendingIndeterminate = false;
     try {
       const pending = await this.blockchainService.isSlashPending(
         this.superPaymasterAddress,
-        operator
+        operator,
+        this.slashLookbackBlocks
       );
-      if (pending === true) {
-        this.markCoarseSlashed(coarseKey);
-        return true;
-      }
-      if (pending === null) pendingIndeterminate = true; // no getter on this deployment → unknown
+      if (pending === true) return "pending";
+      if (pending === null) pendingIndeterminate = true; // scan unavailable → unknown
     } catch {
-      pendingIndeterminate = true; // getter absent / RPC error → unknown
+      pendingIndeterminate = true; // RPC error → unknown
     }
 
     // (5) CONSERVATIVE fail-closed backstop. Reaching here means NO guard positively confirmed an
-    // existing slash. If BOTH the on-chain event scan and the pending flag were indeterminate (and
-    // there is no durable marker — else we'd have returned above), we have zero authoritative signal
-    // that the operator is un-slashed. Fail CLOSED: skip the irreversible slash rather than risk a
-    // double-slash on unreadable chain state. A determinate on-chain "not slashed" leaves
-    // scanIndeterminate=false, so the normal armed path still slashes.
+    // existing slash OR pending. If BOTH the executed-event scan and the pending reconstruction were
+    // indeterminate (and there is no durable marker — else we'd have returned above), we have zero
+    // authoritative signal. Fail CLOSED: "blocked" → the caller skips the irreversible slash rather
+    // than risk a double-slash on unreadable chain state. A determinate "not slashed / not pending"
+    // returns "clear" → the normal armed path slashes.
     if (scanIndeterminate && pendingIndeterminate) {
       this.logger.warn(
-        `Audit: ${operator} slash-state INDETERMINATE (on-chain scan + pending flag both ` +
-          `unavailable, no durable marker) — over-slash guard fails CLOSED, on-chain slash SKIPPED`
+        `Audit: ${operator} slash-state INDETERMINATE (executed-scan + pending-reconstruction both ` +
+          `unavailable, no durable marker) — fails CLOSED, on-chain slash SKIPPED`
       );
-      return true;
+      return "blocked";
     }
-    return false;
+    return "clear";
   }
 
   /**
    * The slash-consensus orchestration — the SINGLE createProposalWithEvidence call site for BOTH
    * the file-only and the armed (SP #329 two-step) paths. Runs in this exact order:
    *
-   *   1. QUEUE    — (ARMED only) co-sign the 5-field queue preimage → queueSlashWithProof.
-   *   2. PROPOSAL — createProposalWithEvidence(evidenceHash=proofHash) → the REAL proposal id,
-   *                 binding the on-chain slash to the archived evidence. ALWAYS runs.
+   *   1. QUEUE    — (ARMED, and NOT `resume`) co-sign the 5-field queue preimage → queueSlashWithProof.
+   *                 SKIPPED on the `resume` path (the operator is already pending on-chain — re-queuing
+   *                 would hit the BLSAggregator replay guard and revert).
+   *   2. PROPOSAL — createProposalWithEvidence(evidenceHash=proofHash) → the REAL proposal id, binding
+   *                 the on-chain slash to the archived evidence. Runs when NOT armed (file-only: the
+   *                 proposal IS the deliverable) OR the on-chain queue pre-flag is set — queued this
+   *                 tick (queueTx !== null) OR `resume`. Gated so a transiently-aborted queue does NOT
+   *                 spawn an orphan proposal Step 3 can't execute.
    *   3. EXECUTE  — (ARMED only) co-sign the 8-field execute preimage (bound to that real id +
-   *                 evidenceHash) → executeWithProof (slash-only ⇒ repUsers/newScores empty).
-   *                 STRICTLY contingent on the TWO-STEP SAFETY (finding-1): it runs ONLY when the
-   *                 queue step CONFIRMED (queueTx !== null) AND the proposal id resolved. If the
-   *                 queue co-sign/tx failed, the whole slash aborts to file+archive only — a slash
-   *                 must never execute without its confirmed queue pre-flag.
+   *                 evidenceHash) → executeWithProof (slash-only ⇒ repUsers/newScores empty). STRICTLY
+   *                 contingent on the TWO-STEP SAFETY (finding-1): runs ONLY when the queue pre-flag is
+   *                 set (queueTx !== null OR `resume`) AND the proposal id resolved. If neither, the
+   *                 slash aborts to file+archive only — never execute without a confirmed queue.
    *
-   * When executeSlash is OFF (default) only step 2 runs — the file-only path: proposal filed +
-   * evidence bound, nothing queued or slashed. Each step is wrapped: a co-sign or tx failure is
-   * logged and swallowed so the caller still archives the evidence (evidence never lost) and the
-   * poll loop never crashes. With the default PendingSlotCoSigner every co-sign throws (SP
-   * validator slots pending the 24h timelock), so the armed path reduces to just the proposal.
+   * An ARMED attempt that did not reach a real execute (executeTx null) sets `coSignAborted` so the
+   * caller retries next tick and RESUMES (Codex-Critical: a queued-but-unexecuted operator would
+   * otherwise stay pending/withdraw-locked forever). When executeSlash is OFF (default) only step 2
+   * runs — the file-only path: proposal filed + evidence bound, nothing queued or slashed. Each step
+   * is wrapped: a co-sign or tx failure is logged and swallowed so the caller still archives the
+   * evidence (evidence never lost) and the poll loop never crashes.
    *
    * When `proof` is passed, it is RE-ARCHIVED after each CONFIRMED on-chain step (finding-4) so a
    * crash between a confirmed tx and the caller's final archive cannot lose that tx record.
@@ -1134,7 +1161,14 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       epoch: number;
       evidenceHash: string;
     },
-    proof?: SlashProof
+    proof?: SlashProof,
+    /**
+     * RESUME an incomplete on-chain slash: the operator is ALREADY pending-slash (the queue pre-flag
+     * is set — this node queued on a prior tick then failed pre-execute, or a peer queued it). When
+     * true, Step 1 (queue) is SKIPPED (a re-queue hits the BLSAggregator replay guard and reverts);
+     * the flow goes straight to createProposal + execute to complete the slash. Defaults to false.
+     */
+    resume = false
   ): Promise<{
     proposalTx: string | null;
     proposalId: bigint | null;
@@ -1180,8 +1214,17 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       }
     };
 
-    // ── Step 1: QUEUE (ARMED only, quorum co-signed) ──────────────────────────────
-    if (armed) {
+    // ── Step 1: QUEUE (ARMED only, quorum co-signed; SKIPPED when resuming) ────────
+    // On the RESUME path the operator's queue pre-flag is already set on-chain (a prior tick's / a
+    // peer's queueSlashWithProof landed); re-queuing would replay the same 5-field messageHash and
+    // revert on the BLSAggregator `usedSlashQueueHashes` guard. Skip straight to createProposal +
+    // execute to COMPLETE the slash.
+    if (armed && resume) {
+      this.logger.warn(
+        `Audit: ${operator} slash queue SKIPPED — operator already pending-slash on-chain ` +
+          `(resuming to createProposal + execute)`
+      );
+    } else if (armed) {
       try {
         queueMessageHash = buildQueueMessageHash(operator, slashLevel, epoch, this.chainId);
         const cosign = await this.coSigner.coSign({
@@ -1226,14 +1269,14 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
 
     // ── Step 2: file the proposal (binds evidenceHash=proofHash) ───────────────────
     // File-only (NOT armed): the proposal IS the deliverable — always create it.
-    // ARMED: create the proposal ONLY after the queue step CONFIRMED (queueTx !== null,
-    // where a dry-run's DRY_RUN_TX_SENTINEL also counts as confirmed). Creating it when
-    // the queue co-sign aborted (transient no-peers / under-threshold / a PEER node already
-    // queued this operator so our queueSlashWithProof reverts) would spawn an ORPHAN on-chain
-    // proposal that Step 3 then SKIPS (queueTx === null) — and with N nodes each retrying
-    // every tick, one orphan per node per tick. Gating on queueTx makes exactly ONE node —
-    // the one whose queue confirmed — file exactly ONE proposal, which it then executes.
-    if (!armed || queueTx !== null) {
+    // ARMED: create the proposal ONLY when the on-chain queue pre-flag is set — i.e. we queued it
+    // THIS tick (queueTx !== null; a dry-run's DRY_RUN_TX_SENTINEL counts) OR we are RESUMING an
+    // already-pending slash (`resume`). Creating it when the queue co-sign aborted transiently (no
+    // peers / under-threshold / a PEER already queued so our queueSlashWithProof reverts) would spawn
+    // an ORPHAN proposal that Step 3 then SKIPS — and with N nodes each retrying every tick, one
+    // orphan per node per tick. Gating on the queue pre-flag makes only the node(s) that hold it file
+    // a proposal they can actually execute.
+    if (!armed || queueTx !== null || resume) {
       try {
         const res = await this.blockchainService.createProposalWithEvidence(
           this.dvtValidatorAddress,
@@ -1256,14 +1299,17 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       );
     }
 
-    // ── Step 3: EXECUTE (ARMED only) — TWO-STEP SAFETY: confirmed queue + real id required ──
+    // ── Step 3: EXECUTE (ARMED only) — TWO-STEP SAFETY: queue pre-flag set + real id required ──
+    // The pre-flag is set when we queued this tick (queueTx !== null) OR we are RESUMING an operator
+    // already pending on-chain (`resume`). Either way `require(_pendingSlash)` in executeSlashWithBLS
+    // is satisfied; without it the execute would revert.
     if (armed) {
-      if (queueTx === null) {
+      if (queueTx === null && !resume) {
         // finding-1: never execute a slash whose queue pre-flag did not confirm. Abort to
         // file+archive only — the evidence + proposal remain, but no irreversible slash fires.
         this.logger.error(
-          `Audit: ${operator} slash execute SKIPPED — queue step did not confirm (queueTx null); ` +
-            `two-step safety requires a confirmed queueSlashWithProof before executeWithProof`
+          `Audit: ${operator} slash execute SKIPPED — queue step did not confirm (queueTx null, ` +
+            `not resuming); two-step safety requires the on-chain queue pre-flag before executeWithProof`
         );
       } else if (proposalId === null) {
         this.logger.error(
@@ -1333,6 +1379,19 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
         }
       }
     }
+
+    // RESUME-RETRY signal (Codex-Critical fix): an ARMED attempt that did NOT reach a real execute
+    // (executeTx null — createProposal or the execute co-sign failed, or the queue confirmed but a
+    // later step threw) leaves the operator PENDING-slash on-chain yet not slashed. Signal the caller
+    // to retry next tick (bypassing the archived-evidence dedup + clearing cooldown) so `assessSlashState`
+    // sees the "pending" state and RESUMES to completion — instead of marking the block handled and
+    // stranding the operator withdraw-locked forever. Dry-run's sentinel executeTx is non-null, so a
+    // clean rehearsal does not trip this. The existing queue-catch also sets coSignAborted for the
+    // never-queued transient case; this widens it to every incomplete armed outcome.
+    if (armed && !dryRun && executeTx === null) {
+      coSignAborted = true;
+    }
+
     return {
       proposalTx,
       proposalId,

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -792,7 +792,13 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     // this tick's archive overwrite and any crash-before-persist window). Only a COMPLETED archived
     // slash (executeTx set), or the file-only path, takes the fast dedup skip. (Codex-Critical: the
     // archived queueTx alone is NOT a safe skip signal — the on-chain flag is.)
-    const armedUnfinished = this.executeSlash && (!archived || !archived.executeTx);
+    // …unless we ALREADY know (in-memory, this process) the coarse operator+rule was slashed — then
+    // the fast skip is safe (no resume needed) and avoids re-processing/re-archiving every tick when a
+    // slash landed on-chain but its executeTx was never persisted locally (Codex Low: churn).
+    const armedUnfinished =
+      this.executeSlash &&
+      !this.slashedCoarseKeys.has(coarseKey) &&
+      (!archived || !archived.executeTx);
     if (!this.coSignRetryKeys.has(stableKey) && !armedUnfinished) {
       if (this.proposedStableKeys.has(stableKey) || (await this.archive.has(proofHash))) {
         this.logger.debug(
@@ -1026,7 +1032,14 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       proof.messageHash = "0x";
       proof.messageHashNote = proposalIdNote ?? "id-unresolved: no on-chain proposal to sign over";
     }
-    proof.proposalId = proposalId;
+    // Only OVERWRITE proposalId when THIS tick resolved a real on-chain id (a fresh createProposal or
+    // a reused resume id). When it did NOT (a cooldown-SUPPRESSED tick never called the orchestrator,
+    // so onchainProposalId is null), KEEP the value already on `proof` — carried forward from the
+    // archived incomplete attempt — so a durable proposalId survives for reuse and a later crash does
+    // not lose it (Codex: null-clobber reopened orphan reuse). Never clobber a real id with null.
+    if (onchainProposalId !== null) {
+      proof.proposalId = proposalId;
+    }
     if (proposalIdNote) proof.proposalIdNote = proposalIdNote;
     if (proposalTx) proof.proposalTx = proposalTx;
     if (queueTx) proof.queueTx = queueTx;

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -323,6 +323,19 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
             : "file+archive ONLY"
         })`
     );
+    // Armed, real-broadcast operators: surface the two double-slash residuals the DVT over-slash
+    // guard can only PARTIALLY cover (they need operational sizing / an SP contract change — see
+    // docs/RELEASE_TEST_CHECKLIST.md "double-slash residuals").
+    if (this.executeSlash && !this.dryRun) {
+      this.logger.warn(
+        `DVT audit ARMED (real slash): the cross-node over-slash guard scans the last ` +
+          `${this.slashLookbackBlocks} blocks (AUDIT_SLASH_LOOKBACK_BLOCKS). Size it to cover the ` +
+          `worst-case node restart/offline horizon for a SUSTAINED violation — a peer slash that ages ` +
+          `out of this window before a fresh node scans can be double-slashed. AUTHORITATIVE ` +
+          `same-episode double-slash prevention requires the SuperPaymaster BLS execute path to carry ` +
+          `the slash cooldown its owner path already has (executeSlashWithBLS lacks _slashCd) — tracked with @repo:sp.`
+      );
+    }
   }
 
   onApplicationShutdown(): void {

--- a/src/modules/audit/proof-archive.ts
+++ b/src/modules/audit/proof-archive.ts
@@ -227,6 +227,12 @@ export function computeProofHash(identity: ProofIdentity): string {
 export interface IProofArchive {
   put(proof: SlashProof): Promise<{ proofHash: string; location: string }>;
   has(proofHash: string): Promise<boolean>;
+  /**
+   * Read back a previously archived proof (or `null` if absent/unreadable). Used by the armed dedup
+   * to distinguish a COMPLETED slash (skip) from an INCOMPLETE one — a proof with `queueTx` set but
+   * no `executeTx` — which must be RESUMED across a process restart (in-memory retry state is gone).
+   */
+  get(proofHash: string): Promise<SlashProof | null>;
   count(): Promise<number>;
   /**
    * DURABLE executed-slash journal (finding-2). `recordSlashed` persists a coarse
@@ -267,6 +273,16 @@ export class LocalProofArchive implements IProofArchive {
       return true;
     } catch {
       return false;
+    }
+  }
+
+  async get(proofHash: string): Promise<SlashProof | null> {
+    try {
+      const raw = await fs.readFile(path.join(this.dir, `${proofHash}.json`), "utf8");
+      return JSON.parse(raw) as SlashProof;
+    } catch {
+      // Absent or unreadable/corrupt → treat as "no archived proof" (the dedup then falls through).
+      return null;
     }
   }
 
@@ -315,6 +331,10 @@ export class IpfsProofArchive implements IProofArchive {
   }
 
   async has(): Promise<boolean> {
+    throw new Error("IpfsProofArchive not implemented — increment 3");
+  }
+
+  async get(): Promise<SlashProof | null> {
     throw new Error("IpfsProofArchive not implemented — increment 3");
   }
 

--- a/src/modules/blockchain/blockchain.service.spec.ts
+++ b/src/modules/blockchain/blockchain.service.spec.ts
@@ -83,6 +83,89 @@ describe("BlockchainService.getRecentSlashExecuted", () => {
 });
 
 /**
+ * isSlashPending reconstructs the operator's pending-slash flag from SP events (SlashQueued sets,
+ * SlashCancelled/OperatorSlashed clear) — SP exposes no getter (EIP-170). pending == the LATEST such
+ * event (by blockNumber, then logIndex) is SlashQueued. Verifies the ordering + fail-closed nulls.
+ */
+describe("BlockchainService.isSlashPending (event reconstruction)", () => {
+  const PENDING_IFACE = new ethers.Interface([
+    "event SlashQueued(address indexed operator)",
+    "event SlashCancelled(address indexed operator)",
+    "event OperatorSlashed(address indexed operator, uint256 amount, uint8 level)",
+  ]);
+  const TOPIC: Record<string, string> = {
+    SlashQueued: PENDING_IFACE.getEvent("SlashQueued")!.topicHash,
+    SlashCancelled: PENDING_IFACE.getEvent("SlashCancelled")!.topicHash,
+    OperatorSlashed: PENDING_IFACE.getEvent("OperatorSlashed")!.topicHash,
+  };
+  function pLog(name: string, operator: string, blockNumber: number, index: number) {
+    const opTopic = ethers.zeroPadValue(ethers.getAddress(operator), 32);
+    return { topics: [TOPIC[name], opTopic], data: "0x", blockNumber, index };
+  }
+  /** getLogs dispatches on the requested topics[0] (isSlashPending queries each event type once). */
+  function pendingService(
+    pool: ReturnType<typeof pLog>[],
+    getBlockNumber: () => Promise<number> = async () => 1000
+  ) {
+    return makeService(
+      async (filter: any) => pool.filter(l => l.topics[0] === filter.topics[0]),
+      getBlockNumber
+    );
+  }
+
+  it("only SlashQueued in window → pending (true)", async () => {
+    const svc = pendingService([pLog("SlashQueued", OPERATOR, 100, 0)]);
+    expect(await svc.isSlashPending(CONTRACT, OPERATOR, 500)).toBe(true);
+  });
+
+  it("SlashQueued then a LATER OperatorSlashed (BLS or owner-manual clear) → not pending (false)", async () => {
+    const svc = pendingService([
+      pLog("SlashQueued", OPERATOR, 100, 0),
+      pLog("OperatorSlashed", OPERATOR, 102, 0),
+    ]);
+    expect(await svc.isSlashPending(CONTRACT, OPERATOR, 500)).toBe(false);
+  });
+
+  it("SlashQueued then a LATER SlashCancelled → not pending (false)", async () => {
+    const svc = pendingService([
+      pLog("SlashQueued", OPERATOR, 100, 0),
+      pLog("SlashCancelled", OPERATOR, 101, 3),
+    ]);
+    expect(await svc.isSlashPending(CONTRACT, OPERATOR, 500)).toBe(false);
+  });
+
+  it("re-queued after a clear (SlashQueued is latest by logIndex in the SAME block) → pending (true)", async () => {
+    const svc = pendingService([
+      pLog("SlashCancelled", OPERATOR, 200, 1),
+      pLog("SlashQueued", OPERATOR, 200, 4), // same block, higher logIndex → latest
+    ]);
+    expect(await svc.isSlashPending(CONTRACT, OPERATOR, 500)).toBe(true);
+  });
+
+  it("no events in window → not pending (false), determinate", async () => {
+    const svc = pendingService([]);
+    expect(await svc.isSlashPending(CONTRACT, OPERATOR, 500)).toBe(false);
+  });
+
+  it("fail-closed: a getLogs error returns null (INDETERMINATE), never false", async () => {
+    const svc = makeService(async () => {
+      throw new Error("RPC range too wide");
+    });
+    expect(await svc.isSlashPending(CONTRACT, OPERATOR, 500)).toBeNull();
+  });
+
+  it("fail-closed: a getBlockNumber error returns null (INDETERMINATE)", async () => {
+    const svc = makeService(
+      async () => [],
+      async () => {
+        throw new Error("head unavailable");
+      }
+    );
+    expect(await svc.isSlashPending(CONTRACT, OPERATOR, 500)).toBeNull();
+  });
+});
+
+/**
  * Cross-repo interface lock for the owner-auth gate (airaccount-contract AAStarAirAccountV7).
  * The magic value the DVT gate checks MUST equal the function selector of the delegated view —
  * if airaccount ever changes this interface, updating OWNER_AUTH_FN/OWNER_AUTH_MAGIC/OWNER_AUTH_ABI

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -582,10 +582,11 @@ export class BlockchainService {
     const iface = new ethers.Interface([
       "event SlashExecutedWithProof(address indexed operator, uint8 level, uint256 penalty, bytes32 proofHash, uint256 timestamp)",
       "event SlashExecuted(uint256 indexed proposalId, address indexed operator, uint8 level)",
+      "event OperatorSlashed(address indexed operator, uint256 amount, uint8 level)",
     ]);
     const opTopic = ethers.zeroPadValue(ethers.getAddress(operator), 32);
     const filters = [
-      // SlashExecutedWithProof: operator is the 1st indexed field (topics[1]).
+      // SlashExecutedWithProof: operator is the 1st indexed field (topics[1]). BLS/DVT execute path.
       {
         name: "SlashExecutedWithProof",
         topics: [iface.getEvent("SlashExecutedWithProof")!.topicHash, opTopic],
@@ -594,6 +595,13 @@ export class BlockchainService {
       {
         name: "SlashExecuted",
         topics: [iface.getEvent("SlashExecuted")!.topicHash, null, opTopic],
+      },
+      // OperatorSlashed: operator 1st indexed (topics[1]). Emitted by `_slash` on BOTH the BLS/DVT
+      // execute path AND owner-manual `slashOperator` — which does NOT emit SlashExecutedWithProof, so
+      // WITHOUT this an owner-slashed operator reads as "not slashed" and the audit double-slashes it.
+      {
+        name: "OperatorSlashed",
+        topics: [iface.getEvent("OperatorSlashed")!.topicHash, opTopic],
       },
     ];
     for (const f of filters) {

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -627,6 +627,85 @@ export class BlockchainService {
     return false;
   }
 
+  /**
+   * Reconstruct whether `operator` is currently pending-slash on the SuperPaymaster WITHOUT an
+   * on-chain getter. SP is at the EIP-170 size limit (39 bytes free) so it deliberately exposes NO
+   * `isSlashPending` view; the state is instead rebuilt from the events SP emits at every
+   * `_pendingSlash` flip. Rule (authoritative, from repo:sp): over a head-anchored window, take the
+   * LATEST (by blockNumber, then logIndex) event for `operator` among —
+   *   SET   → `SlashQueued(operator)`
+   *   CLEAR → `SlashCancelled(operator)`         (owner `cancelSlash`)
+   *   CLEAR → `OperatorSlashed(operator, ...)`   (emitted by BOTH the BLS execute path AND owner
+   *                                               manual `slashOperator`; the latter does NOT emit
+   *                                               `SlashExecutedWithProof`, so keying off that alone
+   *                                               would forever mis-read a manually-slashed operator
+   *                                               as still pending — hence `OperatorSlashed` is the
+   *                                               authoritative CLEAR signal).
+   * pending == (the latest such event is `SlashQueued`).
+   *
+   * Returns `null` (INDETERMINATE, fail-closed) on any getBlockNumber/getLogs error — the caller must
+   * not read an unreadable chain as a definite pending/not-pending. Returns `false` when the window
+   * holds no such event: size `lookbackBlocks` to the queue→execute latency / your RPC's getLogs cap
+   * (Alchemy free = 10). A `SlashQueued` OLDER than the window reads as not-pending → the caller then
+   * re-queues → the BLSAggregator `usedSlashQueueHashes` replay guard reverts the duplicate → the
+   * queue step aborts transiently → retry next tick. Never a wrong slash, just a bounded retry.
+   */
+  async isSlashPending(
+    superPaymasterAddress: string,
+    operator: string,
+    lookbackBlocks: number
+  ): Promise<boolean | null> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+    let latest: number;
+    try {
+      latest = await this.provider.getBlockNumber();
+    } catch (error: any) {
+      this.logger.warn(`isSlashPending getBlockNumber failed: ${error.message} — indeterminate`);
+      return null;
+    }
+    const fromBlock = Math.max(0, latest - Math.max(0, lookbackBlocks));
+    const iface = new ethers.Interface([
+      "event SlashQueued(address indexed operator)",
+      "event SlashCancelled(address indexed operator)",
+      "event OperatorSlashed(address indexed operator, uint256 amount, uint8 level)",
+    ]);
+    // `operator` is the 1st indexed field (topics[1]) in ALL three events.
+    const opTopic = ethers.zeroPadValue(ethers.getAddress(operator), 32);
+    const kinds = [
+      { name: "SlashQueued", pending: true },
+      { name: "SlashCancelled", pending: false },
+      { name: "OperatorSlashed", pending: false },
+    ] as const;
+    let best: { block: number; index: number; pending: boolean } | null = null;
+    for (const k of kinds) {
+      let logs;
+      try {
+        logs = await this.provider.getLogs({
+          address: superPaymasterAddress,
+          fromBlock,
+          toBlock: "latest",
+          topics: [iface.getEvent(k.name)!.topicHash, opTopic],
+        });
+      } catch (error: any) {
+        // FAIL-CLOSED: an unscannable window is INDETERMINATE, never a silent "not pending".
+        this.logger.warn(
+          `isSlashPending getLogs failed on ${superPaymasterAddress} (${k.name}): ${error.message} — indeterminate`
+        );
+        return null;
+      }
+      for (const log of logs) {
+        const block = log.blockNumber;
+        const index = log.index; // ethers v6: logIndex within the block
+        if (best === null || block > best.block || (block === best.block && index > best.index)) {
+          best = { block, index, pending: k.pending };
+        }
+      }
+    }
+    return best === null ? false : best.pending;
+  }
+
   // ── BLSAggregator slot registry (inc-2 live gossip co-sign) ────────────────────
   //
   // The authoritative slot→validator→BLS-key mapping the quorum co-sign binds against. Slot is
@@ -952,42 +1031,6 @@ export class BlockchainService {
         (proposalId !== null ? ` (proposalId ${proposalId})` : "")
     );
     return { txHash: tx.hash, proposalId };
-  }
-
-  /**
-   * Best-effort read of an operator's on-chain pending-slash flag. This is the DURABLE
-   * cross-restart guard against double-slashing a sustained violation (finding-4/5): if a slash
-   * is already queued/pending, the audit must NOT queue+execute another.
-   *
-   * SP #329 keeps `_pendingSlash` PRIVATE with no public getter, so on the current deployment this
-   * call reverts and returns `null` ("unknown") — the caller then falls back to the in-memory
-   * coarse operator|rule guard. Should a future SuperPaymaster expose `pendingSlash(address)`
-   * (or `isSlashPending`), this begins returning the real flag and becomes the authoritative,
-   * restart-surviving guard with no caller change. `null` is treated as "unknown", never "false".
-   */
-  async isSlashPending(
-    superPaymasterAddress: string,
-    operator: string,
-    blockTag?: number
-  ): Promise<boolean | null> {
-    if (!this.provider) {
-      throw new Error("Blockchain provider not configured");
-    }
-    // Try both plausible public getter names; either returning a bool answers the question.
-    const abi = [
-      "function pendingSlash(address operator) view returns (bool)",
-      "function isSlashPending(address operator) view returns (bool)",
-    ];
-    const contract = new ethers.Contract(superPaymasterAddress, abi, this.provider);
-    for (const fn of ["pendingSlash", "isSlashPending"] as const) {
-      try {
-        const pending: boolean = await contract[fn](operator, { blockTag });
-        return Boolean(pending);
-      } catch {
-        // getter absent on this deployment — try the next name.
-      }
-    }
-    return null;
   }
 
   /**


### PR DESCRIPTION
## 背景 — Stage 3 真罚 drill 发现的缺陷
昨天首次真实 slash E2E(真链真执行,queue `0x18cb61a5` + execute `0x59981070`)暴露了一个 **dry-run 用 staticCall 掩盖、只有武装真跑才现形**的 bug。

## Bug
`coordinateQuorumCoSign` 的 Step 2 `createProposalWithEvidence` 标着 "ALWAYS" **无条件执行** —— 武装模式下 queue co-sign 瞬时失败(无 peers / 未达门槛 / **某个 peer 节点已抢先 queue 该 operator → 本节点 queueSlashWithProof revert**)时,仍**广播一笔真链上提案**,而 Step 3 随即因 `queueTx === null` 跳过它。N 节点 × 每 tick 重试 = **每节点每 tick 一个孤儿提案**。本次 drill 造出提案 id 1-6,只执行 id 3 → **5 个孤儿**。

## 修复
Step 2 按 queue 结果门控:createProposal 只在 **非武装**(file-only,提案本身是交付物)**或 queue 已确认**(`queueTx !== null`,dry-run 的 `DRY_RUN_TX_SENTINEL` 也算)时执行。这样**只有 queue 抢先成功的那一个节点**建**恰好一个**提案并执行它;其余节点 queue revert → queueTx null → 跳过。同时消除:① 瞬时中止造孤儿;② 多节点重复建提案。

## 测试
- 新增 `queue co-sign aborts → files NO orphan proposal` 用例(武装 + queue 抛错 → order===[]、无 createProposal、无 execute、证据仍归档)。
- 更新 2 个既有 armed-abort 测试(它们断言的是旧的造孤儿行为)。
- **365/365** 全绿,type-check/build/lint(0 errors)/prettier 干净。

## 关系
建议**先合本 PR**,再合 #185(v1.11.0),使 v1.11.0 含此修复。

Claude-Session: https://claude.ai/code/session_01JrdmiUk4A258FmhDSKn9aj