### PR TITLE
feat(#163 audit): adopt SP 5.4.2 isSlashPending getter (event-recon fallback) + residuals contract-closed

### DIFF
--- a/docs/RELEASE_TEST_CHECKLIST.md
+++ b/docs/RELEASE_TEST_CHECKLIST.md
@@ -110,36 +110,39 @@ RPC every tick. The node's RPC MUST provide:
 
 ---
 
-## Double-slash residuals (armed real-slash — read before flipping `AUDIT_DRY_RUN=false` in prod)
+## Double-slash residuals — ✅ CONTRACT-CLOSED by SuperPaymaster 5.4.2
 
-The DVT over-slash guard (`getRecentSlashExecuted` incl. `OperatorSlashed`, +
-event-reconstructed `isSlashPending`, + the during-cooldown "learning" scan for
-in-flight keys) prevents same-node and the common cross-node double-slash. Two
-residuals it can only PARTIALLY cover (surfaced by an 8-round adversarial
-review):
+Both residuals below (surfaced by an 8-round adversarial review) are now
+**authoritatively closed on-chain** by SuperPaymaster **5.4.2** (deployed
+Sepolia 2026-07-08, UUPS in-place — address unchanged): the BLS slash path now
+enforces a **1h cooldown gate inside `SP.queueSlash`** (`_blsSlashCd`, decoupled
+from the owner-path `_slashCd`). Within the window, a `BLS_AGGREGATOR`
+`queueSlash` reverts `SlashCooldown()`, so a racing second slash of the same
+operator **cannot even queue** — the DVT `queueSlashWithProof` staticCall
+preflight catches it and degrades to file+archive (no gas, no parked pending).
+The gate is at `queueSlash` (not `executeSlashWithBLS`) precisely so a stale
+`_pendingSlash` is never parked.
 
-1. **Fresh-node / long-offline window** — a node with no in-memory state and no
-   local durable slashed marker, started after a peer's `SlashExecuted` /
-   `OperatorSlashed` has aged out of `AUDIT_SLASH_LOOKBACK_BLOCKS`, can read
-   "clear" for a still-sustained violation and slash again. **Mitigation
-   (operational):** size `AUDIT_SLASH_LOOKBACK_BLOCKS` to cover the worst-case
-   node restart/offline horizon (bounded by the RPC's `eth_getLogs` cap — use a
-   provider whose cap exceeds that horizon), or seed/share the durable slashed
-   journal across the fleet.
+The DVT over-slash guard (`getRecentSlashExecuted` incl. `OperatorSlashed`,
+`isSlashPending` — now the O(1) typed getter with the event reconstruction as a
+pre-5.4.2 fallback, + the during-cooldown "learning" scan) is retained as
+gas-saving defence-in-depth; the contract is the authority.
 
-2. **Different-epoch concurrent slash — needs an SP contract change
-   (@repo:sp).** `epoch = violationBlock`, and the BLSAggregator queue replay
-   guard keys on `operator + slashLevel + epoch + chainid`. Two nodes that
-   observe the same sustained violation at DIFFERENT finalized blocks produce
-   DIFFERENT queue hashes, so both can queue; if one lands after the other
-   executed and cleared `_pendingSlash`, it re-sets pending and executes a
-   SECOND slash. The DVT over-slash guard mitigates but cannot authoritatively
-   close a cross-node contract race. **Authoritative fix (SuperPaymaster):**
-   `executeSlashWithBLS` must carry the same slash cooldown its owner path
-   already has — `slashOperator` enforces `_slashCd[operator]` (24h) but
-   `executeSlashWithBLS` does NOT — or make the queue/replay guard coarse
-   (`operator + slashLevel`, dropping `epoch`). Tracked with @repo:sp on the
-   Cooperation-Center board.
+1. **Fresh-node / long-offline window** — a fresh node could read "clear" for a
+   sustained violation whose peer slash aged out of
+   `AUDIT_SLASH_LOOKBACK_BLOCKS` → ✅ now the contract reverts its `queueSlash`
+   within the 1h cooldown. Still size `AUDIT_SLASH_LOOKBACK_BLOCKS` sensibly to
+   avoid needless preflight churn.
+
+2. **Different-epoch concurrent slash** → ✅ closed: two nodes at different
+   `epoch`s could both queue, but the 1h `_blsSlashCd` gate in `SP.queueSlash`
+   reverts the second regardless of epoch.
+
+⚠️ **Cold-start floor:** the 5.4.2 upgrade atomically primed a 1h blanket BLS
+cooldown (`primeBlsSlashCooldown`), so for ~1h AFTER the upgrade EVERY BLS
+`queueSlash` (even a never-slashed operator) reverts `SlashCooldown`. **Schedule
+the first real slash E2E ≥ 1h after the upgrade** (≥ ~2026-07-08 09:24 UTC), or
+the queue reverts. The owner path is unaffected.
 
 ---
 

--- a/src/modules/blockchain/blockchain.service.spec.ts
+++ b/src/modules/blockchain/blockchain.service.spec.ts
@@ -120,6 +120,22 @@ describe("BlockchainService.isSlashPending (event reconstruction)", () => {
     );
   }
 
+  it("PREFERS the typed getter (SP 5.4.2): returns its bool WITHOUT any event scan", async () => {
+    const config = { get: (_k: string) => undefined } as any;
+    const svc = new BlockchainService(config);
+    (svc as any).provider = {
+      // isSlashPending(address)→bool ABI-encoded true; getLogs must NOT be reached on the getter path.
+      call: async () => ethers.AbiCoder.defaultAbiCoder().encode(["bool"], [true]),
+      getLogs: async () => {
+        throw new Error("event fallback must NOT run when the getter answers");
+      },
+      getBlockNumber: async () => 1000,
+    };
+    expect(await svc.isSlashPending(CONTRACT, OPERATOR, 500)).toBe(true);
+  });
+
+  // NB: every test BELOW uses a provider with NO `.call`, so the getter throws → the code FALLS BACK
+  // to the event reconstruction — i.e. these now also assert the pre-5.4.2 fallback path works.
   it("only SlashQueued in window → pending (true)", async () => {
     const svc = pendingService([pLog("SlashQueued", OPERATOR, 100, 0)]);
     expect(await svc.isSlashPending(CONTRACT, OPERATOR, 500)).toBe(true);

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -669,6 +669,39 @@ export class BlockchainService {
     if (!this.provider) {
       throw new Error("Blockchain provider not configured");
     }
+    // PREFER the O(1) authoritative typed getter added in SuperPaymaster 5.4.2
+    // (ISuperPaymaster.isSlashPending → reads _pendingSlash directly): no getLogs window, no reorg
+    // edge, no owner-path OperatorSlashed miss — and it closes the fresh-node "peer slash aged out of
+    // the window" residual. FALL BACK to the event reconstruction only when the getter is absent
+    // (pre-5.4.2 SP → the call reverts) so the same DVT binary works against both. A getter that
+    // returns a real bool is authoritative; a getter revert is treated as "not present", NOT as a
+    // definite state.
+    try {
+      const contract = new ethers.Contract(
+        superPaymasterAddress,
+        ["function isSlashPending(address operator) view returns (bool)"],
+        this.provider
+      );
+      const pending: boolean = await contract.isSlashPending(operator);
+      return Boolean(pending);
+    } catch {
+      // getter absent (older SP) / decode failure → fall back to the durable event reconstruction.
+      return this.isSlashPendingFromEvents(superPaymasterAddress, operator, lookbackBlocks);
+    }
+  }
+
+  /**
+   * Fallback pending reconstruction from SP events (used only against a pre-5.4.2 SP with no
+   * isSlashPending getter). See the getter above for the authoritative path.
+   */
+  private async isSlashPendingFromEvents(
+    superPaymasterAddress: string,
+    operator: string,
+    lookbackBlocks: number
+  ): Promise<boolean | null> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
     let latest: number;
     try {
       latest = await this.provider.getBlockNumber();


### PR DESCRIPTION
## 背景
SuperPaymaster **5.4.2**（Sepolia UUPS 部署，地址不变）新增 O(1) typed `isSlashPending(address)` view，并把 BLS slash 路径的 **1h 冷却闸放进 `SP.queueSlash`** —— 权威关闭了 checklist 记录的两个 double-slash 残留。本 PR 让 DVT 采纳 getter + 标注残留已闭合。

## 改动
- **`isSlashPending` 改为 getter 优先**：`ISuperPaymaster.isSlashPending` 直读 `_pendingSlash` —— 无 getLogs 窗口、无 reorg 边界、无 owner-path OperatorSlashed 漏判，**顺带关掉 fresh-node pending 窗口残留**。getter 不存在（旧 SP → call revert）时 **fallback 到事件重建**，同一份 DVT binary 兼容新旧 SP。
- **RELEASE_TEST_CHECKLIST**：两个 double-slash 残留标注为 **✅ 合约层已闭合（SP 5.4.2）**（`queueSlash` 的 1h `_blsSlashCd` 闸；DVT staticCall 预检 catch `SlashCooldown` → 降级归档、零 gas、不 park）。DVT over-slash guard 保留为省 gas 纵深防御。记录 **cold-start floor**：首次真实 slash E2E 须 ≥ 升级后 1h（≥ ~2026-07-08 09:24 UTC）。

## 测试
新增 getter-path 测试（返回 bool、不走事件扫描）；既有 7 个 pending 测试现同时验证 pre-5.4.2 fallback 路径。**380/380**、type-check/build/lint（0 errors）/format 全绿。

Claude-Session: https://claude.ai/code/session_01JrdmiUk4A258FmhDSKn9aj
