### PR TITLE
feat(#163 rule③): over-issue detection inc-1 — objective on-chain isOverIssued() → file proposal

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -316,6 +316,13 @@ export default () => {
       }
       return process.env.AUDIT_OFFLINE_ENABLED === "true";
     })(),
+    // Rule ③ over-issue detection (CC-28). Opt-in; audits each configured community xPNTs TOKEN's
+    // OBJECTIVE on-chain isOverIssued() flag (issued value > governance cap). The slash SUBJECT is the
+    // token's communityOwner. Unlike offline, this is objectively slashable (deterministic on-chain
+    // bool). AUDIT_XPNTS_TOKENS: comma-separated community xPNTs token addresses to check (later:
+    // derive from the xPNTs factory, like the rule ① watchlist).
+    auditOverIssueEnabled: process.env.AUDIT_OVER_ISSUE_ENABLED === "true",
+    auditXpntsTokens: parseAllowlist(process.env.AUDIT_XPNTS_TOKENS || ""),
 
     // Gossip Network
     gossipPublicUrl: process.env.GOSSIP_PUBLIC_URL || `ws://localhost:${port}/ws`,

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -2837,5 +2837,91 @@ describe("AuditService", () => {
       await svc.tick();
       expect(queued).toBe(false);
     });
+
+    it("TWO over-issued tokens under ONE owner file TWO proposals (token-scoped dedup, Codex High)", async () => {
+      const TOKEN2 = "0x" + "18".repeat(20);
+      const created: string[] = [];
+      const blockchain = makeBlockchain({
+        getIsOverIssued: async () => true,
+        getCommunityOwner: async () => OWNER, // SAME owner for both tokens
+        createProposalWithEvidence: async (_a: string, operator: string) => {
+          created.push(operator);
+          return { txHash: "0xTX", proposalId: 11n };
+        },
+      });
+      const archive = makeArchive();
+      const svc = makeService(
+        blockchain,
+        overIssueConfig({ auditXpntsTokens: [TOKEN, TOKEN2] }),
+        archive
+      );
+      await svc.tick();
+      // BOTH tokens produce a distinct over-issue proof (not collapsed by the shared owner).
+      expect(archive.records.filter(r => r.evidence.rule === "over-issue")).toHaveLength(2);
+      expect(created).toHaveLength(2);
+    });
+
+    it("sustained breach does NOT re-file within cooldown; a cure→re-breach DOES re-file", async () => {
+      let over = true;
+      let blk = BLOCK; // blocks ADVANCE each tick (a finalized block's state can't flip)
+      const created: string[] = [];
+      const blockchain = makeBlockchain({
+        getViolationBlock: async () => ({ number: blk++, hash: BLOCK_HASH }),
+        getIsOverIssued: async () => over,
+        getCommunityOwner: async () => OWNER,
+        createProposalWithEvidence: async (_a: string, operator: string) => {
+          created.push(operator);
+          return { txHash: "0xTX", proposalId: 11n };
+        },
+      });
+      const svc = makeService(
+        blockchain,
+        overIssueConfig(),
+        makeArchive(),
+        clockAt(1_700_000_000_000)
+      );
+      await svc.tick(); // breach → 1 proposal
+      await svc.tick(); // still breached, within cooldown → NOT re-filed
+      expect(created).toHaveLength(1);
+      over = false;
+      await svc.tick(); // cure → clears the token marker
+      over = true;
+      await svc.tick(); // re-breach after cure → files again
+      expect(created).toHaveLength(2);
+    });
+
+    it("a thrown isOverIssued SKIPS that token but still audits the others", async () => {
+      const BAD = "0x" + "19".repeat(20);
+      const created: string[] = [];
+      const blockchain = makeBlockchain({
+        getIsOverIssued: async (token: string) => {
+          if (token === BAD) throw new Error("no archive at block");
+          return true;
+        },
+        getCommunityOwner: async () => OWNER,
+        createProposalWithEvidence: async (_a: string, operator: string) => {
+          created.push(operator);
+          return { txHash: "0xTX", proposalId: 11n };
+        },
+      });
+      const svc = makeService(
+        blockchain,
+        overIssueConfig({ auditXpntsTokens: [BAD, TOKEN] }),
+        makeArchive()
+      );
+      await svc.tick();
+      expect(created).toHaveLength(1); // BAD skipped, TOKEN still flagged
+    });
+
+    it("a TOKEN-ONLY node (empty watchlist) still schedules — over-issue runs (bootstrap starvation fix)", async () => {
+      const blockchain = makeBlockchain({ getIsOverIssued: async () => false });
+      const svc = makeService(
+        blockchain,
+        overIssueConfig({ auditWatchlist: [] }), // no operators, only tokens
+        makeArchive()
+      );
+      await svc.onApplicationBootstrap();
+      expect((await svc.getStatus()).enabled).toBe(true); // did NOT bail on empty watchlist
+    });
   });
 });

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -90,6 +90,8 @@ function makeBlockchain(
     ) => Promise<boolean>;
     getOperatorNodeId: (blsAgg: string, operator: string) => Promise<string | null>;
     getBlockTimestamp: (blockNumber: number) => Promise<number>;
+    getIsOverIssued: (token: string, blockTag?: number) => Promise<boolean>;
+    getCommunityOwner: (token: string, blockTag?: number) => Promise<string | null>;
   }> = {}
 ): any {
   return {
@@ -123,6 +125,10 @@ function makeBlockchain(
     // A1#6 (round-3) — per-operator membership at the evidence block. Default TRUE (a derived operator
     // is still a role member); a test overrides to model an operator that exited by the epoch block.
     hasRole: overrides.hasRole ?? (async () => true),
+    // Rule ③ over-issue — default WITHIN cap (isOverIssued false); a fixed community owner.
+    getIsOverIssued: overrides.getIsOverIssued ?? (async () => false),
+    getCommunityOwner:
+      overrides.getCommunityOwner ?? (async () => ethers.getAddress("0x" + "c0".repeat(20))),
     // Rule ② offline — operator → nodeId resolution + block timestamp. Defaults model an operator with
     // an active slot (nodeId) and a fixed block time; offline tests override these.
     getOperatorNodeId: overrides.getOperatorNodeId ?? (async () => "0x" + "ab".repeat(32)),
@@ -2730,6 +2736,106 @@ describe("AuditService", () => {
       );
       await svc.tick();
       expect(queued).toBe(false); // offline never queues an on-chain slash in inc-1
+    });
+  });
+
+  // ── Rule ③ over-issue detection (CC-28, inc-1 file-only) ──────────────────────
+  describe("rule ③ over-issue detection", () => {
+    const TOKEN = "0x" + "17".repeat(20);
+    const OWNER = ethers.getAddress("0x" + "c0".repeat(20));
+    const overIssueConfig = (overrides: Record<string, unknown> = {}) =>
+      makeConfig({ auditOverIssueEnabled: true, auditXpntsTokens: [TOKEN], ...overrides });
+
+    it("files an over-issue proposal when a token's isOverIssued() is true (subject = communityOwner)", async () => {
+      const created: string[] = [];
+      const blockchain = makeBlockchain({
+        getIsOverIssued: async () => true,
+        getCommunityOwner: async () => OWNER,
+        createProposalWithEvidence: async (_a: string, operator: string) => {
+          created.push(operator);
+          return { txHash: "0xTX", proposalId: 11n };
+        },
+      });
+      const archive = makeArchive();
+      const svc = makeService(blockchain, overIssueConfig(), archive);
+      await svc.tick();
+      const proof = archive.records.find(r => r.evidence.rule === "over-issue");
+      expect(proof).toBeDefined();
+      expect(proof!.slashLevel).toBe(1); // SlashLevel.MINOR
+      expect(created).toEqual([ethers.getAddress(OWNER)]); // slash subject = communityOwner
+    });
+
+    it("does NOT flag a token within cap (isOverIssued=false)", async () => {
+      const archive = makeArchive();
+      const svc = makeService(
+        makeBlockchain({ getIsOverIssued: async () => false }),
+        overIssueConfig(),
+        archive
+      );
+      await svc.tick();
+      expect(archive.records.find(r => r.evidence.rule === "over-issue")).toBeUndefined();
+    });
+
+    it("SKIPS when communityOwner can't be resolved (fail-safe, no fabricated subject)", async () => {
+      const archive = makeArchive();
+      const svc = makeService(
+        makeBlockchain({ getIsOverIssued: async () => true, getCommunityOwner: async () => null }),
+        overIssueConfig(),
+        archive
+      );
+      await svc.tick();
+      expect(archive.records.find(r => r.evidence.rule === "over-issue")).toBeUndefined();
+    });
+
+    it("is a no-op when AUDIT_OVER_ISSUE_ENABLED is not set (isOverIssued never called)", async () => {
+      let called = false;
+      const blockchain = makeBlockchain({
+        getIsOverIssued: async () => {
+          called = true;
+          return true;
+        },
+      });
+      const svc = makeService(blockchain, makeConfig({ auditXpntsTokens: [TOKEN] }), makeArchive());
+      await svc.tick();
+      expect(called).toBe(false);
+    });
+
+    it("over-issue proofHash is DETERMINISTIC (on-chain bool, no per-node data)", async () => {
+      const build = async () => {
+        const archive = makeArchive();
+        const svc = makeService(
+          makeBlockchain({
+            getIsOverIssued: async () => true,
+            getCommunityOwner: async () => OWNER,
+          }),
+          overIssueConfig(),
+          archive
+        );
+        await svc.tick();
+        return archive.records.find(r => r.evidence.rule === "over-issue")!.proofHash;
+      };
+      expect(await build()).toBe(await build());
+    });
+
+    it("is FILE-ONLY in inc-1 — no queue/execute even when armed (community-slash path unconfirmed)", async () => {
+      let queued = false;
+      const blockchain = makeBlockchain({
+        getIsOverIssued: async () => true,
+        getCommunityOwner: async () => OWNER,
+        queueSlashWithProof: async () => {
+          queued = true;
+          return "0xQUEUE";
+        },
+      });
+      const svc = makeService(
+        blockchain,
+        overIssueConfig({ auditExecuteSlash: true }),
+        makeArchive(),
+        clockAt(1_700_000_000_000),
+        makeCoSigner()
+      );
+      await svc.tick();
+      expect(queued).toBe(false);
     });
   });
 });

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -2861,9 +2861,10 @@ describe("AuditService", () => {
       expect(created).toHaveLength(2);
     });
 
-    it("sustained breach does NOT re-file within cooldown; a cure→re-breach DOES re-file", async () => {
+    it("sustained/flapping breach is RATE-LIMITED by cooldown; re-files only after cooldown expires", async () => {
       let over = true;
       let blk = BLOCK; // blocks ADVANCE each tick (a finalized block's state can't flip)
+      let t = 1_700_000_000_000; // mutable clock
       const created: string[] = [];
       const blockchain = makeBlockchain({
         getViolationBlock: async () => ({ number: blk++, hash: BLOCK_HASH }),
@@ -2874,19 +2875,16 @@ describe("AuditService", () => {
           return { txHash: "0xTX", proposalId: 11n };
         },
       });
-      const svc = makeService(
-        blockchain,
-        overIssueConfig(),
-        makeArchive(),
-        clockAt(1_700_000_000_000)
-      );
+      const svc = makeService(blockchain, overIssueConfig(), makeArchive(), () => t);
       await svc.tick(); // breach → 1 proposal
-      await svc.tick(); // still breached, within cooldown → NOT re-filed
-      expect(created).toHaveLength(1);
+      await svc.tick(); // still breached, within cooldown → rate-limited, NOT re-filed
       over = false;
-      await svc.tick(); // cure → clears the token marker
+      await svc.tick(); // cure (within cooldown)
       over = true;
-      await svc.tick(); // re-breach after cure → files again
+      await svc.tick(); // re-breach still within cooldown → NOT re-filed (flap is rate-limited, no spam)
+      expect(created).toHaveLength(1);
+      t += 3_600_001; // advance past the 1h cooldown
+      await svc.tick(); // re-breach after cooldown → re-files
       expect(created).toHaveLength(2);
     });
 
@@ -2922,6 +2920,42 @@ describe("AuditService", () => {
       );
       await svc.onApplicationBootstrap();
       expect((await svc.getStatus()).enabled).toBe(true); // did NOT bail on empty watchlist
+    });
+
+    it("FAIL-CLOSED on an oversized token list (>256) — over-issue disabled, not silently truncated (Codex High)", async () => {
+      const many = Array.from({ length: 257 }, (_, i) => "0x" + i.toString(16).padStart(40, "0"));
+      let called = false;
+      const blockchain = makeBlockchain({
+        getIsOverIssued: async () => {
+          called = true;
+          return true;
+        },
+      });
+      const svc = makeService(
+        blockchain,
+        overIssueConfig({ auditXpntsTokens: many }),
+        makeArchive()
+      );
+      expect((svc as any).overIssueEnabled).toBe(false); // disabled in the constructor
+      expect((svc as any).xpntsTokens).toHaveLength(0);
+      await svc.tick();
+      expect(called).toBe(false); // nothing audited (fail-closed, not partial coverage)
+    });
+
+    it("bootstrap DROPS a token with no on-chain code (loud error, keeps the good ones — Codex Medium)", async () => {
+      const BAD = "0x" + "19".repeat(20);
+      const blockchain = makeBlockchain({
+        getIsOverIssued: async () => false,
+        getCode: async (addr: string) => (addr === BAD ? "0x" : "0x60006000fd"),
+      });
+      const svc = makeService(
+        blockchain,
+        overIssueConfig({ auditXpntsTokens: [TOKEN, BAD] }),
+        makeArchive()
+      );
+      await svc.onApplicationBootstrap();
+      expect((svc as any).xpntsTokens).toEqual([TOKEN]); // BAD dropped, TOKEN kept
+      expect((svc as any).overIssueEnabled).toBe(true);
     });
   });
 });

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -257,6 +257,9 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     this.logger.warn(`[AUDIT-EVENT] kind=${kind} ${kv}`);
   }
   private static readonly MAX_RECENT = 20;
+  /** Bound on AUDIT_XPNTS_TOKENS — the over-issue rule polls tokens serially per tick (2 reads each),
+   *  so a huge list could elongate a tick and starve the single-flight guard (Codex Low). */
+  private static readonly MAX_XPNTS_TOKENS = 256;
 
   constructor(
     private readonly blockchainService: BlockchainService,
@@ -317,7 +320,8 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     this.roleMaxStaleMs = config.get<number>("auditRoleMaxStaleMs") ?? 900_000;
     this.offlineEnabled = config.get<boolean>("auditOfflineEnabled") === true;
     this.overIssueEnabled = config.get<boolean>("auditOverIssueEnabled") === true;
-    this.xpntsTokens = (config.get<string[]>("auditXpntsTokens") ?? [])
+    // Checksum, drop invalid, DEDUP, and cap (bounded serial polling per tick — Codex Low).
+    const canonicalTokens = (config.get<string[]>("auditXpntsTokens") ?? [])
       .map(a => a.trim())
       .filter(Boolean)
       .map(a => {
@@ -329,6 +333,13 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
         }
       })
       .filter((a): a is string => a !== null);
+    const deduped = [...new Set(canonicalTokens)];
+    if (deduped.length > AuditService.MAX_XPNTS_TOKENS) {
+      this.logger.warn(
+        `Audit: AUDIT_XPNTS_TOKENS has ${deduped.length} entries — capping to ${AuditService.MAX_XPNTS_TOKENS}`
+      );
+    }
+    this.xpntsTokens = deduped.slice(0, AuditService.MAX_XPNTS_TOKENS);
     this.gossip = gossip ?? null;
     this.clock = clock ?? (() => Date.now());
     this.random = random ?? (() => Math.random());
@@ -350,9 +361,15 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       this.logger.log("DVT audit DISABLED (AUDIT_ENABLED!=true) — no operators watched");
       return;
     }
-    if (this.watchlist.length === 0 && !this.roleDerive) {
+    // A node may audit OPERATORS (static watchlist / on-chain-derived) and/or TOKENS (rule ③ over-
+    // issue) — over-issue is operator-independent, so a token-ONLY deployment must still schedule the
+    // tick (Codex: bootstrap starvation). Only bail when there is nothing of EITHER kind to watch.
+    const hasOperators = this.watchlist.length > 0 || this.roleDerive;
+    const hasOverIssueTokens = this.overIssueEnabled && this.xpntsTokens.length > 0;
+    if (!hasOperators && !hasOverIssueTokens) {
       this.logger.warn(
-        "Audit: AUDIT_ENABLED=true but AUDIT_WATCHLIST is empty and AUDIT_ROLE_DERIVE!=true — nothing to watch"
+        "Audit: AUDIT_ENABLED=true but nothing to watch — AUDIT_WATCHLIST empty, AUDIT_ROLE_DERIVE!=true, " +
+          "and no AUDIT_XPNTS_TOKENS (over-issue)"
       );
       return;
     }
@@ -585,6 +602,10 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     // belonged to is over); drop it so a genuinely-new future violation files a fresh proposal rather
     // than reusing a dead id (Codex: stale-id poisoning on the healthy→re-offend path).
     this.pendingProposalIds.delete(coarseKey);
+    // End the episode: drop the proposal COOLDOWN too, so a genuinely-NEW violation after a cure is
+    // not suppressed by the resolved episode's cooldown window (Codex episode semantics — a
+    // cure→re-breach must be able to re-file promptly, not wait out the prior episode's cooldown).
+    this.lastProposalAt.delete(coarseKey);
     // A healthy read ALWAYS attempts the durable removal, regardless of the current executeSlash
     // setting. A durable marker written by an EARLIER armed run must be cleared even if the node is
     // now running disarmed — otherwise it would survive an armed→disarmed→armed restart cycle and,
@@ -1184,7 +1205,9 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     if (!owner) return; // can't identify the subject → skip (fail-safe)
 
     if (!over) {
-      await this.clearCoarseSlashed(owner, RULE_OVER_ISSUE);
+      // Cure: within cap → clear the TOKEN-scoped marker so a later re-breach of THIS token can file
+      // again (episode semantics: one open episode per token, cleared on cure).
+      await this.clearCoarseSlashed(token, RULE_OVER_ISSUE);
       return;
     }
 
@@ -1228,6 +1251,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       identity,
       observed: `over-issued (token ${token})`,
       threshold: "isOverIssued=false",
+      dedupSubject: token, // TOKEN-scoped dedup (one owner may over-issue multiple tokens)
     });
   }
 
@@ -1394,6 +1418,9 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     // credit path's debt/creditLimit are used, so its archived evidence is unchanged.
     observed?: string;
     threshold?: string;
+    /** Dedup/cooldown key subject — defaults to `operator`. Rule ③ over-issue passes the TOKEN so
+     *  multiple over-issued tokens under one communityOwner are tracked independently (not collapsed). */
+    dedupSubject?: string;
   }): Promise<AuditDetection | null> {
     // DETERMINISTIC slash epoch = the violationBlock (an on-chain fact). Two DVT nodes observing
     // the SAME violation derive the SAME epoch, so their queue/execute co-sign preimages match and
@@ -1424,8 +1451,13 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     const proofHash = computeProofHash(identity);
 
     // ── DEDUP ─────────────────────────────────────────────────────────────────────
-    const stableKey = `${this.chainId}|${v.operator}|${v.rule}|${v.violationBlock}`;
-    const coarseKey = this.coarseKey(v.operator, v.rule);
+    // The dedup/cooldown SUBJECT defaults to the operator, but a rule whose violation stream is keyed
+    // by something OTHER than the slash subject overrides it (rule ③ over-issue: one community owner
+    // can have MULTIPLE over-issued tokens — keying by the owner would collapse them into one proposal,
+    // so it keys by the TOKEN while the slash subject stays the owner).
+    const dedupSubject = v.dedupSubject ?? v.operator;
+    const stableKey = `${this.chainId}|${dedupSubject}|${v.rule}|${v.violationBlock}`;
+    const coarseKey = this.coarseKey(dedupSubject, v.rule);
     // Exact same violation@block already handled (this process, or on disk from a prior run) — with
     // TWO bypasses so an incomplete slash is not stranded:
     //   (a) `coSignRetryKeys` (in-memory): a prior attempt's ARMED co-sign aborted transiently.

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -1247,16 +1247,19 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       return;
     }
 
-    // The communityOwner is the slash subject — read it at the SAME block so the subject is pinned.
-    const owner = await this.blockchainService.getCommunityOwner(token, pinnedBlock.number);
-    if (!owner) return; // can't identify the subject → skip (fail-safe)
-
     if (!over) {
       // Cure: within cap → clear the TOKEN-scoped marker so a later re-breach of THIS token can file
-      // again (episode semantics: one open episode per token, cleared on cure).
+      // again (episode semantics: one open episode per token). Checked BEFORE reading communityOwner
+      // (Codex Low): a within-cap token needs no owner read, and a transient owner-null must not block
+      // the marker clear.
       await this.clearCoarseSlashed(token, RULE_OVER_ISSUE);
       return;
     }
+
+    // Over-issued → the communityOwner is the slash subject; read it at the SAME block (pinned). Only
+    // fetched on a real violation (not on every within-cap token).
+    const owner = await this.blockchainService.getCommunityOwner(token, pinnedBlock.number);
+    if (!owner) return; // can't identify the subject → skip (fail-safe)
 
     // OVER-ISSUE violation. DETERMINISTIC identity — on-chain bool, no per-node data.
     const identity: ProofIdentity = {

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -444,13 +444,18 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
         try {
           code = await this.blockchainService.getCode(token);
         } catch (err: unknown) {
+          // TRANSIENT RPC error — do NOT permanently drop a possibly-valid token on a one-time startup
+          // hiccup (Codex Medium). KEEP it; the per-tick getIsOverIssued read retries once RPC recovers
+          // (and its own per-token catch skips a genuinely-broken read without a false violation).
           const msg = err instanceof Error ? err.message : String(err);
-          this.logger.error(
-            `Audit: getCode(AUDIT_XPNTS_TOKENS ${token}) failed (${msg}) — DROPPED`
+          this.logger.warn(
+            `Audit: getCode(AUDIT_XPNTS_TOKENS ${token}) failed (${msg}) — KEEPING (transient; read retries)`
           );
+          valid.push(token);
           continue;
         }
         if (!code || code === "0x") {
+          // AUTHORITATIVE: no code = EOA / wrong chain / destroyed → drop (loud, not silent).
           this.logger.error(
             `Audit: AUDIT_XPNTS_TOKENS ${token} has no on-chain code on chainId ${this.chainId} — DROPPED`
           );
@@ -2297,6 +2302,8 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     derivedOperatorCount: number;
     derivedSetFresh: boolean;
     lastRoleRefreshAt: number | null;
+    overIssueEnabled: boolean;
+    overIssueTokenCount: number;
     lastTickAt: number | null;
     recentDetections: AuditDetection[];
     archivedProofCount: number;
@@ -2322,6 +2329,8 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       roleDerive: this.roleDerive,
       derivedOperatorCount: this.derivedOperators.length,
       derivedSetFresh: this.derivedSetIsFresh(),
+      overIssueEnabled: this.overIssueEnabled,
+      overIssueTokenCount: this.xpntsTokens.length,
       lastRoleRefreshAt: this.lastRoleRefreshAt,
       lastTickAt: this.lastTickAt,
       recentDetections: this.recentDetections,

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -66,6 +66,14 @@ const RULE_OFFLINE = "offline";
  * 10 minutes. (The effective window is this + the finality lag of the evidence block.)
  */
 const OFFLINE_THRESHOLD_MS = 600_000;
+/**
+ * Rule ③ over-issue (CC-28). MINOR (3-of-3 quorum) — a community minting xPNTs beyond its governance
+ * cap is a serious economic abuse, and the evidence is OBJECTIVE (on-chain isOverIssued() bool), so
+ * the strict quorum is warranted. Slash SUBJECT = the token's communityOwner. Cleared when the token
+ * is next seen within cap.
+ */
+const SLASH_LEVEL_OVER_ISSUE = SlashLevel.MINOR;
+const RULE_OVER_ISSUE = "over-issue";
 /** ROLE_DVT = keccak256("DVT") — the staking role lock the audit inspects. */
 const ROLE_DVT = ethers.id("DVT");
 
@@ -140,6 +148,10 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
   /** Stable operator→nodeId cache (offline rule ②). A transient resolve failure keeps the cached
    *  nodeId so a still-relevant operator is never pruned from the gossip ledger on an RPC blip. */
   private readonly offlineNodeIdCache = new Map<string, string>();
+  /** Rule ③ over-issue — opt-in; audits each community xPNTs token's on-chain isOverIssued() flag. */
+  private readonly overIssueEnabled: boolean;
+  /** Community xPNTs token addresses to check for over-issuance (checksummed at ingest). */
+  private readonly xpntsTokens: string[];
   /** Last successfully-derived on-chain operator set (checksummed); UNIONed with the static list. */
   private derivedOperators: string[] = [];
   /** Wall-clock of the last SUCCESSFUL role derivation (null = never); drives freshness. */
@@ -304,6 +316,19 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     this.roleUseGetter = config.get<boolean>("auditRoleUseGetter") === true;
     this.roleMaxStaleMs = config.get<number>("auditRoleMaxStaleMs") ?? 900_000;
     this.offlineEnabled = config.get<boolean>("auditOfflineEnabled") === true;
+    this.overIssueEnabled = config.get<boolean>("auditOverIssueEnabled") === true;
+    this.xpntsTokens = (config.get<string[]>("auditXpntsTokens") ?? [])
+      .map(a => a.trim())
+      .filter(Boolean)
+      .map(a => {
+        try {
+          return ethers.getAddress(a);
+        } catch {
+          this.logger.warn(`Audit: dropping invalid AUDIT_XPNTS_TOKENS entry "${a}"`);
+          return null;
+        }
+      })
+      .filter((a): a is string => a !== null);
     this.gossip = gossip ?? null;
     this.clock = clock ?? (() => Date.now());
     this.random = random ?? (() => Math.random());
@@ -678,6 +703,19 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
           }
         }
         this.gossip.setRelevantNodeIds(this.offlineNodeIdCache.values());
+      }
+      // Rule ③ over-issue — audits TOKENS (per community), INDEPENDENT of the operator set, so it runs
+      // even when the operator watchlist is empty. One token's failure never skips another.
+      if (this.overIssueEnabled) {
+        for (const token of this.xpntsTokens) {
+          try {
+            await this.auditOverIssueForToken(token, pinnedBlock);
+          } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : String(err);
+            this.logger.error(`Audit: over-issue audit failed for token ${token} — ${msg}`);
+            this.emitAuditEvent("ERROR", { operator: token, error: msg });
+          }
+        }
       }
       if (operators.length === 0) {
         this.logger.debug("Audit: no operators to watch this tick (static + derived both empty)");
@@ -1115,6 +1153,81 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       identity,
       observed: `offline ${offlineForMs}ms`,
       threshold: `${OFFLINE_THRESHOLD_MS}ms`,
+    });
+  }
+
+  /**
+   * Rule ③ over-issue (CC-28) for ONE community xPNTs token, pinned to the finalized block. Reads the
+   * token's OBJECTIVE on-chain isOverIssued() flag (issued value > governance effectiveCap). On true,
+   * the SLASH SUBJECT is the token's communityOwner (the community that minted beyond its cap). The
+   * evidence is a deterministic on-chain bool → every DVT node agrees → SAFELY quorum-slashable
+   * (unlike gossip-offline). Fail-SAFE: over-issue disabled, an isOverIssued/communityOwner read
+   * error, or a null owner → SKIP (never fabricate). A within-cap read CLEARS any coarse marker.
+   */
+  private async auditOverIssueForToken(
+    token: string,
+    pinnedBlock: { number: number; hash: string }
+  ): Promise<void> {
+    if (!this.overIssueEnabled) return;
+
+    let over: boolean;
+    try {
+      over = await this.blockchainService.getIsOverIssued(token, pinnedBlock.number);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`Audit: over-issue isOverIssued read failed for token ${token} — ${msg}`);
+      return;
+    }
+
+    // The communityOwner is the slash subject — read it at the SAME block so the subject is pinned.
+    const owner = await this.blockchainService.getCommunityOwner(token, pinnedBlock.number);
+    if (!owner) return; // can't identify the subject → skip (fail-safe)
+
+    if (!over) {
+      await this.clearCoarseSlashed(owner, RULE_OVER_ISSUE);
+      return;
+    }
+
+    // OVER-ISSUE violation. DETERMINISTIC identity — on-chain bool, no per-node data.
+    const identity: ProofIdentity = {
+      proofSchemaVersion: PROOF_SCHEMA_VERSION,
+      chainId: this.chainId,
+      operator: owner,
+      rule: RULE_OVER_ISSUE,
+      violationBlock: pinnedBlock.number,
+      slashLevel: SLASH_LEVEL_OVER_ISSUE,
+      registry: this.normalizeAddress(this.registryAddress),
+      dvtValidator: this.normalizeAddress(this.dvtValidatorAddress),
+      overIssueToken: this.normalizeAddress(token),
+    };
+    const reason = `${RULE_OVER_ISSUE}: community ${owner} over-issued xPNTs token ${token} (isOverIssued=true @block ${pinnedBlock.number})`;
+    this.logger.warn(reason);
+    const sources: EvidenceSource[] = [
+      {
+        type: "view",
+        name: "xPNTs.isOverIssued()",
+        value: "true",
+        block: pinnedBlock.number,
+      },
+      {
+        type: "view",
+        name: "xPNTs.communityOwner()",
+        value: owner,
+        block: pinnedBlock.number,
+      },
+    ];
+    await this.handleViolation({
+      operator: owner,
+      slashLevel: SLASH_LEVEL_OVER_ISSUE,
+      reason,
+      rule: RULE_OVER_ISSUE,
+      violationBlock: pinnedBlock.number,
+      violationBlockHash: pinnedBlock.hash,
+      sources,
+      observedAt: this.clock(),
+      identity,
+      observed: `over-issued (token ${token})`,
+      threshold: "isOverIssued=false",
     });
   }
 
@@ -1847,10 +1960,12 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     coSignAborted: boolean;
   }> {
     const { operator, slashLevel, reason, epoch, evidenceHash } = args;
-    // Rule ② offline (inc-1) is FILE-ONLY: the armed BLS co-sign for offline (the responder re-checking
-    // its OWN gossip liveness) is inc-2, so the offline path never queues/executes — it only files a
-    // proposal + archives the proof. The credit rule is unaffected.
-    const fileOnlyRule = args.rule === RULE_OFFLINE;
+    // FILE-ONLY rules (inc-1): file a proposal + archive the proof, but never queue/execute an on-chain
+    // slash yet. Offline's armed co-sign is deferred (its evidence is gossip-local; see #202). Over-
+    // issue's evidence IS objective (on-chain isOverIssued) so it is armable in principle, but its slash
+    // SUBJECT is a communityOwner (not a BLS-slotted DVT operator) — arming waits until the SP contract
+    // community-slash path is confirmed. The credit rule is unaffected (stays armed).
+    const fileOnlyRule = args.rule === RULE_OFFLINE || args.rule === RULE_OVER_ISSUE;
     // A1#6 (Codex High-2 + round-3) — a derived-ONLY operator is armed for the irreversible on-chain
     // slash only when its membership is CONFIRMED at the evidence block (epoch) via hasRole — not just
     // the cached set's wall-clock freshness. Stale/never-confirmed/exited-by-epoch membership degrades

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -148,10 +148,12 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
   /** Stable operator→nodeId cache (offline rule ②). A transient resolve failure keeps the cached
    *  nodeId so a still-relevant operator is never pruned from the gossip ledger on an RPC blip. */
   private readonly offlineNodeIdCache = new Map<string, string>();
-  /** Rule ③ over-issue — opt-in; audits each community xPNTs token's on-chain isOverIssued() flag. */
-  private readonly overIssueEnabled: boolean;
-  /** Community xPNTs token addresses to check for over-issuance (checksummed at ingest). */
-  private readonly xpntsTokens: string[];
+  /** Rule ③ over-issue — opt-in; audits each community xPNTs token's on-chain isOverIssued() flag.
+   *  May be disabled at bootstrap (oversized list / all tokens invalid). */
+  private overIssueEnabled: boolean;
+  /** Community xPNTs token addresses to check for over-issuance (checksummed at ingest; bytecode-
+   *  validated + pruned at bootstrap). */
+  private xpntsTokens: string[];
   /** Last successfully-derived on-chain operator set (checksummed); UNIONed with the static list. */
   private derivedOperators: string[] = [];
   /** Wall-clock of the last SUCCESSFUL role derivation (null = never); drives freshness. */
@@ -319,8 +321,7 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     this.roleUseGetter = config.get<boolean>("auditRoleUseGetter") === true;
     this.roleMaxStaleMs = config.get<number>("auditRoleMaxStaleMs") ?? 900_000;
     this.offlineEnabled = config.get<boolean>("auditOfflineEnabled") === true;
-    this.overIssueEnabled = config.get<boolean>("auditOverIssueEnabled") === true;
-    // Checksum, drop invalid, DEDUP, and cap (bounded serial polling per tick — Codex Low).
+    // Checksum, drop invalid, DEDUP.
     const canonicalTokens = (config.get<string[]>("auditXpntsTokens") ?? [])
       .map(a => a.trim())
       .filter(Boolean)
@@ -334,12 +335,22 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       })
       .filter((a): a is string => a !== null);
     const deduped = [...new Set(canonicalTokens)];
-    if (deduped.length > AuditService.MAX_XPNTS_TOKENS) {
-      this.logger.warn(
-        `Audit: AUDIT_XPNTS_TOKENS has ${deduped.length} entries — capping to ${AuditService.MAX_XPNTS_TOKENS}`
+    const rawOverIssue = config.get<boolean>("auditOverIssueEnabled") === true;
+    // FAIL-CLOSED on an oversized list (Codex High): silently truncating to a cap would drop configured
+    // audit targets — a security allowlist must NEVER silently reduce coverage. Over the bound → DISABLE
+    // over-issue with a loud error so the operator shards/reduces rather than getting partial coverage.
+    if (rawOverIssue && deduped.length > AuditService.MAX_XPNTS_TOKENS) {
+      this.logger.error(
+        `Audit: AUDIT_XPNTS_TOKENS has ${deduped.length} > ${AuditService.MAX_XPNTS_TOKENS} tokens — ` +
+          `over-issue DISABLED (fail-closed). Reduce the list or shard it across nodes; silent ` +
+          `truncation would leave tokens unaudited.`
       );
+      this.overIssueEnabled = false;
+      this.xpntsTokens = [];
+    } else {
+      this.overIssueEnabled = rawOverIssue;
+      this.xpntsTokens = deduped;
     }
-    this.xpntsTokens = deduped.slice(0, AuditService.MAX_XPNTS_TOKENS);
     this.gossip = gossip ?? null;
     this.clock = clock ?? (() => Date.now());
     this.random = random ?? (() => Math.random());
@@ -421,6 +432,36 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
           `Audit: ${name}=${addr} has no on-chain code on chainId ${this.chainId} — DISABLED (fail-closed)`
         );
         return;
+      }
+    }
+    // Rule ③ — bytecode-validate each configured xPNTs token (Codex Medium: a missing/EOA/wrong-chain
+    // token address would otherwise be caught-and-swallowed per read, silently unaudited forever). A
+    // bad token is DROPPED with a loud error (not the whole audit — credit/offline may still be valid).
+    if (this.overIssueEnabled && this.xpntsTokens.length > 0) {
+      const valid: string[] = [];
+      for (const token of this.xpntsTokens) {
+        let code: string;
+        try {
+          code = await this.blockchainService.getCode(token);
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err);
+          this.logger.error(
+            `Audit: getCode(AUDIT_XPNTS_TOKENS ${token}) failed (${msg}) — DROPPED`
+          );
+          continue;
+        }
+        if (!code || code === "0x") {
+          this.logger.error(
+            `Audit: AUDIT_XPNTS_TOKENS ${token} has no on-chain code on chainId ${this.chainId} — DROPPED`
+          );
+          continue;
+        }
+        valid.push(token);
+      }
+      this.xpntsTokens = valid;
+      if (valid.length === 0) {
+        this.overIssueEnabled = false;
+        this.logger.error("Audit: no valid AUDIT_XPNTS_TOKENS remain — over-issue DISABLED");
       }
     }
     // A1#6 — eager first derivation so the startup log + first tick already see the on-chain set
@@ -602,10 +643,11 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     // belonged to is over); drop it so a genuinely-new future violation files a fresh proposal rather
     // than reusing a dead id (Codex: stale-id poisoning on the healthy→re-offend path).
     this.pendingProposalIds.delete(coarseKey);
-    // End the episode: drop the proposal COOLDOWN too, so a genuinely-NEW violation after a cure is
-    // not suppressed by the resolved episode's cooldown window (Codex episode semantics — a
-    // cure→re-breach must be able to re-file promptly, not wait out the prior episode's cooldown).
-    this.lastProposalAt.delete(coarseKey);
+    // NOTE: the proposal COOLDOWN (lastProposalAt) is deliberately NOT cleared here — it is a pure
+    // RATE LIMIT (≤1 proposal per subject per cooldownMs). Clearing it on every healthy read would let
+    // a FLAPPING condition (cross the boundary each block) spam a fresh proposal every tick. Episode
+    // semantics: a cure→re-breach re-files once the cooldown expires (or immediately if the gap already
+    // exceeds it), never faster. This keeps credit/offline (both live) spam-safe.
     // A healthy read ALWAYS attempts the durable removal, regardless of the current executeSlash
     // setting. A durable marker written by an EARLIER armed run must be cleared even if the node is
     // now running disarmed — otherwise it would survive an armed→disarmed→armed restart cycle and,
@@ -1997,6 +2039,11 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     // issue's evidence IS objective (on-chain isOverIssued) so it is armable in principle, but its slash
     // SUBJECT is a communityOwner (not a BLS-slotted DVT operator) — arming waits until the SP contract
     // community-slash path is confirmed. The credit rule is unaffected (stays armed).
+    // INC-2 BLOCKER for over-issue (Codex High): the dedup coarseKey is TOKEN-scoped but the slash
+    // subject + assessSlashState + execute are OWNER-scoped. Two tokens of one owner would keep
+    // independent token-scoped armed state (slashedCoarseKeys/pendingProposalIds) yet slash the SAME
+    // owner — enabling a double-slash / orphaned-proposal. Over-issue MUST stay file-only until the
+    // proposal-dedup (token) is SEPARATED from the pending/executed-slash guard (owner).
     const fileOnlyRule = args.rule === RULE_OFFLINE || args.rule === RULE_OVER_ISSUE;
     // A1#6 (Codex High-2 + round-3) — a derived-ONLY operator is armed for the irreversible on-chain
     // slash only when its membership is CONFIRMED at the evidence block (epoch) via hasRole — not just

--- a/src/modules/audit/proof-archive.ts
+++ b/src/modules/audit/proof-archive.ts
@@ -206,6 +206,11 @@ export interface ProofIdentity {
   offlineThresholdMs?: number;
   /** BLSAggregator used to resolve operator → registered BLS key → gossip nodeId (checksummed). */
   blsAggregator?: string;
+
+  // ── over-issue rule fields (rule ③). Present ONLY on over-issue proofs. The violation is the
+  //    token's on-chain isOverIssued() bool at violationBlock (objective); operator = communityOwner.
+  /** The community xPNTs token whose isOverIssued() was true (checksummed). */
+  overIssueToken?: string;
 }
 
 /** Deterministic JSON with recursively sorted keys — a stable content-address preimage. */

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -886,6 +886,42 @@ export class BlockchainService {
   }
 
   /**
+   * Over-issue-audit rule ③ (CC-28) — read a community xPNTs token's OBJECTIVE over-issuance flag,
+   * pinned to a finalized block. `isOverIssued()` is the SP-delivered getter: true when the token's
+   * issued value (totalSupply × exchangeRate × apntsPrice) exceeds its governance effectiveCap
+   * (industryScale × capRatio + staked backing). A pure on-chain bool → every DVT node reads the SAME
+   * value → deterministic content-address (unlike gossip-offline, this is objectively slashable).
+   * THROWS on a provider/read error (fail-loud: the caller skips this token, never guesses a violation).
+   */
+  async getIsOverIssued(xpntsToken: string, blockTag?: number): Promise<boolean> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+    const abi = ["function isOverIssued() view returns (bool)"];
+    const contract = new ethers.Contract(xpntsToken, abi, this.provider);
+    return await contract.isOverIssued({ blockTag });
+  }
+
+  /**
+   * Over-issue-audit rule ③ — the community owner of an xPNTs token (the SLASH SUBJECT for over-
+   * issuance; it is the community that minted beyond its cap). Read pinned to the evidence block so
+   * the subject is fixed with the violation. Returns null on a read error (caller skips the token).
+   */
+  async getCommunityOwner(xpntsToken: string, blockTag?: number): Promise<string | null> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+    const abi = ["function communityOwner() view returns (address)"];
+    const contract = new ethers.Contract(xpntsToken, abi, this.provider);
+    try {
+      return ethers.getAddress(await contract.communityOwner({ blockTag }));
+    } catch (error: any) {
+      this.logger.warn(`getCommunityOwner(${xpntsToken}) failed: ${error.message}`);
+      return null;
+    }
+  }
+
+  /**
    * Offline-audit rule ② — resolve an on-chain operator to its gossip `nodeId`, the bridge between
    * the on-chain slash target (operator EOA) and the off-chain liveness key (gossip peer id). Reads
    * BLSAggregator.getBLSPublicKey(operator) → the registered EIP-2537 G1 key tuple (x_a,x_b,y_a,y_b =


### PR DESCRIPTION
## Rule ③ over-issue detection — inc-1 (file-only)

Third DVT audit rule (CC-28, SP delivered `isOverIssued()`). Audits each configured community xPNTs
**token**'s on-chain over-issuance flag. **Unlike offline** (gossip-local, un-adjudicable — arming
correctly deferred to #202/auto-jail), over-issue evidence is **OBJECTIVE**: a deterministic on-chain
`bool`, like credit-over-limit → every DVT node reads the same value → soundly quorum-slashable.
Opt-in (`AUDIT_OVER_ISSUE_ENABLED`), default OFF. **inc-1 = file-only.**

### How
- **blockchain**: `getIsOverIssued(token, block)` (getter-first, pinned to finalized block; throws on
  read error → skip token) + `getCommunityOwner(token, block)` (the slash **subject**).
- **audit**: `RULE_OVER_ISSUE` (MINOR / 3-of-3 — serious + objective). `auditOverIssueForToken` reads
  `isOverIssued` at the finalized block; on true → resolve `communityOwner` → deterministic identity
  (no per-node data) → `handleViolation` with the owner as subject. A per-**token** loop in the tick,
  **independent of the operator set** (runs on an empty watchlist). Fail-safe on every uncertainty.
- **dedup**: `handleViolation` gains `dedupSubject` (defaults to operator); over-issue keys by the
  **TOKEN** so a community with N over-issued tokens files N independent proposals (subject stays the
  owner). Cooldown is a pure rate-limit; a cure→re-breach re-files after it expires (no flap-spam).
- **fail-closed config**: an oversized `AUDIT_XPNTS_TOKENS` (>256) DISABLES over-issue (never silent
  truncation); bootstrap bytecode-validates each token (drops an authoritative no-code one, keeps it
  on a transient RPC error); `getStatus` exposes `overIssueEnabled`/`overIssueTokenCount`.

### Review
Codex adversarial, **3 rounds** — converged (2 High + Mediums fixed) to Low/nits. **434 tests** (+15),
0 lint errors, type-check clean. Credit + offline unchanged.

### Deferred to inc-2 (correctly — inc-1 is file-only)
Arming needs: (1) separate the token-scoped proposal dedup from the **owner-scoped** pending/executed
slash guard (else two tokens of one owner → double-slash/orphan), (2) confirm the SP contract
community-slash route (subject = communityOwner, not a BLS-slotted operator), (3) slash-severity
policy. The file-only gate blocks arming until then.

https://claude.ai/code/session_01JrdmiUk4A258FmhDSKn9aj
