### PR TITLE
fix(#163 audit): PK nits — log isSlashPending getter fallback + drop redundant Boolean() cast

### DIFF
--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -683,9 +683,17 @@ export class BlockchainService {
         this.provider
       );
       const pending: boolean = await contract.isSlashPending(operator);
-      return Boolean(pending);
-    } catch {
-      // getter absent (older SP) / decode failure → fall back to the durable event reconstruction.
+      return pending;
+    } catch (err: unknown) {
+      // The getter call did not return a bool. Two reasons collapse here — a pre-5.4.2 SP with no
+      // isSlashPending function (call reverts), or a TRANSIENT RPC error — and we cannot always tell
+      // them apart, so we log at debug (not warn: on a healthy 5.4.2 SP this branch never runs) and
+      // fall back to the durable event reconstruction (which has its own fail-closed null on error).
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.debug(
+        `isSlashPending getter unavailable on ${superPaymasterAddress} (${msg}) — ` +
+          `falling back to event reconstruction`
+      );
       return this.isSlashPendingFromEvents(superPaymasterAddress, operator, lookbackBlocks);
     }
   }


### PR DESCRIPTION
PK review on #188（已合并）的两个 nit：

- **Medium**：getter 的 `catch{}` 原先静默 —— RPC 故障与 pre-5.4.2 SP revert 两种降级无痕迹、无法区分。加 `logger.debug`（非 warn：健康的 5.4.2 SP 永不走这个分支）记录「getter 不可用 + 原因」再 fallback 到事件重建。
- **Low**：合约已返回 typed bool → 去掉冗余 `Boolean(pending)` cast。

无行为变更。type-check / build / lint（0 errors）/ format 干净；blockchain spec 42/42 绿。

Claude-Session: https://claude.ai/code/session_01JrdmiUk4A258FmhDSKn9aj
