### PR TITLE
feat(#202 inc-2): DVT liveness attest keeper (C1) — self-attest on-chain for SP auto-jail

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -324,6 +324,18 @@ export default () => {
     auditOverIssueEnabled: process.env.AUDIT_OVER_ISSUE_ENABLED === "true",
     auditXpntsTokens: parseAllowlist(process.env.AUDIT_XPNTS_TOKENS || ""),
 
+    // inc-2 liveness attest keeper (SP LivenessRegistry, CC-29). Opt-in. Each DVT node self-proves
+    // liveness on-chain so SP's auto-jail only excludes genuinely-silent operators. Reads NOTHING
+    // for slash-threshold math (BLSAggregator owns the fixed on-chain threshold) — this only writes
+    // attestLiveness(anchorBlock, anchorHash) from the operator EOA. Interval is wall-clock; set it
+    // to ~livenessWindow/3 worth of time for the target chain (keeper logs the on-chain window at boot).
+    auditAttestEnabled: process.env.AUDIT_ATTEST_ENABLED === "true",
+    auditLivenessRegistryAddress: process.env.AUDIT_LIVENESS_REGISTRY_ADDRESS || "",
+    auditAttestIntervalMs: parseInt(process.env.AUDIT_ATTEST_INTERVAL_MS || "600000", 10),
+    // Anchor depth for attestLiveness: head−depth. Must sit ABOVE typical reorg depth (stable hash →
+    // no BadAnchorHash) yet well BELOW SP's 256-block staleness bound. Default 16.
+    auditAttestAnchorDepth: parseInt(process.env.AUDIT_ATTEST_ANCHOR_DEPTH || "16", 10),
+
     // Gossip Network
     gossipPublicUrl: process.env.GOSSIP_PUBLIC_URL || `ws://localhost:${port}/ws`,
     gossipBootstrapPeers: parseBootstrapPeers(process.env.GOSSIP_BOOTSTRAP_PEERS || ""),

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,10 @@ async function bootstrap() {
 
   app.enableCors();
 
+  // Enable signal-driven lifecycle hooks so OnApplicationShutdown fires on SIGINT/SIGTERM —
+  // the liveness attest keeper (and other timers) clear their intervals on shutdown.
+  app.enableShutdownHooks();
+
   // Swagger configuration
   const config = new DocumentBuilder()
     .setTitle("BLS Signer Service API")

--- a/src/modules/audit/audit.module.ts
+++ b/src/modules/audit/audit.module.ts
@@ -12,6 +12,7 @@ import { NodeService } from "../node/node.service.js";
 import { BlockchainService } from "../blockchain/blockchain.service.js";
 import { IQuorumCoSigner, PendingSlotCoSigner, QUORUM_COSIGNER } from "./slash-consensus.js";
 import { GossipQuorumCoSigner } from "./gossip-quorum-cosigner.js";
+import { LivenessKeeperService } from "./liveness-keeper.service.js";
 
 /**
  * DVT Phase 2 (目标2) — autonomous operator audit module. Reuses the shared BlockchainService
@@ -28,6 +29,9 @@ import { GossipQuorumCoSigner } from "./gossip-quorum-cosigner.js";
   controllers: [AuditController],
   providers: [
     AuditService,
+    // inc-2 C1 — liveness attest keeper (opt-in AUDIT_ATTEST_ENABLED). Self-disables at bootstrap
+    // when unconfigured; OpsAlertService is @Global so it injects without an explicit import.
+    LivenessKeeperService,
     {
       provide: QUORUM_COSIGNER,
       useFactory: (

--- a/src/modules/audit/liveness-keeper.service.spec.ts
+++ b/src/modules/audit/liveness-keeper.service.spec.ts
@@ -1,0 +1,127 @@
+import { jest } from "@jest/globals";
+import { LivenessKeeperService } from "./liveness-keeper.service.js";
+
+const REGISTRY = "0x1111111111111111111111111111111111111111";
+const OP = "0x2222222222222222222222222222222222222222";
+
+/** Config stub from a plain map (undefined for unset keys, like NestJS ConfigService). */
+function cfg(map: Record<string, any>): any {
+  return { get: (k: string) => map[k] };
+}
+
+/** BlockchainService stub — only the methods the keeper touches. */
+function chain(over: Partial<Record<string, any>> = {}): any {
+  return {
+    getWalletAddress: () => OP,
+    getAttestAnchor: jest.fn(async () => ({ number: 984, hash: "0x" + "ab".repeat(32) })),
+    attestLiveness: jest.fn(async () => "0xtxhash"),
+    getLivenessWindow: jest.fn(async () => 300n),
+    ...over,
+  };
+}
+
+describe("LivenessKeeperService", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("stays DISABLED when AUDIT_ATTEST_ENABLED is not true (no timer, no attest)", () => {
+    const bc = chain();
+    const k = new LivenessKeeperService(bc, cfg({ auditAttestEnabled: false }));
+    k.onApplicationBootstrap();
+    expect((k as any).timer).toBeNull();
+    expect(bc.attestLiveness).not.toHaveBeenCalled();
+  });
+
+  it("DISABLES when the registry address is missing/invalid", () => {
+    const bc = chain();
+    const k = new LivenessKeeperService(
+      bc,
+      cfg({ auditAttestEnabled: true, auditLivenessRegistryAddress: "not-an-address" })
+    );
+    k.onApplicationBootstrap();
+    expect((k as any).timer).toBeNull();
+    expect(bc.attestLiveness).not.toHaveBeenCalled();
+  });
+
+  it("DISABLES when there is no operator wallet", () => {
+    const bc = chain({ getWalletAddress: () => null });
+    const k = new LivenessKeeperService(
+      bc,
+      cfg({ auditAttestEnabled: true, auditLivenessRegistryAddress: REGISTRY })
+    );
+    k.onApplicationBootstrap();
+    expect((k as any).timer).toBeNull();
+  });
+
+  it("DISABLES on a non-finite interval", () => {
+    const bc = chain();
+    const k = new LivenessKeeperService(
+      bc,
+      cfg({
+        auditAttestEnabled: true,
+        auditLivenessRegistryAddress: REGISTRY,
+        auditAttestIntervalMs: NaN,
+      })
+    );
+    k.onApplicationBootstrap();
+    expect((k as any).timer).toBeNull();
+  });
+
+  it("when enabled+configured: boot-attests immediately and arms the interval timer", async () => {
+    const bc = chain();
+    const k = new LivenessKeeperService(
+      bc,
+      cfg({
+        auditAttestEnabled: true,
+        auditLivenessRegistryAddress: REGISTRY,
+        auditAttestIntervalMs: 600_000,
+        auditAttestAnchorDepth: 16,
+      })
+    );
+    k.onApplicationBootstrap();
+    expect((k as any).timer).not.toBeNull();
+    // boot-attest is fire-and-forget (void this.tick()); let the microtask settle.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(bc.getAttestAnchor).toHaveBeenCalledWith(16);
+    expect(bc.attestLiveness).toHaveBeenCalledWith(REGISTRY, 984, "0x" + "ab".repeat(32));
+    k.onApplicationShutdown();
+    expect((k as any).timer).toBeNull();
+  });
+
+  it("tick() NEVER throws on an attest failure and alerts ops", async () => {
+    const alert = jest.fn();
+    const bc = chain({
+      attestLiveness: jest.fn(async () => {
+        throw new Error("StaleAnchor");
+      }),
+    });
+    const k = new LivenessKeeperService(
+      bc,
+      cfg({ auditAttestEnabled: true, auditLivenessRegistryAddress: REGISTRY }),
+      { alert } as any
+    );
+    await expect(k.tick()).resolves.toBeUndefined();
+    expect(alert).toHaveBeenCalledWith("warn", expect.stringContaining("StaleAnchor"));
+  });
+
+  it("tick() skips when a previous attest is still in-flight (no overlap)", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>(r => (release = r));
+    const bc = chain({
+      attestLiveness: jest.fn(async () => {
+        await gate;
+        return "0xtxhash";
+      }),
+    });
+    const k = new LivenessKeeperService(
+      bc,
+      cfg({ auditAttestEnabled: true, auditLivenessRegistryAddress: REGISTRY })
+    );
+    const first = k.tick(); // starts, blocks on gate → inFlight=true
+    await Promise.resolve();
+    await k.tick(); // must skip (inFlight)
+    expect(bc.attestLiveness).toHaveBeenCalledTimes(1);
+    release();
+    await first;
+  });
+});

--- a/src/modules/audit/liveness-keeper.service.ts
+++ b/src/modules/audit/liveness-keeper.service.ts
@@ -58,7 +58,17 @@ export class LivenessKeeperService implements OnApplicationBootstrap, OnApplicat
     this.enabled = this.config?.get<boolean>("auditAttestEnabled") === true;
     this.registryAddress = this.config?.get<string>("auditLivenessRegistryAddress") ?? "";
     this.intervalMs = this.config?.get<number>("auditAttestIntervalMs") ?? 600_000;
-    this.anchorDepth = this.config?.get<number>("auditAttestAnchorDepth") ?? 16;
+    // Clamp anchor depth to the protocol-valid [1,255] up front, so the ENABLED log reports the depth
+    // actually used (getAttestAnchor clamps too; keeping them in sync avoids a misleading log).
+    const rawDepth = this.config?.get<number>("auditAttestAnchorDepth") ?? 16;
+    this.anchorDepth = Number.isFinite(rawDepth)
+      ? Math.min(255, Math.max(1, Math.floor(rawDepth)))
+      : 16;
+    if (this.anchorDepth !== rawDepth) {
+      this.logger.warn(
+        `AUDIT_ATTEST_ANCHOR_DEPTH ${rawDepth} out of [1,255] — clamped to ${this.anchorDepth}`
+      );
+    }
   }
 
   onApplicationBootstrap(): void {
@@ -118,6 +128,7 @@ export class LivenessKeeperService implements OnApplicationBootstrap, OnApplicat
     this.inFlight = true;
     try {
       const anchor = await this.blockchain.getAttestAnchor(this.anchorDepth);
+      if (this.stopping) return; // shutdown began during the anchor read — do not start a write
       const txHash = await this.blockchain.attestLiveness(
         this.registryAddress,
         anchor.number,

--- a/src/modules/audit/liveness-keeper.service.ts
+++ b/src/modules/audit/liveness-keeper.service.ts
@@ -35,6 +35,10 @@ import { OpsAlertService } from "../ops-alert/ops-alert.service.js";
  */
 @Injectable()
 export class LivenessKeeperService implements OnApplicationBootstrap, OnApplicationShutdown {
+  /** Operationally-safe cadence bounds (fail-closed outside these). */
+  private static readonly MIN_INTERVAL_MS = 30_000; // 30s — below this floods RPC/gas
+  private static readonly MAX_INTERVAL_MS = 21_600_000; // 6h — above risks tripping the offline window
+
   private readonly logger = new Logger(LivenessKeeperService.name);
   private readonly enabled: boolean;
   private readonly registryAddress: string;
@@ -43,6 +47,8 @@ export class LivenessKeeperService implements OnApplicationBootstrap, OnApplicat
   private timer: ReturnType<typeof setInterval> | null = null;
   /** Guards against overlapping ticks if one attest runs longer than the interval. */
   private inFlight = false;
+  /** Set on shutdown so a fired timer / in-flight boot-attest starts no NEW work. */
+  private stopping = false;
 
   constructor(
     private readonly blockchain: BlockchainService,
@@ -69,10 +75,17 @@ export class LivenessKeeperService implements OnApplicationBootstrap, OnApplicat
       );
       return;
     }
-    // Defensive: a non-finite / non-positive interval must never reach setInterval.
-    if (!Number.isFinite(this.intervalMs) || this.intervalMs <= 0) {
+    // Bound the interval to an operationally-safe range [30s, 6h]. Too small floods RPC/gas; too
+    // large (or NaN/Infinity from bad env) can wrap Node's timer range to a near-immediate fire.
+    // Fail-CLOSED (disable) rather than fail-open on a misconfigured cadence.
+    if (
+      !Number.isFinite(this.intervalMs) ||
+      this.intervalMs < LivenessKeeperService.MIN_INTERVAL_MS ||
+      this.intervalMs > LivenessKeeperService.MAX_INTERVAL_MS
+    ) {
       this.logger.warn(
-        `invalid AUDIT_ATTEST_INTERVAL_MS (${this.intervalMs}) — attest keeper DISABLED`
+        `AUDIT_ATTEST_INTERVAL_MS (${this.intervalMs}) out of [${LivenessKeeperService.MIN_INTERVAL_MS}, ` +
+          `${LivenessKeeperService.MAX_INTERVAL_MS}] — attest keeper DISABLED`
       );
       return;
     }
@@ -88,6 +101,7 @@ export class LivenessKeeperService implements OnApplicationBootstrap, OnApplicat
   }
 
   onApplicationShutdown(): void {
+    this.stopping = true;
     if (this.timer !== null) {
       clearInterval(this.timer);
       this.timer = null;
@@ -96,6 +110,7 @@ export class LivenessKeeperService implements OnApplicationBootstrap, OnApplicat
 
   /** One attest cycle: read a fresh anchor, send attestLiveness. Never throws. */
   async tick(): Promise<void> {
+    if (this.stopping) return; // no new work during shutdown
     if (this.inFlight) {
       this.logger.debug("attest tick skipped — previous still in-flight");
       return;

--- a/src/modules/audit/liveness-keeper.service.ts
+++ b/src/modules/audit/liveness-keeper.service.ts
@@ -1,0 +1,132 @@
+import {
+  Injectable,
+  Logger,
+  Optional,
+  OnApplicationBootstrap,
+  OnApplicationShutdown,
+} from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { BlockchainService } from "../blockchain/blockchain.service.js";
+import { OpsAlertService } from "../ops-alert/ops-alert.service.js";
+
+/**
+ * Liveness attest keeper (inc-2 C1 — SP LivenessRegistry, CC-29).
+ *
+ * Each DVT node IS a registered operator. SP's LivenessRegistry AUTO-JAILS an operator that is
+ * `never-attested` or whose `lastLive` is older than `livenessWindow` (objective on-chain fact:
+ * `block.number > lastLive + window`). A jailed operator is excluded from the active set + its fee
+ * is stopped. So a node MUST periodically prove its own liveness on-chain, or the whole fleet's
+ * auto-jail is meaningless — this keeper is that prover.
+ *
+ * It calls `LivenessRegistry.attestLiveness(anchorBlock, anchorHash)` from the OPERATOR EOA
+ * (ETH_PRIVATE_KEY — the registry attests msg.sender). anchorBlock/anchorHash bind the attest to a
+ * recent unpredictable blockhash (SP's M-01 fix: a pre-signed stale attest can't cover the future).
+ *
+ * Opt-in (AUDIT_ATTEST_ENABLED, default off). Attests once on boot (re-establish liveness fast
+ * after a restart — a node may have been jailed while down) then every `intervalMs`. Fire-and-
+ * forget per tick: a failure is logged/alerted and retried next tick (which re-anchors); a
+ * persistently-failing node SHOULD be jailed (it genuinely can't prove liveness). This is why the
+ * keeper never crashes the process on an attest failure.
+ *
+ * NOTE: `intervalMs` is wall-clock; set it to roughly `livenessWindow/3` worth of time for the
+ * target chain (window is in BLOCKS — the keeper logs the on-chain window at boot so the operator
+ * can sanity-check the cadence). Attesting every window/3 leaves 2 missed ticks of slack before an
+ * operator would trip the offline threshold, absorbing RPC/gas jitter.
+ */
+@Injectable()
+export class LivenessKeeperService implements OnApplicationBootstrap, OnApplicationShutdown {
+  private readonly logger = new Logger(LivenessKeeperService.name);
+  private readonly enabled: boolean;
+  private readonly registryAddress: string;
+  private readonly intervalMs: number;
+  private readonly anchorDepth: number;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  /** Guards against overlapping ticks if one attest runs longer than the interval. */
+  private inFlight = false;
+
+  constructor(
+    private readonly blockchain: BlockchainService,
+    @Optional() private readonly config?: ConfigService,
+    @Optional() private readonly opsAlert?: OpsAlertService
+  ) {
+    this.enabled = this.config?.get<boolean>("auditAttestEnabled") === true;
+    this.registryAddress = this.config?.get<string>("auditLivenessRegistryAddress") ?? "";
+    this.intervalMs = this.config?.get<number>("auditAttestIntervalMs") ?? 600_000;
+    this.anchorDepth = this.config?.get<number>("auditAttestAnchorDepth") ?? 16;
+  }
+
+  onApplicationBootstrap(): void {
+    if (!this.enabled) return;
+    if (!/^0x[0-9a-fA-F]{40}$/.test(this.registryAddress)) {
+      this.logger.warn(
+        "AUDIT_ATTEST_ENABLED but AUDIT_LIVENESS_REGISTRY_ADDRESS is missing/invalid — attest keeper DISABLED"
+      );
+      return;
+    }
+    if (!this.blockchain.getWalletAddress()) {
+      this.logger.warn(
+        "AUDIT_ATTEST_ENABLED but no operator wallet (ETH_PRIVATE_KEY) — attest keeper DISABLED"
+      );
+      return;
+    }
+    // Defensive: a non-finite / non-positive interval must never reach setInterval.
+    if (!Number.isFinite(this.intervalMs) || this.intervalMs <= 0) {
+      this.logger.warn(
+        `invalid AUDIT_ATTEST_INTERVAL_MS (${this.intervalMs}) — attest keeper DISABLED`
+      );
+      return;
+    }
+
+    this.logger.log(
+      `Liveness attest keeper ENABLED — registry ${this.registryAddress}, ` +
+        `every ${this.intervalMs}ms, anchor depth ${this.anchorDepth}`
+    );
+    // Boot-attest immediately, then on the interval. void — never block bootstrap on chain I/O.
+    void this.tick();
+    this.timer = setInterval(() => void this.tick(), this.intervalMs);
+    void this.logWindow();
+  }
+
+  onApplicationShutdown(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** One attest cycle: read a fresh anchor, send attestLiveness. Never throws. */
+  async tick(): Promise<void> {
+    if (this.inFlight) {
+      this.logger.debug("attest tick skipped — previous still in-flight");
+      return;
+    }
+    this.inFlight = true;
+    try {
+      const anchor = await this.blockchain.getAttestAnchor(this.anchorDepth);
+      const txHash = await this.blockchain.attestLiveness(
+        this.registryAddress,
+        anchor.number,
+        anchor.hash
+      );
+      this.logger.log(`liveness attested @ anchor ${anchor.number}: ${txHash}`);
+    } catch (e: any) {
+      const msg = e?.shortMessage ?? e?.message ?? String(e);
+      this.logger.warn(`attest failed (will retry next tick): ${msg}`);
+      this.opsAlert?.alert("warn", `⚠️ DVT liveness attest failed: ${msg}`);
+    } finally {
+      this.inFlight = false;
+    }
+  }
+
+  /** Log the on-chain livenessWindow at boot so the operator can sanity-check the interval. */
+  private async logWindow(): Promise<void> {
+    try {
+      const window = await this.blockchain.getLivenessWindow(this.registryAddress);
+      this.logger.log(
+        `on-chain livenessWindow = ${window} blocks — set AUDIT_ATTEST_INTERVAL_MS to ~window/3 worth of wall-clock`
+      );
+    } catch {
+      // best-effort — a read failure here must not affect attesting
+    }
+  }
+}

--- a/src/modules/blockchain/blockchain-liveness.spec.ts
+++ b/src/modules/blockchain/blockchain-liveness.spec.ts
@@ -1,0 +1,145 @@
+import { jest } from "@jest/globals";
+import { BlockchainService } from "./blockchain.service.js";
+
+const REGISTRY = "0x1111111111111111111111111111111111111111";
+const OP = "0x2222222222222222222222222222222222222222";
+const ANCHOR_HASH = "0x" + "ab".repeat(32);
+
+function svcWithWallet(): BlockchainService {
+  const config = { get: (_k: string) => undefined } as any;
+  const svc = new BlockchainService(config);
+  (svc as any).wallet = { address: OP };
+  return svc;
+}
+
+/** Fee-data stub so bumpedFees() resolves without a real provider. */
+const feeData = { maxFeePerGas: 100n, maxPriorityFeePerGas: 2n };
+
+/** A tx whose wait(confirms, timeout) resolves/rejects as configured. */
+function tx(hash: string, wait: () => Promise<any>) {
+  return { hash, wait };
+}
+
+/** Install an attestLiveness contract: `staticCall` + a queue of per-attempt send behaviours. */
+function installAttest(
+  svc: BlockchainService,
+  staticCall: () => Promise<any>,
+  sends: Array<() => Promise<any>>
+) {
+  let i = 0;
+  const attestLiveness: any = () => sends[Math.min(i++, sends.length - 1)]();
+  attestLiveness.staticCall = staticCall;
+  (svc as any).buildContract = () => ({ attestLiveness });
+}
+
+describe("BlockchainService.attestLiveness", () => {
+  it("preflight revert (stale/bad anchor) throws BEFORE consuming a nonce", async () => {
+    const svc = svcWithWallet();
+    const getTransactionCount = jest.fn(async () => 5);
+    (svc as any).provider = { getFeeData: async () => feeData, getTransactionCount };
+    installAttest(svc, async () => {
+      throw new Error("StaleAnchor");
+    }, [async () => tx("0xnope", async () => ({ status: 1 }))]);
+    await expect(svc.attestLiveness(REGISTRY, 984, ANCHOR_HASH)).rejects.toThrow(
+      /preflight reverted/
+    );
+    expect(getTransactionCount).not.toHaveBeenCalled();
+  });
+
+  it("happy path: preflight ok, tx confirms status 1 → returns the tx hash", async () => {
+    const svc = svcWithWallet();
+    (svc as any).provider = { getFeeData: async () => feeData, getTransactionCount: async () => 5 };
+    installAttest(svc, async () => undefined, [
+      async () => tx("0xgood", async () => ({ status: 1 })),
+    ]);
+    await expect(svc.attestLiveness(REGISTRY, 984, ANCHOR_HASH)).resolves.toBe("0xgood");
+  });
+
+  it("mined-but-reverted receipt → throws not-confirmed (re-anchor next tick)", async () => {
+    const svc = svcWithWallet();
+    (svc as any).provider = {
+      getFeeData: async () => feeData,
+      getTransactionCount: async () => 5,
+      getTransactionReceipt: async () => ({ status: 0 }),
+    };
+    installAttest(svc, async () => undefined, [
+      async () => tx("0xrev", async () => ({ status: 0 })),
+    ]);
+    await expect(svc.attestLiveness(REGISTRY, 984, ANCHOR_HASH)).rejects.toThrow(/not confirmed/);
+  });
+
+  it("nonce dead-heat (slash grabbed it): refetches a fresh nonce and retries", async () => {
+    const svc = svcWithWallet();
+    const getTransactionCount = jest
+      .fn<() => Promise<number>>()
+      .mockResolvedValueOnce(5) // initial
+      .mockResolvedValueOnce(6); // refetch after nonce-too-low
+    (svc as any).provider = { getFeeData: async () => feeData, getTransactionCount };
+    installAttest(svc, async () => undefined, [
+      async () => {
+        throw new Error("nonce too low");
+      },
+      async () => tx("0xafteryield", async () => ({ status: 1 })),
+    ]);
+    await expect(svc.attestLiveness(REGISTRY, 984, ANCHOR_HASH)).resolves.toBe("0xafteryield");
+    expect(getTransactionCount).toHaveBeenCalledTimes(2); // refetched → yielded to the slash
+  });
+
+  it("both attempts time out but the FIRST later mined → reconciliation returns it", async () => {
+    const svc = svcWithWallet();
+    const receipts: Record<string, any> = { "0xt1": { status: 1 } };
+    (svc as any).provider = {
+      getFeeData: async () => feeData,
+      getTransactionCount: async () => 5,
+      getTransactionReceipt: async (h: string) => receipts[h] ?? null,
+    };
+    installAttest(svc, async () => undefined, [
+      async () =>
+        tx("0xt1", async () => {
+          throw new Error("timeout waiting for tx");
+        }),
+      async () =>
+        tx("0xt2", async () => {
+          throw new Error("timeout waiting for tx");
+        }),
+    ]);
+    await expect(svc.attestLiveness(REGISTRY, 984, ANCHOR_HASH)).resolves.toBe("0xt1");
+  });
+
+  it("throws without an operator wallet", async () => {
+    const config = { get: (_k: string) => undefined } as any;
+    const svc = new BlockchainService(config);
+    await expect(svc.attestLiveness(REGISTRY, 1, ANCHOR_HASH)).rejects.toThrow(
+      /no operator wallet/
+    );
+  });
+});
+
+describe("BlockchainService liveness reads", () => {
+  it("getAttestAnchor returns head−depth block {number,hash}, floored at depth 1", async () => {
+    const svc = svcWithWallet();
+    const getBlock = jest.fn(async (n: number) => ({ number: n, hash: "0xh" }));
+    (svc as any).provider = { getBlockNumber: async () => 1000, getBlock };
+    const a = await svc.getAttestAnchor(16);
+    expect(a).toEqual({ number: 984, hash: "0xh" });
+    expect(getBlock).toHaveBeenCalledWith(984);
+  });
+
+  it("getAreOffline short-circuits to [] for an empty operator list (no RPC)", async () => {
+    const svc = svcWithWallet();
+    const areOffline = jest.fn();
+    (svc as any).buildContract = () => ({ areOffline });
+    (svc as any).provider = {};
+    await expect(svc.getAreOffline(REGISTRY, [])).resolves.toEqual([]);
+    expect(areOffline).not.toHaveBeenCalled();
+  });
+
+  it("getIsOffline reads the registry view at the pinned blockTag", async () => {
+    const svc = svcWithWallet();
+    const isOffline = jest.fn(async (_op: string, _opts: any) => true);
+    (svc as any).provider = {};
+    (svc as any).buildContract = () => ({ isOffline });
+    await expect(svc.getIsOffline(REGISTRY, OP, 777)).resolves.toBe(true);
+    expect(isOffline).toHaveBeenCalledWith(OP, { blockTag: 777 });
+  });
+});

--- a/src/modules/blockchain/blockchain-liveness.spec.ts
+++ b/src/modules/blockchain/blockchain-liveness.spec.ts
@@ -256,17 +256,42 @@ describe("BlockchainService operator-wallet slash priority", () => {
     );
   });
 
-  it("enqueueSlashWrite bumps slashPending during the write and clears it after (even on throw)", async () => {
+  it("runWithSlashPriority bumps slashPending during the write and clears it after (even on throw)", async () => {
     const svc = svcWithWallet();
     let seenDuring = -1;
     await (svc as any)
-      .enqueueSlashWrite(async () => {
+      .runWithSlashPriority(async () => {
         seenDuring = (svc as any).slashPending;
         throw new Error("boom");
       })
       .catch(() => undefined);
     expect(seenDuring).toBe(1); // pending while running
     expect((svc as any).slashPending).toBe(0); // cleared in finally even though it threw
+  });
+
+  it("a slash-priority op does NOT hold the wallet FIFO during its WAIT (Codex r3 deadlock-free)", async () => {
+    const svc = svcWithWallet();
+    let concurrentRan = false;
+    let releaseWait!: () => void;
+    const waitGate = new Promise<void>(r => (releaseWait = r));
+    // Model a slash: broadcast under the lock (brief), then WAIT outside it (gated). If the wait
+    // held the FIFO, the concurrent write below would deadlock behind it.
+    const slash = (svc as any).runWithSlashPriority(async () => {
+      await (svc as any).enqueueWalletWrite(async () => "slash-broadcast");
+      await waitGate; // wait phase — must run OUTSIDE the FIFO
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    // A concurrent operator-wallet write (e.g. an attest fee-bump of a stuck nonce) must proceed
+    // WHILE the slash is waiting — this is exactly the replace-N path the r3 deadlock blocked.
+    await (svc as any).enqueueWalletWrite(async () => {
+      concurrentRan = true;
+    });
+    expect(concurrentRan).toBe(true); // FIFO was free during the slash's wait → no deadlock
+    expect((svc as any).slashPending).toBe(1); // priority signal stays up through the wait
+    releaseWait();
+    await slash;
+    expect((svc as any).slashPending).toBe(0);
   });
 });
 

--- a/src/modules/blockchain/blockchain-liveness.spec.ts
+++ b/src/modules/blockchain/blockchain-liveness.spec.ts
@@ -181,24 +181,79 @@ describe("BlockchainService.attestLiveness", () => {
 });
 
 describe("BlockchainService operator-wallet slash priority", () => {
-  it("BAILS mid-loop when a slash arrives while the attest is waiting (releases the lock for it)", async () => {
+  it("after broadcasting nonce N, does NOT abandon it when a slash arrives (drives N to inclusion)", async () => {
     const svc = svcWithWallet();
     (svc as any).provider = {
       getFeeData: async () => feeData,
       getTransactionCount: async () => 5,
       getTransactionReceipt: async () => null,
     };
-    // First send lands but the wait times out; DURING that wait a slash arrives (slashPending=1),
-    // so the next loop iteration must bail instead of burning the rest of the retry budget.
+    // A slash arrives DURING the first wait — but since N is already broadcast and the slash sits at
+    // N+1 depending on N, the attest must drive N to inclusion (replacement), NOT yield/abandon it.
+    let call = 0;
+    const attestLiveness: any = () => {
+      call++;
+      if (call === 1)
+        return tx("0xt", async () => {
+          (svc as any).slashPending = 1;
+          throw new Error("timeout waiting for tx");
+        });
+      return tx("0xt", async () => ({ status: 1 })); // replacement confirms → drove N
+    };
+    attestLiveness.staticCall = async () => undefined;
+    (svc as any).buildContract = () => ({ attestLiveness });
+    await expect(svc.attestLiveness(REGISTRY, 984, ANCHOR_HASH, { maxAttempts: 3 })).resolves.toBe(
+      "0xt"
+    );
+  });
+
+  it("runs the receipt WAIT outside the lock (a concurrent wallet write proceeds during the wait)", async () => {
+    const svc = svcWithWallet();
+    (svc as any).provider = { getFeeData: async () => feeData, getTransactionCount: async () => 5 };
+    let ran = false;
+    let release!: () => void;
+    const gate = new Promise<void>(r => (release = r));
     const attestLiveness: any = () =>
-      tx("0xt", async () => {
-        (svc as any).slashPending = 1;
-        throw new Error("timeout waiting for tx");
+      tx("0xa", async () => {
+        await gate;
+        return { status: 1 };
       });
     attestLiveness.staticCall = async () => undefined;
     (svc as any).buildContract = () => ({ attestLiveness });
-    // The final error embeds the bail reason ("yielded to a pending slash write").
-    await expect(svc.attestLiveness(REGISTRY, 984, ANCHOR_HASH)).rejects.toThrow(/yielded/);
+    const p = svc.attestLiveness(REGISTRY, 984, ANCHOR_HASH);
+    await Promise.resolve();
+    await Promise.resolve(); // let the attest broadcast (under lock) then enter its wait
+    // If the wait held the lock this would deadlock; it must run while the attest waits.
+    await (svc as any).enqueueWalletWrite(async () => {
+      ran = true;
+    });
+    expect(ran).toBe(true);
+    release();
+    await p;
+  });
+
+  it("a nonce refetch does NOT consume the send budget — resend guaranteed even at maxAttempts:1 (High #3)", async () => {
+    const svc = svcWithWallet();
+    const getTransactionCount = jest
+      .fn<() => Promise<number>>()
+      .mockResolvedValueOnce(5)
+      .mockResolvedValueOnce(6);
+    (svc as any).provider = {
+      getFeeData: async () => feeData,
+      getTransactionCount,
+      getTransactionReceipt: async () => null,
+    };
+    let call = 0;
+    const attestLiveness: any = () => {
+      call++;
+      if (call === 1) throw new Error("nonce too low");
+      return tx("0xresent", async () => ({ status: 1 }));
+    };
+    attestLiveness.staticCall = async () => undefined;
+    (svc as any).buildContract = () => ({ attestLiveness });
+    await expect(svc.attestLiveness(REGISTRY, 984, ANCHOR_HASH, { maxAttempts: 1 })).resolves.toBe(
+      "0xresent"
+    );
   });
 
   it("enqueueSlashWrite bumps slashPending during the write and clears it after (even on throw)", async () => {

--- a/src/modules/blockchain/blockchain-liveness.spec.ts
+++ b/src/modules/blockchain/blockchain-liveness.spec.ts
@@ -113,6 +113,106 @@ describe("BlockchainService.attestLiveness", () => {
       /no operator wallet/
     );
   });
+
+  it("YIELDS immediately (before taking a nonce) when a slash write is pending", async () => {
+    const svc = svcWithWallet();
+    const getTransactionCount = jest.fn(async () => 5);
+    const staticCall = jest.fn(async () => undefined);
+    (svc as any).provider = { getFeeData: async () => feeData, getTransactionCount };
+    const attestLiveness: any = () => tx("0xnever", async () => ({ status: 1 }));
+    attestLiveness.staticCall = staticCall;
+    (svc as any).buildContract = () => ({ attestLiveness });
+    (svc as any).slashPending = 1; // a slash is queued/running → attest must yield
+    await expect(svc.attestLiveness(REGISTRY, 984, ANCHOR_HASH)).rejects.toThrow(/yielded/);
+    expect(staticCall).not.toHaveBeenCalled(); // bailed before preflight + before any nonce read
+    expect(getTransactionCount).not.toHaveBeenCalled();
+  });
+
+  it("replacement on timeout uses STRICTLY-increasing fees on both fields", async () => {
+    const svc = svcWithWallet();
+    // Rising base fee would still be undercut without the +12.5% prev-fee floor; keep it flat so the
+    // strict-increase must come from the replacement logic, not the fresh estimate.
+    (svc as any).provider = {
+      getFeeData: async () => ({ maxFeePerGas: 100n, maxPriorityFeePerGas: 10n }),
+      getTransactionCount: async () => 5,
+      getTransactionReceipt: async () => null,
+    };
+    const feeArgs: Array<{ maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }> = [];
+    const attestLiveness: any = (_a: number, _h: string, opts: any) => {
+      feeArgs.push({
+        maxFeePerGas: opts.maxFeePerGas,
+        maxPriorityFeePerGas: opts.maxPriorityFeePerGas,
+      });
+      return tx("0x" + feeArgs.length, async () => {
+        throw new Error("timeout waiting for tx");
+      });
+    };
+    attestLiveness.staticCall = async () => undefined;
+    (svc as any).buildContract = () => ({ attestLiveness });
+    await expect(svc.attestLiveness(REGISTRY, 984, ANCHOR_HASH)).rejects.toThrow(/not confirmed/);
+    expect(feeArgs.length).toBeGreaterThanOrEqual(2);
+    for (let i = 1; i < feeArgs.length; i++) {
+      expect(feeArgs[i].maxFeePerGas > feeArgs[i - 1].maxFeePerGas).toBe(true);
+      expect(feeArgs[i].maxPriorityFeePerGas > feeArgs[i - 1].maxPriorityFeePerGas).toBe(true);
+    }
+  });
+
+  it("REPLACEMENT_UNDERPRICED on send → retries (does not abort the loop)", async () => {
+    const svc = svcWithWallet();
+    (svc as any).provider = {
+      getFeeData: async () => feeData,
+      getTransactionCount: async () => 5,
+      getTransactionReceipt: async () => null,
+    };
+    let call = 0;
+    const attestLiveness: any = () => {
+      call++;
+      if (call === 1) {
+        const e: any = new Error("replacement transaction underpriced");
+        e.code = "REPLACEMENT_UNDERPRICED";
+        throw e;
+      }
+      return tx("0xafterbump", async () => ({ status: 1 }));
+    };
+    attestLiveness.staticCall = async () => undefined;
+    (svc as any).buildContract = () => ({ attestLiveness });
+    await expect(svc.attestLiveness(REGISTRY, 984, ANCHOR_HASH)).resolves.toBe("0xafterbump");
+  });
+});
+
+describe("BlockchainService operator-wallet slash priority", () => {
+  it("BAILS mid-loop when a slash arrives while the attest is waiting (releases the lock for it)", async () => {
+    const svc = svcWithWallet();
+    (svc as any).provider = {
+      getFeeData: async () => feeData,
+      getTransactionCount: async () => 5,
+      getTransactionReceipt: async () => null,
+    };
+    // First send lands but the wait times out; DURING that wait a slash arrives (slashPending=1),
+    // so the next loop iteration must bail instead of burning the rest of the retry budget.
+    const attestLiveness: any = () =>
+      tx("0xt", async () => {
+        (svc as any).slashPending = 1;
+        throw new Error("timeout waiting for tx");
+      });
+    attestLiveness.staticCall = async () => undefined;
+    (svc as any).buildContract = () => ({ attestLiveness });
+    // The final error embeds the bail reason ("yielded to a pending slash write").
+    await expect(svc.attestLiveness(REGISTRY, 984, ANCHOR_HASH)).rejects.toThrow(/yielded/);
+  });
+
+  it("enqueueSlashWrite bumps slashPending during the write and clears it after (even on throw)", async () => {
+    const svc = svcWithWallet();
+    let seenDuring = -1;
+    await (svc as any)
+      .enqueueSlashWrite(async () => {
+        seenDuring = (svc as any).slashPending;
+        throw new Error("boom");
+      })
+      .catch(() => undefined);
+    expect(seenDuring).toBe(1); // pending while running
+    expect((svc as any).slashPending).toBe(0); // cleared in finally even though it threw
+  });
 });
 
 describe("BlockchainService liveness reads", () => {

--- a/src/modules/blockchain/blockchain-liveness.spec.ts
+++ b/src/modules/blockchain/blockchain-liveness.spec.ts
@@ -293,6 +293,37 @@ describe("BlockchainService operator-wallet slash priority", () => {
     await slash;
     expect((svc as any).slashPending).toBe(0);
   });
+
+  it("runWithSlashPriority clears slashPending even when fn throws SYNCHRONOUSLY (Codex r4 Low)", async () => {
+    const svc = svcWithWallet();
+    await (svc as any)
+      .runWithSlashPriority(() => {
+        throw new Error("sync boom"); // NOT async → returns no promise; must still decrement
+      })
+      .catch(() => undefined);
+    expect((svc as any).slashPending).toBe(0);
+  });
+
+  it("attest rechecks slash-priority AFTER the nonce/fee awaits — a slash arriving mid-broadcast wins", async () => {
+    const svc = svcWithWallet();
+    let sent = false;
+    const attestLiveness: any = () => {
+      sent = true;
+      return tx("0xshouldnotsend", async () => ({ status: 1 }));
+    };
+    attestLiveness.staticCall = async () => undefined;
+    (svc as any).provider = {
+      getFeeData: async () => feeData,
+      // A slash arrives DURING the nonce read (after the top-of-broadcast check passed).
+      getTransactionCount: async () => {
+        (svc as any).slashPending = 1;
+        return 5;
+      },
+    };
+    (svc as any).buildContract = () => ({ attestLiveness });
+    await expect(svc.attestLiveness(REGISTRY, 984, ANCHOR_HASH)).rejects.toThrow(/yielded/);
+    expect(sent).toBe(false); // yielded before the actual send → slash keeps the lower nonce
+  });
 });
 
 describe("BlockchainService liveness reads", () => {

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -60,8 +60,30 @@ export class BlockchainService {
    *  to `wallet` (ETH_PRIVATE_KEY) only when KEEPER_PRIVATE_KEY is unset. */
   private keeperWallet?: ethers.Wallet;
 
+  /**
+   * FIFO serialization for the liveness ATTEST keeper (inc-2), which fires on a timer and shares
+   * the operator EOA with the slash writes. Design choice: slash writes are the PRIORITY and stay
+   * UNWRAPPED (they proceed immediately, never wait) — the attest instead YIELDS. This lock only
+   * serializes concurrent attests (one in-flight at a time); the attest's retry loop additionally
+   * detects a nonce grabbed by a slash and refetches, so a slash never fails because of an attest.
+   * An attest is idempotent + retriable, so losing a rare dead-heat costs only a retry/next tick.
+   */
+  private walletLock: Promise<unknown> = Promise.resolve();
+
   constructor(private configService: ConfigService) {
     this.initializeProvider();
+  }
+
+  /** Run `fn` with at most one attest in-flight (see `walletLock`). */
+  protected async runWithWallet<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.walletLock.then(fn, fn);
+    // Keep the chain alive regardless of fn's outcome; swallow here so one failure
+    // doesn't reject every future waiter (each caller still gets its own result/throw).
+    this.walletLock = run.then(
+      () => undefined,
+      () => undefined
+    );
+    return run;
   }
 
   private initializeProvider(): void {
@@ -526,6 +548,185 @@ export class BlockchainService {
       );
     }
     return { number: b.number, hash: b.hash };
+  }
+
+  // ── SP LivenessRegistry (CC-29) reads — objective on-chain liveness. inc-2 uses these for
+  //    OBSERVABILITY (alerting/forensics) + a soft co-sign request-set optimization, NOT for
+  //    threshold math (BLSAggregator owns the fixed on-chain threshold; see INC2_DESIGN.md). All
+  //    reads are `blockTag`-capable so a co-signer can reproduce the live-set at a slash epoch.
+  //    Stable read ABI locked by SP PR #346 (Codex-APPROVED).
+
+  private static readonly LIVENESS_READ_ABI = [
+    "function isOffline(address op) view returns (bool)",
+    "function areOffline(address[] ops) view returns (bool[])",
+    "function lastLive(address op) view returns (uint256)",
+    "function livenessWindow() view returns (uint256)",
+  ];
+
+  /** LivenessRegistry.livenessWindow() — fleet-global governance value (blocks). */
+  async getLivenessWindow(registryAddress: string, blockTag?: number): Promise<bigint> {
+    if (!this.provider) throw new Error("Blockchain provider not configured");
+    const c = this.buildContract(
+      registryAddress,
+      BlockchainService.LIVENESS_READ_ABI,
+      this.provider
+    );
+    return BigInt(await c.livenessWindow({ blockTag }));
+  }
+
+  /** LivenessRegistry.lastLive(op) — last block the operator attested (0 = never). Forensics/audit. */
+  async getLastLive(registryAddress: string, op: string, blockTag?: number): Promise<bigint> {
+    if (!this.provider) throw new Error("Blockchain provider not configured");
+    const c = this.buildContract(
+      registryAddress,
+      BlockchainService.LIVENESS_READ_ABI,
+      this.provider
+    );
+    return BigInt(await c.lastLive(op, { blockTag }));
+  }
+
+  /** LivenessRegistry.isOffline(op) — objective `block.number > lastLive + window`; never-attested ⇒ true. */
+  async getIsOffline(registryAddress: string, op: string, blockTag?: number): Promise<boolean> {
+    if (!this.provider) throw new Error("Blockchain provider not configured");
+    const c = this.buildContract(
+      registryAddress,
+      BlockchainService.LIVENESS_READ_ABI,
+      this.provider
+    );
+    return await c.isOffline(op, { blockTag });
+  }
+
+  /** LivenessRegistry.areOffline(ops) — batch; build the epoch live-set in one call (pin blockTag=epoch). */
+  async getAreOffline(
+    registryAddress: string,
+    ops: string[],
+    blockTag?: number
+  ): Promise<boolean[]> {
+    if (!this.provider) throw new Error("Blockchain provider not configured");
+    if (ops.length === 0) return [];
+    const c = this.buildContract(
+      registryAddress,
+      BlockchainService.LIVENESS_READ_ABI,
+      this.provider
+    );
+    const res: boolean[] = await c.areOffline(ops, { blockTag });
+    return res.map(Boolean);
+  }
+
+  /**
+   * A recent anchor block `{ number, hash }` for `attestLiveness`, at `head − depth`. SP's M-01
+   * fix requires anchorBlock ∈ [head−256, head−1] AND anchorHash == blockhash(anchorBlock). Pick
+   * `depth` well ABOVE typical reorg depth (so the hash is stable → no BadAnchorHash) yet well
+   * BELOW 256 (so the tx has ample inclusion margin before StaleAnchor). Depth is floored at 1.
+   */
+  async getAttestAnchor(depth: number): Promise<{ number: number; hash: string }> {
+    if (!this.provider) throw new Error("Blockchain provider not configured");
+    const latest = await this.provider.getBlockNumber();
+    const target = Math.max(0, latest - Math.max(1, Math.floor(depth)));
+    const b = await this.provider.getBlock(target);
+    if (!b || typeof b.number !== "number" || !b.hash) {
+      throw new Error(
+        `getAttestAnchor: could not resolve anchor block (latest ${latest}, target ${target})`
+      );
+    }
+    return { number: b.number, hash: b.hash };
+  }
+
+  /**
+   * LivenessRegistry.attestLiveness(anchorBlock, anchorHash) — the operator (this node) self-proves
+   * liveness on-chain so SP's auto-jail excludes it only when it is genuinely silent (inc-2 C1).
+   *
+   * msg.sender MUST be the registered operator EOA (`this.wallet`) — NOT the keeper key — because
+   * the registry attests the SENDER. Runs under `runWithWallet` (one attest in-flight) and YIELDS
+   * to slash writes on a nonce dead-heat (refetch + retry), so a slash — the priority — never fails
+   * because of an attest. Hardening (Codex inc-2 review): staticCall preflight (fail fast on a
+   * stale/bad anchor without burning a nonce), a bounded deadline loop with same-nonce fee-bumped
+   * REPLACEMENT (a fresh-nonce resend cannot clear a stuck lower nonce — and a tx stuck > 256
+   * blocks would freeze `lastLive` into a false-offline), and a final receipt reconciliation across
+   * every hash we broadcast (the original may mine while we wait on a replacement).
+   */
+  async attestLiveness(
+    registryAddress: string,
+    anchorBlock: number,
+    anchorHash: string,
+    opts: { perAttemptMs?: number; maxAttempts?: number } = {}
+  ): Promise<string> {
+    if (!this.wallet) {
+      throw new Error("attestLiveness: no operator wallet (ETH_PRIVATE_KEY unset)");
+    }
+    // Tight deadline on purpose: attest shares the operator-EOA FIFO lock with slash writes, so a
+    // slash waits at most one attest cycle. ≤ ~40s worst case (2 × 20s) bounds that wait. True
+    // slash-PREEMPTION of an in-flight attest is deferred (bootstrap N=3: slashes are rare +
+    // manual-review-gated, and the audit pipeline re-tries the slash on its next tick).
+    const perAttemptMs = opts.perAttemptMs ?? 20_000;
+    const maxAttempts = Math.max(1, opts.maxAttempts ?? 2);
+    return this.runWithWallet(async () => {
+      const op = this.wallet.address;
+      const abi = ["function attestLiveness(uint256 anchorBlock, bytes32 anchorHash) external"];
+      const contract = this.buildContract(registryAddress, abi, this.wallet);
+
+      // Preflight: a stale/bad anchor reverts (StaleAnchor/BadAnchorHash). Fail here BEFORE
+      // consuming a nonce so the keeper re-anchors on the next tick instead of burning gas.
+      try {
+        await contract.attestLiveness.staticCall(anchorBlock, anchorHash);
+      } catch (e: any) {
+        throw new Error(
+          `attestLiveness preflight reverted (stale/bad anchor?): ${e?.shortMessage ?? e?.message ?? e}`,
+          { cause: e }
+        );
+      }
+
+      // Pin a nonce so a resend is a same-nonce REPLACEMENT (not a new tx). If a slash grabs this
+      // nonce (dead-heat), the send throws a nonce-too-low error → we REFETCH a fresh nonce and
+      // retry (yielding priority to the slash). A stuck/underpriced tx instead keeps the nonce and
+      // escalates fees so the replacement displaces it before the anchor goes stale.
+      let nonce = await this.provider.getTransactionCount(op, "pending");
+      const sent: string[] = [];
+      let bumpPct = 20;
+      let lastErr: any;
+      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        try {
+          const fees = await bumpedFees(this.provider, bumpPct);
+          const tx: ethers.TransactionResponse = await contract.attestLiveness(
+            anchorBlock,
+            anchorHash,
+            {
+              nonce,
+              ...fees,
+            }
+          );
+          sent.push(tx.hash);
+          const receipt = await tx.wait(1, perAttemptMs);
+          if (receipt?.status === 1) return tx.hash;
+          // Mined but reverted → nonce consumed; a same-nonce replacement can't help. Re-anchor next tick.
+          throw new Error(`attest tx ${tx.hash} reverted (status ${receipt?.status ?? "unknown"})`);
+        } catch (e: any) {
+          lastErr = e;
+          const msg = String(e?.shortMessage ?? e?.message ?? e);
+          // A reverted receipt is terminal for this anchor — stop and reconcile.
+          if (msg.includes("reverted")) break;
+          // A slash took our nonce (dead-heat) → yield: refetch the fresh pending nonce and retry.
+          if (/nonce too low|nonce has already been used|NONCE_EXPIRED/i.test(msg)) {
+            nonce = await this.provider.getTransactionCount(op, "pending");
+            continue;
+          }
+          // Timeout / underpriced replacement → keep the same nonce, escalate fees, resend.
+          bumpPct += 30;
+        }
+      }
+      // Reconcile: the original may have mined while we waited on a replacement (or vice versa).
+      for (const h of sent) {
+        try {
+          const r = await this.provider.getTransactionReceipt(h);
+          if (r?.status === 1) return h;
+        } catch {
+          // ignore — best-effort reconciliation
+        }
+      }
+      throw new Error(
+        `attestLiveness not confirmed after ${maxAttempts} attempt(s): ${lastErr?.message ?? lastErr}`
+      );
+    });
   }
 
   /**

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -61,29 +61,48 @@ export class BlockchainService {
   private keeperWallet?: ethers.Wallet;
 
   /**
-   * FIFO serialization for the liveness ATTEST keeper (inc-2), which fires on a timer and shares
-   * the operator EOA with the slash writes. Design choice: slash writes are the PRIORITY and stay
-   * UNWRAPPED (they proceed immediately, never wait) — the attest instead YIELDS. This lock only
-   * serializes concurrent attests (one in-flight at a time); the attest's retry loop additionally
-   * detects a nonce grabbed by a slash and refetches, so a slash never fails because of an attest.
-   * An attest is idempotent + retriable, so losing a rare dead-heat costs only a retry/next tick.
+   * Single FIFO serialization for ALL operator-EOA (`this.wallet`) writes — the liveness attest
+   * keeper (inc-2, fires on a timer) AND every slash/proposal write share the same EOA, so without
+   * one lock two of them can read the same pending nonce and collide (a time-sensitive slash could
+   * fail as an underpriced same-nonce replacement, or an attest could displace a pending slash).
+   * Every write goes through `enqueueWalletWrite`, so exactly one holds the nonce at a time.
+   *
+   * Slash PRIORITY: `slashPending` counts slash writes that are queued-or-running. A slash bumps it
+   * synchronously BEFORE it waits for the lock, so a currently-running attest sees it (`hasPendingSlashWrite`)
+   * and BAILS between send attempts — releasing the lock so the slash runs next instead of waiting out
+   * the attest's retry budget. An attest is idempotent + retriable (re-anchors next tick), so yielding
+   * costs nothing; a slash never waits more than one in-flight attest SEND (seconds), never a full loop.
    */
-  private walletLock: Promise<unknown> = Promise.resolve();
+  private walletChain: Promise<unknown> = Promise.resolve();
+  private slashPending = 0;
 
   constructor(private configService: ConfigService) {
     this.initializeProvider();
   }
 
-  /** Run `fn` with at most one attest in-flight (see `walletLock`). */
-  protected async runWithWallet<T>(fn: () => Promise<T>): Promise<T> {
-    const run = this.walletLock.then(fn, fn);
+  /** True while any slash write is queued or running — the attest polls this to yield priority. */
+  protected hasPendingSlashWrite(): boolean {
+    return this.slashPending > 0;
+  }
+
+  /** Enqueue an operator-wallet write on the single FIFO chain (serializes nonce use). */
+  protected enqueueWalletWrite<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.walletChain.then(fn, fn);
     // Keep the chain alive regardless of fn's outcome; swallow here so one failure
     // doesn't reject every future waiter (each caller still gets its own result/throw).
-    this.walletLock = run.then(
+    this.walletChain = run.then(
       () => undefined,
       () => undefined
     );
     return run;
+  }
+
+  /** Enqueue a PRIORITY slash write: bump `slashPending` synchronously (so a running attest yields). */
+  protected enqueueSlashWrite<T>(fn: () => Promise<T>): Promise<T> {
+    this.slashPending++;
+    return this.enqueueWalletWrite(fn).finally(() => {
+      this.slashPending--;
+    });
   }
 
   private initializeProvider(): void {
@@ -621,8 +640,11 @@ export class BlockchainService {
    */
   async getAttestAnchor(depth: number): Promise<{ number: number; hash: string }> {
     if (!this.provider) throw new Error("Blockchain provider not configured");
+    // Coerce to a protocol-valid depth: a finite integer in [1, 255]. An out-of-range/NaN depth
+    // would otherwise select genesis, a stale block, or `getBlock(NaN)` (permanent tick failure).
+    const safeDepth = Number.isFinite(depth) ? Math.min(255, Math.max(1, Math.floor(depth))) : 16;
     const latest = await this.provider.getBlockNumber();
-    const target = Math.max(0, latest - Math.max(1, Math.floor(depth)));
+    const target = Math.max(0, latest - safeDepth);
     const b = await this.provider.getBlock(target);
     if (!b || typeof b.number !== "number" || !b.hash) {
       throw new Error(
@@ -633,17 +655,38 @@ export class BlockchainService {
   }
 
   /**
+   * Next fee bundle for an attest (re)send. For a same-nonce REPLACEMENT (`prev` set) it must
+   * STRICTLY exceed the previous tx on BOTH fields (geth requires ≥10%; we use +12.5%), else the
+   * node rejects it as `REPLACEMENT_UNDERPRICED` and the stuck tx never clears. It also floors at
+   * the fresh network estimate, so a rising base fee is followed rather than undercut.
+   */
+  private async nextAttestFees(
+    prev: { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint } | null
+  ): Promise<{ maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }> {
+    const fresh = await bumpedFees(this.provider);
+    if (!prev) return fresh;
+    const bump = (x: bigint): bigint => (x * 1125n) / 1000n; // +12.5% > geth's 10% replacement floor
+    const max = (a: bigint, b: bigint): bigint => (a > b ? a : b);
+    return {
+      maxFeePerGas: max(fresh.maxFeePerGas, bump(prev.maxFeePerGas)),
+      maxPriorityFeePerGas: max(fresh.maxPriorityFeePerGas, bump(prev.maxPriorityFeePerGas)),
+    };
+  }
+
+  /**
    * LivenessRegistry.attestLiveness(anchorBlock, anchorHash) — the operator (this node) self-proves
    * liveness on-chain so SP's auto-jail excludes it only when it is genuinely silent (inc-2 C1).
    *
    * msg.sender MUST be the registered operator EOA (`this.wallet`) — NOT the keeper key — because
-   * the registry attests the SENDER. Runs under `runWithWallet` (one attest in-flight) and YIELDS
-   * to slash writes on a nonce dead-heat (refetch + retry), so a slash — the priority — never fails
-   * because of an attest. Hardening (Codex inc-2 review): staticCall preflight (fail fast on a
-   * stale/bad anchor without burning a nonce), a bounded deadline loop with same-nonce fee-bumped
-   * REPLACEMENT (a fresh-nonce resend cannot clear a stuck lower nonce — and a tx stuck > 256
-   * blocks would freeze `lastLive` into a false-offline), and a final receipt reconciliation across
-   * every hash we broadcast (the original may mine while we wait on a replacement).
+   * the registry attests the SENDER. Runs on the single operator-wallet FIFO (`enqueueWalletWrite`)
+   * shared with the slash writes, so no attest/slash nonce race is possible; and it YIELDS to a
+   * pending slash (bails between attempts — `hasPendingSlashWrite`) so a slash never waits out the
+   * attest's retry budget. Hardening (Codex inc-2 review): staticCall preflight (fail before burning
+   * a nonce on a stale/bad anchor); a bounded deadline loop with same-nonce STRICTLY-increasing fee
+   * REPLACEMENT (`nextAttestFees` — a tx stuck > 256 blocks would freeze `lastLive` into a false-
+   * offline); a nonce-consumed error triggers a reconcile-then-refetch (our own tx may have mined →
+   * don't double-attest; otherwise a slash took the nonce → refetch + retry, guaranteeing a resend);
+   * and a final receipt reconciliation across every broadcast hash.
    */
   async attestLiveness(
     registryAddress: string,
@@ -654,17 +697,30 @@ export class BlockchainService {
     if (!this.wallet) {
       throw new Error("attestLiveness: no operator wallet (ETH_PRIVATE_KEY unset)");
     }
-    // Tight deadline on purpose: attest shares the operator-EOA FIFO lock with slash writes, so a
-    // slash waits at most one attest cycle. ≤ ~40s worst case (2 × 20s) bounds that wait. True
-    // slash-PREEMPTION of an in-flight attest is deferred (bootstrap N=3: slashes are rare +
-    // manual-review-gated, and the audit pipeline re-tries the slash on its next tick).
     const perAttemptMs = opts.perAttemptMs ?? 20_000;
-    const maxAttempts = Math.max(1, opts.maxAttempts ?? 2);
-    return this.runWithWallet(async () => {
+    const maxAttempts = Math.max(1, opts.maxAttempts ?? 3);
+    return this.enqueueWalletWrite(async () => {
       const op = this.wallet.address;
       const abi = ["function attestLiveness(uint256 anchorBlock, bytes32 anchorHash) external"];
       const contract = this.buildContract(registryAddress, abi, this.wallet);
+      const sent: string[] = [];
+      // Best-effort: return the first broadcast hash that already confirmed status 1.
+      const reconcile = async (): Promise<string | null> => {
+        for (const h of sent) {
+          try {
+            const r = await this.provider.getTransactionReceipt(h);
+            if (r?.status === 1) return h;
+          } catch {
+            // ignore — best-effort
+          }
+        }
+        return null;
+      };
 
+      // Yield to a waiting slash BEFORE taking a nonce (slash is the priority).
+      if (this.hasPendingSlashWrite()) {
+        throw new Error("attestLiveness yielded to a pending slash write");
+      }
       // Preflight: a stale/bad anchor reverts (StaleAnchor/BadAnchorHash). Fail here BEFORE
       // consuming a nonce so the keeper re-anchors on the next tick instead of burning gas.
       try {
@@ -676,53 +732,59 @@ export class BlockchainService {
         );
       }
 
-      // Pin a nonce so a resend is a same-nonce REPLACEMENT (not a new tx). If a slash grabs this
-      // nonce (dead-heat), the send throws a nonce-too-low error → we REFETCH a fresh nonce and
-      // retry (yielding priority to the slash). A stuck/underpriced tx instead keeps the nonce and
-      // escalates fees so the replacement displaces it before the anchor goes stale.
       let nonce = await this.provider.getTransactionCount(op, "pending");
-      const sent: string[] = [];
-      let bumpPct = 20;
+      let prevFees: { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint } | null = null;
       let lastErr: any;
       for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        // Yield mid-loop the moment a slash is waiting — release the lock for it (re-anchor next tick).
+        if (this.hasPendingSlashWrite()) {
+          lastErr = new Error("yielded to a pending slash write");
+          break;
+        }
+        // 1) Broadcast (same nonce = replacement; strictly-increasing fees so it isn't underpriced).
+        let tx: ethers.TransactionResponse;
         try {
-          const fees = await bumpedFees(this.provider, bumpPct);
-          const tx: ethers.TransactionResponse = await contract.attestLiveness(
-            anchorBlock,
-            anchorHash,
-            {
-              nonce,
-              ...fees,
-            }
-          );
+          const fees = await this.nextAttestFees(prevFees);
+          prevFees = fees;
+          tx = await contract.attestLiveness(anchorBlock, anchorHash, { nonce, ...fees });
           sent.push(tx.hash);
-          const receipt = await tx.wait(1, perAttemptMs);
-          if (receipt?.status === 1) return tx.hash;
-          // Mined but reverted → nonce consumed; a same-nonce replacement can't help. Re-anchor next tick.
-          throw new Error(`attest tx ${tx.hash} reverted (status ${receipt?.status ?? "unknown"})`);
         } catch (e: any) {
           lastErr = e;
+          const code = e?.code;
           const msg = String(e?.shortMessage ?? e?.message ?? e);
-          // A reverted receipt is terminal for this anchor — stop and reconcile.
-          if (msg.includes("reverted")) break;
-          // A slash took our nonce (dead-heat) → yield: refetch the fresh pending nonce and retry.
-          if (/nonce too low|nonce has already been used|NONCE_EXPIRED/i.test(msg)) {
+          // Nonce consumed: our OWN earlier tx may have mined (reconcile → don't double-attest);
+          // otherwise a slash took the nonce → refetch a fresh nonce and retry (guaranteed resend).
+          if (code === "NONCE_EXPIRED" || /nonce too low|nonce has already been used/i.test(msg)) {
+            const hit = await reconcile();
+            if (hit) return hit;
             nonce = await this.provider.getTransactionCount(op, "pending");
             continue;
           }
-          // Timeout / underpriced replacement → keep the same nonce, escalate fees, resend.
-          bumpPct += 30;
+          // Replacement underpriced → next iteration bumps from prevFees; just retry.
+          if (
+            code === "REPLACEMENT_UNDERPRICED" ||
+            /replacement transaction underpriced/i.test(msg)
+          ) {
+            continue;
+          }
+          break; // unknown send error — reconcile + throw
         }
-      }
-      // Reconcile: the original may have mined while we waited on a replacement (or vice versa).
-      for (const h of sent) {
+        // 2) Await inclusion with a per-attempt deadline.
         try {
-          const r = await this.provider.getTransactionReceipt(h);
-          if (r?.status === 1) return h;
-        } catch {
-          // ignore — best-effort reconciliation
+          const receipt = await tx.wait(1, perAttemptMs);
+          if (receipt?.status === 1) return tx.hash;
+          // Mined but reverted → terminal for this anchor (re-anchor next tick).
+          lastErr = new Error(
+            `attest tx ${tx.hash} reverted (status ${receipt?.status ?? "unknown"})`
+          );
+          break;
+        } catch (e: any) {
+          lastErr = e;
+          // Timeout / not yet mined → keep the SAME nonce, escalate fees next iteration (replacement).
         }
       }
+      const hit = await reconcile();
+      if (hit) return hit;
       throw new Error(
         `attestLiveness not confirmed after ${maxAttempts} attempt(s): ${lastErr?.message ?? lastErr}`
       );
@@ -1523,64 +1585,68 @@ export class BlockchainService {
     level: number,
     reason: string
   ): Promise<{ txHash: string; proposalId: bigint | null }> {
-    if (!this.wallet) {
-      throw new Error("Blockchain not configured. Set ETH_PRIVATE_KEY environment variable.");
-    }
-    // Minimal fragment set: the write function plus the event we parse the real id from.
-    const abi = [
-      "function createProposal(address operator, uint8 level, string reason) returns (uint256)",
-      "event ProposalCreated(uint256 indexed id, address indexed operator, uint8 level)",
-    ];
-    const iface = new ethers.Interface(abi);
-    const contract = this.buildContract(dvtValidatorAddress, abi, this.wallet);
-    const fees = await bumpedFees(this.provider);
-    const tx: ethers.TransactionResponse = await contract.createProposal(
-      operator,
-      level,
-      reason,
-      fees
-    );
-    this.logger.log(`createProposal(${operator}, ${level}) submitted: ${tx.hash}`);
-    // Await the receipt: a dropped/reverted proposal must NOT be recorded as success.
-    // Throw on failure so the caller archives the evidence but records proposalTx=null.
-    const receipt = await tx.wait();
-    if (!receipt || receipt.status !== 1) {
-      throw new Error(
-        `createProposal tx ${tx.hash} failed (status ${receipt?.status ?? "unknown"})`
-      );
-    }
-    // Parse the REAL on-chain proposal id from the emitted ProposalCreated event. Best-effort:
-    // decode by topic, ignore unrelated logs, and fall back to null (never fabricate an id).
-    let proposalId: bigint | null = null;
-    for (const log of receipt.logs) {
-      try {
-        // MEDIUM 3 (Codex): only trust a ProposalCreated emitted BY the DVTValidator we called AND
-        // matching THIS proposal's operator + level. A decodable log from another contract, or one
-        // whose args disagree, must NEVER be mistaken for our proposal id (a wrong id would bind the
-        // evidence to someone else's proposal and later make executeWithProof slash the wrong thing).
-        if (ethers.getAddress(log.address) !== ethers.getAddress(dvtValidatorAddress)) continue;
-        const parsed = iface.parseLog({ topics: [...log.topics], data: log.data });
-        if (!parsed || parsed.name !== "ProposalCreated") continue;
-        const evOperator = parsed.args.operator ?? parsed.args[1];
-        const evLevel = parsed.args.level ?? parsed.args[2];
-        if (ethers.getAddress(evOperator) !== ethers.getAddress(operator)) continue;
-        if (Number(evLevel) !== level) continue;
-        proposalId = BigInt(parsed.args.id ?? parsed.args[0]);
-        break;
-      } catch {
-        // Not a ProposalCreated log from this validator (or from another contract) — skip.
+    // Priority slash write on the shared operator-wallet FIFO (bumps slashPending so a running
+    // attest yields; serializes the nonce). See `enqueueSlashWrite` / `enqueueWalletWrite`.
+    return this.enqueueSlashWrite(async () => {
+      if (!this.wallet) {
+        throw new Error("Blockchain not configured. Set ETH_PRIVATE_KEY environment variable.");
       }
-    }
-    if (proposalId === null) {
-      this.logger.warn(
-        `createProposal ${tx.hash} confirmed but no ProposalCreated event found — id unresolved`
+      // Minimal fragment set: the write function plus the event we parse the real id from.
+      const abi = [
+        "function createProposal(address operator, uint8 level, string reason) returns (uint256)",
+        "event ProposalCreated(uint256 indexed id, address indexed operator, uint8 level)",
+      ];
+      const iface = new ethers.Interface(abi);
+      const contract = this.buildContract(dvtValidatorAddress, abi, this.wallet);
+      const fees = await bumpedFees(this.provider);
+      const tx: ethers.TransactionResponse = await contract.createProposal(
+        operator,
+        level,
+        reason,
+        fees
       );
-    }
-    this.logger.log(
-      `createProposal(${operator}, ${level}) confirmed in block ${receipt.blockNumber}` +
-        (proposalId !== null ? ` (proposalId ${proposalId})` : "")
-    );
-    return { txHash: tx.hash, proposalId };
+      this.logger.log(`createProposal(${operator}, ${level}) submitted: ${tx.hash}`);
+      // Await the receipt: a dropped/reverted proposal must NOT be recorded as success.
+      // Throw on failure so the caller archives the evidence but records proposalTx=null.
+      const receipt = await tx.wait();
+      if (!receipt || receipt.status !== 1) {
+        throw new Error(
+          `createProposal tx ${tx.hash} failed (status ${receipt?.status ?? "unknown"})`
+        );
+      }
+      // Parse the REAL on-chain proposal id from the emitted ProposalCreated event. Best-effort:
+      // decode by topic, ignore unrelated logs, and fall back to null (never fabricate an id).
+      let proposalId: bigint | null = null;
+      for (const log of receipt.logs) {
+        try {
+          // MEDIUM 3 (Codex): only trust a ProposalCreated emitted BY the DVTValidator we called AND
+          // matching THIS proposal's operator + level. A decodable log from another contract, or one
+          // whose args disagree, must NEVER be mistaken for our proposal id (a wrong id would bind the
+          // evidence to someone else's proposal and later make executeWithProof slash the wrong thing).
+          if (ethers.getAddress(log.address) !== ethers.getAddress(dvtValidatorAddress)) continue;
+          const parsed = iface.parseLog({ topics: [...log.topics], data: log.data });
+          if (!parsed || parsed.name !== "ProposalCreated") continue;
+          const evOperator = parsed.args.operator ?? parsed.args[1];
+          const evLevel = parsed.args.level ?? parsed.args[2];
+          if (ethers.getAddress(evOperator) !== ethers.getAddress(operator)) continue;
+          if (Number(evLevel) !== level) continue;
+          proposalId = BigInt(parsed.args.id ?? parsed.args[0]);
+          break;
+        } catch {
+          // Not a ProposalCreated log from this validator (or from another contract) — skip.
+        }
+      }
+      if (proposalId === null) {
+        this.logger.warn(
+          `createProposal ${tx.hash} confirmed but no ProposalCreated event found — id unresolved`
+        );
+      }
+      this.logger.log(
+        `createProposal(${operator}, ${level}) confirmed in block ${receipt.blockNumber}` +
+          (proposalId !== null ? ` (proposalId ${proposalId})` : "")
+      );
+      return { txHash: tx.hash, proposalId };
+    });
   }
 
   /**
@@ -1604,78 +1670,80 @@ export class BlockchainService {
     evidenceHash: string,
     dryRun = false
   ): Promise<{ txHash: string; proposalId: bigint | null }> {
-    if (!this.wallet) {
-      throw new Error("Blockchain not configured. Set ETH_PRIVATE_KEY environment variable.");
-    }
-    const abi = [
-      "function createProposal(address operator, uint8 level, string reason, bytes32 evidenceHash) returns (uint256)",
-      "event ProposalCreated(uint256 indexed id, address indexed operator, uint8 level)",
-    ];
-    const iface = new ethers.Interface(abi);
-    const contract = this.buildContract(dvtValidatorAddress, abi, this.wallet);
-    // DRY RUN (Codex #181 F1): createProposal is a REAL governance tx — broadcasting it in a drill
-    // would leave an orphaned on-chain proposal. staticCall instead: it validates the call AND returns
-    // the would-be proposalId (createProposal's return value) for the execute messageHash, with NO
-    // broadcast and no side effect.
-    if (dryRun) {
-      const wouldBeId: bigint = await contract.createProposal.staticCall(
+    return this.enqueueSlashWrite(async () => {
+      if (!this.wallet) {
+        throw new Error("Blockchain not configured. Set ETH_PRIVATE_KEY environment variable.");
+      }
+      const abi = [
+        "function createProposal(address operator, uint8 level, string reason, bytes32 evidenceHash) returns (uint256)",
+        "event ProposalCreated(uint256 indexed id, address indexed operator, uint8 level)",
+      ];
+      const iface = new ethers.Interface(abi);
+      const contract = this.buildContract(dvtValidatorAddress, abi, this.wallet);
+      // DRY RUN (Codex #181 F1): createProposal is a REAL governance tx — broadcasting it in a drill
+      // would leave an orphaned on-chain proposal. staticCall instead: it validates the call AND returns
+      // the would-be proposalId (createProposal's return value) for the execute messageHash, with NO
+      // broadcast and no side effect.
+      if (dryRun) {
+        const wouldBeId: bigint = await contract.createProposal.staticCall(
+          operator,
+          level,
+          reason,
+          evidenceHash
+        );
+        this.logger.log(
+          `createProposal DRY RUN: staticCall passed (would-be id ${wouldBeId}) — NOT broadcasting`
+        );
+        return { txHash: DRY_RUN_TX_SENTINEL, proposalId: wouldBeId };
+      }
+      const fees = await bumpedFees(this.provider);
+      const tx: ethers.TransactionResponse = await contract.createProposal(
         operator,
         level,
         reason,
-        evidenceHash
+        evidenceHash,
+        fees
       );
       this.logger.log(
-        `createProposal DRY RUN: staticCall passed (would-be id ${wouldBeId}) — NOT broadcasting`
+        `createProposal(${operator}, ${level}, evidence ${evidenceHash}) submitted: ${tx.hash}`
       );
-      return { txHash: DRY_RUN_TX_SENTINEL, proposalId: wouldBeId };
-    }
-    const fees = await bumpedFees(this.provider);
-    const tx: ethers.TransactionResponse = await contract.createProposal(
-      operator,
-      level,
-      reason,
-      evidenceHash,
-      fees
-    );
-    this.logger.log(
-      `createProposal(${operator}, ${level}, evidence ${evidenceHash}) submitted: ${tx.hash}`
-    );
-    const receipt = await tx.wait();
-    if (!receipt || receipt.status !== 1) {
-      throw new Error(
-        `createProposal tx ${tx.hash} failed (status ${receipt?.status ?? "unknown"})`
-      );
-    }
-    let proposalId: bigint | null = null;
-    for (const log of receipt.logs) {
-      try {
-        // MEDIUM 3 (Codex): only trust a ProposalCreated emitted BY the DVTValidator we called AND
-        // matching THIS proposal's operator + level. A decodable log from another contract, or one
-        // whose args disagree, must NEVER be mistaken for our proposal id (a wrong id would bind the
-        // evidence to someone else's proposal and later make executeWithProof slash the wrong thing).
-        if (ethers.getAddress(log.address) !== ethers.getAddress(dvtValidatorAddress)) continue;
-        const parsed = iface.parseLog({ topics: [...log.topics], data: log.data });
-        if (!parsed || parsed.name !== "ProposalCreated") continue;
-        const evOperator = parsed.args.operator ?? parsed.args[1];
-        const evLevel = parsed.args.level ?? parsed.args[2];
-        if (ethers.getAddress(evOperator) !== ethers.getAddress(operator)) continue;
-        if (Number(evLevel) !== level) continue;
-        proposalId = BigInt(parsed.args.id ?? parsed.args[0]);
-        break;
-      } catch {
-        // Not a ProposalCreated log from this validator (or from another contract) — skip.
+      const receipt = await tx.wait();
+      if (!receipt || receipt.status !== 1) {
+        throw new Error(
+          `createProposal tx ${tx.hash} failed (status ${receipt?.status ?? "unknown"})`
+        );
       }
-    }
-    if (proposalId === null) {
-      this.logger.warn(
-        `createProposal ${tx.hash} confirmed but no ProposalCreated event found — id unresolved`
+      let proposalId: bigint | null = null;
+      for (const log of receipt.logs) {
+        try {
+          // MEDIUM 3 (Codex): only trust a ProposalCreated emitted BY the DVTValidator we called AND
+          // matching THIS proposal's operator + level. A decodable log from another contract, or one
+          // whose args disagree, must NEVER be mistaken for our proposal id (a wrong id would bind the
+          // evidence to someone else's proposal and later make executeWithProof slash the wrong thing).
+          if (ethers.getAddress(log.address) !== ethers.getAddress(dvtValidatorAddress)) continue;
+          const parsed = iface.parseLog({ topics: [...log.topics], data: log.data });
+          if (!parsed || parsed.name !== "ProposalCreated") continue;
+          const evOperator = parsed.args.operator ?? parsed.args[1];
+          const evLevel = parsed.args.level ?? parsed.args[2];
+          if (ethers.getAddress(evOperator) !== ethers.getAddress(operator)) continue;
+          if (Number(evLevel) !== level) continue;
+          proposalId = BigInt(parsed.args.id ?? parsed.args[0]);
+          break;
+        } catch {
+          // Not a ProposalCreated log from this validator (or from another contract) — skip.
+        }
+      }
+      if (proposalId === null) {
+        this.logger.warn(
+          `createProposal ${tx.hash} confirmed but no ProposalCreated event found — id unresolved`
+        );
+      }
+      this.logger.log(
+        `createProposal(${operator}, ${level}) confirmed in block ${receipt.blockNumber}` +
+          (proposalId !== null ? ` (proposalId ${proposalId})` : "")
       );
-    }
-    this.logger.log(
-      `createProposal(${operator}, ${level}) confirmed in block ${receipt.blockNumber}` +
-        (proposalId !== null ? ` (proposalId ${proposalId})` : "")
-    );
-    return { txHash: tx.hash, proposalId };
+      return { txHash: tx.hash, proposalId };
+    });
   }
 
   /**
@@ -1693,57 +1761,59 @@ export class BlockchainService {
     proof: string,
     dryRun = false
   ): Promise<string> {
-    if (!this.wallet) {
-      throw new Error("Blockchain not configured. Set ETH_PRIVATE_KEY environment variable.");
-    }
-    const abi = [
-      "function queueSlashWithProof(address operator, uint8 slashLevel, uint256 epoch, bytes proof) external",
-    ];
-    const contract = this.buildContract(dvtValidatorAddress, abi, this.wallet);
-    // STATIC-CALL PREFLIGHT (Codex HIGH 2): simulate the EXACT call first. Any deterministic
-    // mismatch (bad signerMask, sigG2 encoding, DST, on-chain threshold, stale slot mapping, wrong
-    // address, proposal state) reverts HERE — before spending a single wei of gas — so the audit's
-    // try/catch degrades to file+archive instead of eating a PAID on-chain revert. Only a passing
-    // simulation lets the real, irreversible tx broadcast.
-    try {
-      await contract.queueSlashWithProof.staticCall(operator, slashLevel, epoch, proof);
-    } catch (err: unknown) {
-      const reason = err instanceof Error ? err.message : String(err);
-      throw new Error(
-        `queueSlashWithProof preflight (staticCall) reverted — NOT broadcasting: ${reason}`,
-        { cause: err }
+    return this.enqueueSlashWrite(async () => {
+      if (!this.wallet) {
+        throw new Error("Blockchain not configured. Set ETH_PRIVATE_KEY environment variable.");
+      }
+      const abi = [
+        "function queueSlashWithProof(address operator, uint8 slashLevel, uint256 epoch, bytes proof) external",
+      ];
+      const contract = this.buildContract(dvtValidatorAddress, abi, this.wallet);
+      // STATIC-CALL PREFLIGHT (Codex HIGH 2): simulate the EXACT call first. Any deterministic
+      // mismatch (bad signerMask, sigG2 encoding, DST, on-chain threshold, stale slot mapping, wrong
+      // address, proposal state) reverts HERE — before spending a single wei of gas — so the audit's
+      // try/catch degrades to file+archive instead of eating a PAID on-chain revert. Only a passing
+      // simulation lets the real, irreversible tx broadcast.
+      try {
+        await contract.queueSlashWithProof.staticCall(operator, slashLevel, epoch, proof);
+      } catch (err: unknown) {
+        const reason = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `queueSlashWithProof preflight (staticCall) reverted — NOT broadcasting: ${reason}`,
+          { cause: err }
+        );
+      }
+      // DRY-RUN (AUDIT_DRY_RUN): the preflight above ran against the REAL contract and passed, proving
+      // the signerMask/sigG2/threshold/slot mapping are accepted by verifyAndExecute. Stop HERE — do
+      // NOT broadcast the real queue tx and do NOT await a receipt (there is no tx). Return the sentinel
+      // so the caller records that this step was a dry run instead of a real slash queue.
+      if (dryRun) {
+        this.logger.warn(
+          `queueSlashWithProof DRY RUN: staticCall passed, NOT broadcasting — would queue slash of ` +
+            `${operator} (slashLevel ${slashLevel}, epoch ${epoch})`
+        );
+        return DRY_RUN_TX_SENTINEL;
+      }
+      const fees = await bumpedFees(this.provider);
+      const tx: ethers.TransactionResponse = await contract.queueSlashWithProof(
+        operator,
+        slashLevel,
+        epoch,
+        proof,
+        fees
       );
-    }
-    // DRY-RUN (AUDIT_DRY_RUN): the preflight above ran against the REAL contract and passed, proving
-    // the signerMask/sigG2/threshold/slot mapping are accepted by verifyAndExecute. Stop HERE — do
-    // NOT broadcast the real queue tx and do NOT await a receipt (there is no tx). Return the sentinel
-    // so the caller records that this step was a dry run instead of a real slash queue.
-    if (dryRun) {
-      this.logger.warn(
-        `queueSlashWithProof DRY RUN: staticCall passed, NOT broadcasting — would queue slash of ` +
-          `${operator} (slashLevel ${slashLevel}, epoch ${epoch})`
+      this.logger.log(
+        `queueSlashWithProof(${operator}, ${slashLevel}, epoch ${epoch}) submitted: ${tx.hash}`
       );
-      return DRY_RUN_TX_SENTINEL;
-    }
-    const fees = await bumpedFees(this.provider);
-    const tx: ethers.TransactionResponse = await contract.queueSlashWithProof(
-      operator,
-      slashLevel,
-      epoch,
-      proof,
-      fees
-    );
-    this.logger.log(
-      `queueSlashWithProof(${operator}, ${slashLevel}, epoch ${epoch}) submitted: ${tx.hash}`
-    );
-    const receipt = await tx.wait();
-    if (!receipt || receipt.status !== 1) {
-      throw new Error(
-        `queueSlashWithProof tx ${tx.hash} failed (status ${receipt?.status ?? "unknown"})`
-      );
-    }
-    this.logger.log(`queueSlashWithProof(${operator}) confirmed in block ${receipt.blockNumber}`);
-    return tx.hash;
+      const receipt = await tx.wait();
+      if (!receipt || receipt.status !== 1) {
+        throw new Error(
+          `queueSlashWithProof tx ${tx.hash} failed (status ${receipt?.status ?? "unknown"})`
+        );
+      }
+      this.logger.log(`queueSlashWithProof(${operator}) confirmed in block ${receipt.blockNumber}`);
+      return tx.hash;
+    });
   }
 
   /**
@@ -1762,54 +1832,56 @@ export class BlockchainService {
     proof: string,
     dryRun = false
   ): Promise<string> {
-    if (!this.wallet) {
-      throw new Error("Blockchain not configured. Set ETH_PRIVATE_KEY environment variable.");
-    }
-    const abi = [
-      "function executeWithProof(uint256 id, address[] repUsers, uint256[] newScores, uint256 epoch, bytes proof) external",
-    ];
-    const contract = this.buildContract(dvtValidatorAddress, abi, this.wallet);
-    // STATIC-CALL PREFLIGHT (Codex HIGH 2): simulate the EXACT execute call first so any
-    // deterministic revert (signerMask/sigG2/threshold/proposal-state mismatch) surfaces BEFORE the
-    // irreversible slash tx spends gas. Only a passing simulation lets the real tx broadcast.
-    try {
-      await contract.executeWithProof.staticCall(id, repUsers, newScores, epoch, proof);
-    } catch (err: unknown) {
-      const reason = err instanceof Error ? err.message : String(err);
-      throw new Error(
-        `executeWithProof preflight (staticCall) reverted — NOT broadcasting: ${reason}`,
-        { cause: err }
+    return this.enqueueSlashWrite(async () => {
+      if (!this.wallet) {
+        throw new Error("Blockchain not configured. Set ETH_PRIVATE_KEY environment variable.");
+      }
+      const abi = [
+        "function executeWithProof(uint256 id, address[] repUsers, uint256[] newScores, uint256 epoch, bytes proof) external",
+      ];
+      const contract = this.buildContract(dvtValidatorAddress, abi, this.wallet);
+      // STATIC-CALL PREFLIGHT (Codex HIGH 2): simulate the EXACT execute call first so any
+      // deterministic revert (signerMask/sigG2/threshold/proposal-state mismatch) surfaces BEFORE the
+      // irreversible slash tx spends gas. Only a passing simulation lets the real tx broadcast.
+      try {
+        await contract.executeWithProof.staticCall(id, repUsers, newScores, epoch, proof);
+      } catch (err: unknown) {
+        const reason = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `executeWithProof preflight (staticCall) reverted — NOT broadcasting: ${reason}`,
+          { cause: err }
+        );
+      }
+      // DRY-RUN (AUDIT_DRY_RUN): the preflight above simulated the EXACT irreversible slash against the
+      // REAL contract and passed — proving verifyAndExecute accepts the proof — but this is a drill, so
+      // stop HERE. Do NOT broadcast the real slash and do NOT await a receipt. Return the sentinel so the
+      // caller records that NO operator was actually slashed (and skips the durable over-slash marker).
+      if (dryRun) {
+        this.logger.warn(
+          `executeSlashWithProof DRY RUN: staticCall passed, NOT broadcasting — would slash proposal ` +
+            `id ${id} (epoch ${epoch})`
+        );
+        return DRY_RUN_TX_SENTINEL;
+      }
+      const fees = await bumpedFees(this.provider);
+      const tx: ethers.TransactionResponse = await contract.executeWithProof(
+        id,
+        repUsers,
+        newScores,
+        epoch,
+        proof,
+        fees
       );
-    }
-    // DRY-RUN (AUDIT_DRY_RUN): the preflight above simulated the EXACT irreversible slash against the
-    // REAL contract and passed — proving verifyAndExecute accepts the proof — but this is a drill, so
-    // stop HERE. Do NOT broadcast the real slash and do NOT await a receipt. Return the sentinel so the
-    // caller records that NO operator was actually slashed (and skips the durable over-slash marker).
-    if (dryRun) {
-      this.logger.warn(
-        `executeSlashWithProof DRY RUN: staticCall passed, NOT broadcasting — would slash proposal ` +
-          `id ${id} (epoch ${epoch})`
-      );
-      return DRY_RUN_TX_SENTINEL;
-    }
-    const fees = await bumpedFees(this.provider);
-    const tx: ethers.TransactionResponse = await contract.executeWithProof(
-      id,
-      repUsers,
-      newScores,
-      epoch,
-      proof,
-      fees
-    );
-    this.logger.log(`executeWithProof(id ${id}, epoch ${epoch}) submitted: ${tx.hash}`);
-    const receipt = await tx.wait();
-    if (!receipt || receipt.status !== 1) {
-      throw new Error(
-        `executeWithProof tx ${tx.hash} failed (status ${receipt?.status ?? "unknown"})`
-      );
-    }
-    this.logger.log(`executeWithProof(id ${id}) confirmed in block ${receipt.blockNumber}`);
-    return tx.hash;
+      this.logger.log(`executeWithProof(id ${id}, epoch ${epoch}) submitted: ${tx.hash}`);
+      const receipt = await tx.wait();
+      if (!receipt || receipt.status !== 1) {
+        throw new Error(
+          `executeWithProof tx ${tx.hash} failed (status ${receipt?.status ?? "unknown"})`
+        );
+      }
+      this.logger.log(`executeWithProof(id ${id}) confirmed in block ${receipt.blockNumber}`);
+      return tx.hash;
+    });
   }
 
   /** Current network base-fee in gwei (0 on chains without EIP-1559). */

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -169,7 +169,8 @@ export class BlockchainService {
       this.logger.log(`Registering node ${nodeId} on contract ${contractAddress}`);
 
       // Call registerPublicKey function
-      const tx = await contract.registerPublicKey(nodeId, publicKey);
+      // Broadcast on the shared operator-EOA FIFO so a concurrent attest/keeper can't race the nonce.
+      const tx = await this.enqueueWalletWrite(() => contract.registerPublicKey(nodeId, publicKey));
       this.logger.log(`Transaction submitted: ${tx.hash}`);
 
       // Wait for transaction confirmation
@@ -250,7 +251,7 @@ export class BlockchainService {
       this.logger.log(`Revoking node ${nodeId} on contract ${contractAddress}`);
 
       // Call revokePublicKey function
-      const tx = await contract.revokePublicKey(nodeId);
+      const tx = await this.enqueueWalletWrite(() => contract.revokePublicKey(nodeId));
       this.logger.log(`Transaction submitted: ${tx.hash}`);
 
       // Wait for transaction confirmation
@@ -286,7 +287,9 @@ export class BlockchainService {
     try {
       this.logger.log(`Batch registering ${nodeIds.length} nodes on contract ${contractAddress}`);
 
-      const tx = await contract.batchRegisterPublicKeys(nodeIds, publicKeys);
+      const tx = await this.enqueueWalletWrite(() =>
+        contract.batchRegisterPublicKeys(nodeIds, publicKeys)
+      );
       this.logger.log(`Batch registration transaction submitted: ${tx.hash}`);
 
       const receipt = await tx.wait();
@@ -665,7 +668,12 @@ export class BlockchainService {
   ): Promise<{ maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }> {
     const fresh = await bumpedFees(this.provider);
     if (!prev) return fresh;
-    const bump = (x: bigint): bigint => (x * 1125n) / 1000n; // +12.5% > geth's 10% replacement floor
+    // +12.5% (ceil, and at least prev+1) so a REPLACEMENT strictly exceeds prev on BOTH fields even
+    // at tiny wei values where integer *1125/1000 would round back down to prev (geth wants ≥10%).
+    const bump = (x: bigint): bigint => {
+      const b = (x * 1125n + 999n) / 1000n;
+      return b > x ? b : x + 1n;
+    };
     const max = (a: bigint, b: bigint): bigint => (a > b ? a : b);
     return {
       maxFeePerGas: max(fresh.maxFeePerGas, bump(prev.maxFeePerGas)),
@@ -677,16 +685,21 @@ export class BlockchainService {
    * LivenessRegistry.attestLiveness(anchorBlock, anchorHash) — the operator (this node) self-proves
    * liveness on-chain so SP's auto-jail excludes it only when it is genuinely silent (inc-2 C1).
    *
-   * msg.sender MUST be the registered operator EOA (`this.wallet`) — NOT the keeper key — because
-   * the registry attests the SENDER. Runs on the single operator-wallet FIFO (`enqueueWalletWrite`)
-   * shared with the slash writes, so no attest/slash nonce race is possible; and it YIELDS to a
-   * pending slash (bails between attempts — `hasPendingSlashWrite`) so a slash never waits out the
-   * attest's retry budget. Hardening (Codex inc-2 review): staticCall preflight (fail before burning
-   * a nonce on a stale/bad anchor); a bounded deadline loop with same-nonce STRICTLY-increasing fee
-   * REPLACEMENT (`nextAttestFees` — a tx stuck > 256 blocks would freeze `lastLive` into a false-
-   * offline); a nonce-consumed error triggers a reconcile-then-refetch (our own tx may have mined →
-   * don't double-attest; otherwise a slash took the nonce → refetch + retry, guaranteeing a resend);
-   * and a final receipt reconciliation across every broadcast hash.
+   * msg.sender MUST be the registered operator EOA (`this.wallet`) — the registry attests the SENDER.
+   *
+   * Concurrency (Codex inc-2 rounds): the BROADCAST (nonce allocation + send) runs inside the shared
+   * operator-EOA FIFO (`enqueueWalletWrite`) — that window is exclusive so no attest/slash nonce race
+   * is possible — but the receipt WAIT runs OUTSIDE the lock, so a slash arriving during the wait
+   * grabs the lock (and the next nonce) immediately instead of blocking behind our timeout.
+   * Slash priority: we yield (bail) to a pending slash ONLY before our first broadcast (a slash then
+   * takes the lower nonce). Once we've broadcast at nonce N, a slash is at N+1 and DEPENDS on N
+   * mining, so we do NOT abandon N — we drive it to inclusion via same-nonce STRICTLY-increasing fee
+   * replacement (`nextAttestFees`; a tx stuck > 256 blocks would freeze `lastLive` into false-offline),
+   * which also unblocks the slash. A `maxSends` budget bounds real broadcasts; nonce-consumed /
+   * underpriced recoveries don't consume it (bounded separately) so a refetch always gets a resend.
+   * NOTE: this bounds a slash's wait to attest INCLUSION time, not zero — true tx-level preemption is
+   * out of scope and unnecessary: DVT slashes are finalized-evidence-driven + two-step/multi-block,
+   * not sub-block-time-sensitive.
    */
   async attestLiveness(
     registryAddress: string,
@@ -697,98 +710,116 @@ export class BlockchainService {
     if (!this.wallet) {
       throw new Error("attestLiveness: no operator wallet (ETH_PRIVATE_KEY unset)");
     }
-    const perAttemptMs = opts.perAttemptMs ?? 20_000;
-    const maxAttempts = Math.max(1, opts.maxAttempts ?? 3);
-    return this.enqueueWalletWrite(async () => {
-      const op = this.wallet.address;
-      const abi = ["function attestLiveness(uint256 anchorBlock, bytes32 anchorHash) external"];
-      const contract = this.buildContract(registryAddress, abi, this.wallet);
-      const sent: string[] = [];
-      // Best-effort: return the first broadcast hash that already confirmed status 1.
-      const reconcile = async (): Promise<string | null> => {
-        for (const h of sent) {
-          try {
-            const r = await this.provider.getTransactionReceipt(h);
-            if (r?.status === 1) return h;
-          } catch {
-            // ignore — best-effort
-          }
-        }
-        return null;
-      };
-
-      // Yield to a waiting slash BEFORE taking a nonce (slash is the priority).
-      if (this.hasPendingSlashWrite()) {
-        throw new Error("attestLiveness yielded to a pending slash write");
-      }
-      // Preflight: a stale/bad anchor reverts (StaleAnchor/BadAnchorHash). Fail here BEFORE
-      // consuming a nonce so the keeper re-anchors on the next tick instead of burning gas.
-      try {
-        await contract.attestLiveness.staticCall(anchorBlock, anchorHash);
-      } catch (e: any) {
-        throw new Error(
-          `attestLiveness preflight reverted (stale/bad anchor?): ${e?.shortMessage ?? e?.message ?? e}`,
-          { cause: e }
-        );
-      }
-
-      let nonce = await this.provider.getTransactionCount(op, "pending");
-      let prevFees: { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint } | null = null;
-      let lastErr: any;
-      for (let attempt = 0; attempt < maxAttempts; attempt++) {
-        // Yield mid-loop the moment a slash is waiting — release the lock for it (re-anchor next tick).
-        if (this.hasPendingSlashWrite()) {
-          lastErr = new Error("yielded to a pending slash write");
-          break;
-        }
-        // 1) Broadcast (same nonce = replacement; strictly-increasing fees so it isn't underpriced).
-        let tx: ethers.TransactionResponse;
+    const perAttemptMs =
+      Number.isFinite(opts.perAttemptMs) && (opts.perAttemptMs as number) > 0
+        ? (opts.perAttemptMs as number)
+        : 20_000;
+    // Finite integer send budget, capped — an adversarial Infinity/NaN/fractional must not spin.
+    const maxSends =
+      Number.isInteger(opts.maxAttempts) && (opts.maxAttempts as number) > 0
+        ? Math.min(opts.maxAttempts as number, 10)
+        : 3;
+    const op = this.wallet.address;
+    const abi = ["function attestLiveness(uint256 anchorBlock, bytes32 anchorHash) external"];
+    const contract = this.buildContract(registryAddress, abi, this.wallet);
+    const sent: string[] = [];
+    // Best-effort: return the first broadcast hash that already confirmed status 1.
+    const reconcile = async (): Promise<string | null> => {
+      for (const h of sent) {
         try {
+          const r = await this.provider.getTransactionReceipt(h);
+          if (r?.status === 1) return h;
+        } catch {
+          // ignore — best-effort
+        }
+      }
+      return null;
+    };
+
+    // Early yield: a slash already pending → bail before ANY work (no preflight, no nonce).
+    if (this.hasPendingSlashWrite()) {
+      throw new Error("attestLiveness yielded to a pending slash write");
+    }
+    // Preflight is a READ (staticCall) — no nonce, no lock. A stale/bad anchor reverts here BEFORE
+    // consuming a nonce, so the keeper re-anchors next tick instead of burning gas.
+    try {
+      await contract.attestLiveness.staticCall(anchorBlock, anchorHash);
+    } catch (e: any) {
+      throw new Error(
+        `attestLiveness preflight reverted (stale/bad anchor?): ${e?.shortMessage ?? e?.message ?? e}`,
+        { cause: e }
+      );
+    }
+
+    let nonce: number | null = null;
+    let prevFees: { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint } | null = null;
+    let lastErr: any;
+    let sends = 0;
+    const maxIterations = maxSends * 3; // bound recovery (refetch / underpriced) — never spin
+    for (let iter = 0; sends < maxSends && iter < maxIterations; iter++) {
+      // 1) BROADCAST under the lock (only nonce-alloc + send are exclusive; the wait below is not).
+      let tx: ethers.TransactionResponse;
+      try {
+        tx = await this.enqueueWalletWrite(async () => {
+          // Yield to a pending slash ONLY before our first broadcast — once we hold nonce N a slash
+          // is at N+1 and needs N to mine, so we must finish N rather than abandon it.
+          if (sent.length === 0 && this.hasPendingSlashWrite()) {
+            throw new Error("attestLiveness yielded to a pending slash write");
+          }
+          if (nonce === null) nonce = await this.provider.getTransactionCount(op, "pending");
           const fees = await this.nextAttestFees(prevFees);
           prevFees = fees;
-          tx = await contract.attestLiveness(anchorBlock, anchorHash, { nonce, ...fees });
-          sent.push(tx.hash);
-        } catch (e: any) {
-          lastErr = e;
-          const code = e?.code;
-          const msg = String(e?.shortMessage ?? e?.message ?? e);
-          // Nonce consumed: our OWN earlier tx may have mined (reconcile → don't double-attest);
-          // otherwise a slash took the nonce → refetch a fresh nonce and retry (guaranteed resend).
-          if (code === "NONCE_EXPIRED" || /nonce too low|nonce has already been used/i.test(msg)) {
-            const hit = await reconcile();
-            if (hit) return hit;
-            nonce = await this.provider.getTransactionCount(op, "pending");
-            continue;
-          }
-          // Replacement underpriced → next iteration bumps from prevFees; just retry.
-          if (
-            code === "REPLACEMENT_UNDERPRICED" ||
-            /replacement transaction underpriced/i.test(msg)
-          ) {
-            continue;
-          }
-          break; // unknown send error — reconcile + throw
-        }
-        // 2) Await inclusion with a per-attempt deadline.
-        try {
-          const receipt = await tx.wait(1, perAttemptMs);
-          if (receipt?.status === 1) return tx.hash;
-          // Mined but reverted → terminal for this anchor (re-anchor next tick).
-          lastErr = new Error(
-            `attest tx ${tx.hash} reverted (status ${receipt?.status ?? "unknown"})`
+          const t: ethers.TransactionResponse = await contract.attestLiveness(
+            anchorBlock,
+            anchorHash,
+            { nonce, ...fees }
           );
-          break;
-        } catch (e: any) {
-          lastErr = e;
-          // Timeout / not yet mined → keep the SAME nonce, escalate fees next iteration (replacement).
+          sent.push(t.hash);
+          return t;
+        });
+        sends++;
+      } catch (e: any) {
+        lastErr = e;
+        const code = e?.code;
+        const msg = String(e?.shortMessage ?? e?.message ?? e);
+        if (msg.includes("yielded")) break; // slash priority — re-anchor next tick
+        // Nonce consumed: our OWN earlier tx may have mined (reconcile → don't double-attest);
+        // otherwise a slash took the nonce → refetch a fresh nonce (new tx → fresh fee baseline) and
+        // retry. This recovery does NOT consume the send budget, so a resend is guaranteed.
+        if (code === "NONCE_EXPIRED" || /nonce too low|nonce has already been used/i.test(msg)) {
+          const hit = await reconcile();
+          if (hit) return hit;
+          nonce = null;
+          prevFees = null;
+          continue;
         }
+        // Replacement underpriced → prevFees already bumped; retry same nonce (not a send).
+        if (
+          code === "REPLACEMENT_UNDERPRICED" ||
+          /replacement transaction underpriced/i.test(msg)
+        ) {
+          continue;
+        }
+        break; // unknown send error — reconcile + throw
       }
-      const hit = await reconcile();
-      if (hit) return hit;
-      throw new Error(
-        `attestLiveness not confirmed after ${maxAttempts} attempt(s): ${lastErr?.message ?? lastErr}`
-      );
-    });
+      // 2) WAIT outside the lock — a slash can grab the lock + nonce N+1 during this window.
+      try {
+        const receipt = await tx.wait(1, perAttemptMs);
+        if (receipt?.status === 1) return tx.hash;
+        lastErr = new Error(
+          `attest tx ${tx.hash} reverted (status ${receipt?.status ?? "unknown"})`
+        );
+        break; // mined but reverted → terminal for this anchor
+      } catch (e: any) {
+        lastErr = e;
+        // Timeout / not yet mined → keep the SAME nonce, escalate fees next iteration (replacement).
+      }
+    }
+    const hit = await reconcile();
+    if (hit) return hit;
+    throw new Error(
+      `attestLiveness not confirmed after ${sends} send(s): ${lastErr?.message ?? lastErr}`
+    );
   }
 
   /**
@@ -1955,7 +1986,12 @@ export class BlockchainService {
     const abi = ["function updatePrice() external"];
     const contract = new ethers.Contract(paymasterAddress, abi, signer);
     const fees = await bumpedFees(this.provider);
-    const tx: ethers.TransactionResponse = await contract.updatePrice(fees);
+    // When no dedicated KEEPER_PRIVATE_KEY is set, `signer` IS the operator EOA — serialize this
+    // periodic broadcast on the shared FIFO so it can't race the attest/slash nonce. A dedicated
+    // keeper key is a SEPARATE EOA (its own nonce space) and needs no serialization.
+    const broadcast = (): Promise<ethers.TransactionResponse> => contract.updatePrice(fees);
+    const tx: ethers.TransactionResponse =
+      signer === this.wallet ? await this.enqueueWalletWrite(broadcast) : await broadcast();
     return tx.hash;
   }
 }

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -61,17 +61,19 @@ export class BlockchainService {
   private keeperWallet?: ethers.Wallet;
 
   /**
-   * Single FIFO serialization for ALL operator-EOA (`this.wallet`) writes — the liveness attest
-   * keeper (inc-2, fires on a timer) AND every slash/proposal write share the same EOA, so without
-   * one lock two of them can read the same pending nonce and collide (a time-sensitive slash could
-   * fail as an underpriced same-nonce replacement, or an attest could displace a pending slash).
-   * Every write goes through `enqueueWalletWrite`, so exactly one holds the nonce at a time.
+   * Nonce-race protection for the shared operator EOA (`this.wallet`): the attest keeper (inc-2)
+   * and every slash/proposal/registration/updatePrice write share the same EOA. The rule is
+   * BROADCAST-under-lock, WAIT-outside-lock: `enqueueWalletWrite` serializes only the nonce
+   * allocation + send of each tx, NOT its receipt wait. That is what makes it deadlock-free — if a
+   * write held the FIFO through its (possibly 20s) wait, a stuck lower-nonce attest could never be
+   * replaced while a higher-nonce slash sat waiting on it (nonce head-of-line deadlock, Codex r3).
+   * With waits outside the lock, the attest can always reacquire the FIFO to fee-bump a stuck nonce.
    *
-   * Slash PRIORITY: `slashPending` counts slash writes that are queued-or-running. A slash bumps it
-   * synchronously BEFORE it waits for the lock, so a currently-running attest sees it (`hasPendingSlashWrite`)
-   * and BAILS between send attempts — releasing the lock so the slash runs next instead of waiting out
-   * the attest's retry budget. An attest is idempotent + retriable (re-anchors next tick), so yielding
-   * costs nothing; a slash never waits more than one in-flight attest SEND (seconds), never a full loop.
+   * Slash PRIORITY is a SEPARATE signal from the lock: `runWithSlashPriority` bumps `slashPending`
+   * for a slash's whole lifetime (broadcast + wait), so a running attest sees it via
+   * `hasPendingSlashWrite` and yields BEFORE taking a nonce (letting the slash take the lower nonce).
+   * Once the attest has broadcast nonce N, a slash is at N+1 and DEPENDS on N mining, so the attest
+   * then drives N to inclusion rather than yielding. slashPending does NOT hold the FIFO.
    */
   private walletChain: Promise<unknown> = Promise.resolve();
   private slashPending = 0;
@@ -85,7 +87,11 @@ export class BlockchainService {
     return this.slashPending > 0;
   }
 
-  /** Enqueue an operator-wallet write on the single FIFO chain (serializes nonce use). */
+  /**
+   * Serialize a single operator-wallet BROADCAST (nonce alloc + send) on the FIFO chain. Callers
+   * MUST await the returned tx's receipt OUTSIDE this call (do not `await tx.wait()` inside `fn`),
+   * or a slow inclusion would hold the lock and reintroduce the nonce head-of-line deadlock.
+   */
   protected enqueueWalletWrite<T>(fn: () => Promise<T>): Promise<T> {
     const run = this.walletChain.then(fn, fn);
     // Keep the chain alive regardless of fn's outcome; swallow here so one failure
@@ -97,10 +103,15 @@ export class BlockchainService {
     return run;
   }
 
-  /** Enqueue a PRIORITY slash write: bump `slashPending` synchronously (so a running attest yields). */
-  protected enqueueSlashWrite<T>(fn: () => Promise<T>): Promise<T> {
+  /**
+   * Run a PRIORITY slash operation: bump `slashPending` for its WHOLE lifetime (so a running attest
+   * yields before taking a nonce) — but do NOT hold the FIFO here. The slash method wraps only its
+   * BROADCAST in `enqueueWalletWrite` and awaits the receipt outside it, so its wait never blocks the
+   * attest from replacing a stuck nonce (the r3 deadlock).
+   */
+  protected runWithSlashPriority<T>(fn: () => Promise<T>): Promise<T> {
     this.slashPending++;
-    return this.enqueueWalletWrite(fn).finally(() => {
+    return fn().finally(() => {
       this.slashPending--;
     });
   }
@@ -129,8 +140,20 @@ export class BlockchainService {
     const keeperKey = this.configService.get<string>("keeperPrivateKey");
     if (keeperKey && /^0x[0-9a-fA-F]{64}$/.test(keeperKey)) {
       try {
-        this.keeperWallet = new ethers.Wallet(keeperKey, this.provider);
-        this.logger.log(`Keeper signer (dedicated): ${this.keeperWallet.address}`);
+        const kw = new ethers.Wallet(keeperKey, this.provider);
+        // If KEEPER_PRIVATE_KEY resolves to the SAME EOA as ETH_PRIVATE_KEY (two Wallet objects, one
+        // address), do NOT treat it as dedicated — else `keeperSigner` would be a distinct object and
+        // `signer === this.wallet` in updatePrice would be false, leaving that periodic broadcast
+        // OUTSIDE the shared nonce FIFO (Codex r3 High). Keep keeperWallet only for a DIFFERENT EOA.
+        if (this.wallet && kw.address.toLowerCase() === this.wallet.address.toLowerCase()) {
+          this.logger.warn(
+            "KEEPER_PRIVATE_KEY is the SAME EOA as ETH_PRIVATE_KEY — treating as the operator wallet " +
+              "(keeper writes serialize on the shared nonce FIFO)"
+          );
+        } else {
+          this.keeperWallet = kw;
+          this.logger.log(`Keeper signer (dedicated): ${this.keeperWallet.address}`);
+        }
       } catch (error: any) {
         this.logger.error(`Invalid KEEPER_PRIVATE_KEY: ${error.message}`);
       }
@@ -755,8 +778,12 @@ export class BlockchainService {
     let prevFees: { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint } | null = null;
     let lastErr: any;
     let sends = 0;
-    const maxIterations = maxSends * 3; // bound recovery (refetch / underpriced) — never spin
-    for (let iter = 0; sends < maxSends && iter < maxIterations; iter++) {
+    // A recovery (nonce refetch / underpriced retry) does NOT consume the SEND budget — it only
+    // consumes a separate recovery budget — so `maxSends` real broadcasts are guaranteed even when a
+    // recovery lands on what would have been the last iteration (Codex r3 High #3 / Medium).
+    let recoveries = 0;
+    const maxRecoveries = maxSends * 2 + 2;
+    while (sends < maxSends) {
       // 1) BROADCAST under the lock (only nonce-alloc + send are exclusive; the wait below is not).
       let tx: ethers.TransactionResponse;
       try {
@@ -783,9 +810,10 @@ export class BlockchainService {
         const code = e?.code;
         const msg = String(e?.shortMessage ?? e?.message ?? e);
         if (msg.includes("yielded")) break; // slash priority — re-anchor next tick
+        if (++recoveries > maxRecoveries) break; // too many recoveries — give up (reconcile + throw)
         // Nonce consumed: our OWN earlier tx may have mined (reconcile → don't double-attest);
         // otherwise a slash took the nonce → refetch a fresh nonce (new tx → fresh fee baseline) and
-        // retry. This recovery does NOT consume the send budget, so a resend is guaranteed.
+        // retry. Recovery does NOT increment `sends`, so a real resend still follows.
         if (code === "NONCE_EXPIRED" || /nonce too low|nonce has already been used/i.test(msg)) {
           const hit = await reconcile();
           if (hit) return hit;
@@ -1617,8 +1645,8 @@ export class BlockchainService {
     reason: string
   ): Promise<{ txHash: string; proposalId: bigint | null }> {
     // Priority slash write on the shared operator-wallet FIFO (bumps slashPending so a running
-    // attest yields; serializes the nonce). See `enqueueSlashWrite` / `enqueueWalletWrite`.
-    return this.enqueueSlashWrite(async () => {
+    // attest yields). Broadcast is wrapped in `enqueueWalletWrite`; the wait stays OUTSIDE it.
+    return this.runWithSlashPriority(async () => {
       if (!this.wallet) {
         throw new Error("Blockchain not configured. Set ETH_PRIVATE_KEY environment variable.");
       }
@@ -1630,11 +1658,8 @@ export class BlockchainService {
       const iface = new ethers.Interface(abi);
       const contract = this.buildContract(dvtValidatorAddress, abi, this.wallet);
       const fees = await bumpedFees(this.provider);
-      const tx: ethers.TransactionResponse = await contract.createProposal(
-        operator,
-        level,
-        reason,
-        fees
+      const tx: ethers.TransactionResponse = await this.enqueueWalletWrite(() =>
+        contract.createProposal(operator, level, reason, fees)
       );
       this.logger.log(`createProposal(${operator}, ${level}) submitted: ${tx.hash}`);
       // Await the receipt: a dropped/reverted proposal must NOT be recorded as success.
@@ -1701,7 +1726,7 @@ export class BlockchainService {
     evidenceHash: string,
     dryRun = false
   ): Promise<{ txHash: string; proposalId: bigint | null }> {
-    return this.enqueueSlashWrite(async () => {
+    return this.runWithSlashPriority(async () => {
       if (!this.wallet) {
         throw new Error("Blockchain not configured. Set ETH_PRIVATE_KEY environment variable.");
       }
@@ -1728,12 +1753,8 @@ export class BlockchainService {
         return { txHash: DRY_RUN_TX_SENTINEL, proposalId: wouldBeId };
       }
       const fees = await bumpedFees(this.provider);
-      const tx: ethers.TransactionResponse = await contract.createProposal(
-        operator,
-        level,
-        reason,
-        evidenceHash,
-        fees
+      const tx: ethers.TransactionResponse = await this.enqueueWalletWrite(() =>
+        contract.createProposal(operator, level, reason, evidenceHash, fees)
       );
       this.logger.log(
         `createProposal(${operator}, ${level}, evidence ${evidenceHash}) submitted: ${tx.hash}`
@@ -1792,7 +1813,7 @@ export class BlockchainService {
     proof: string,
     dryRun = false
   ): Promise<string> {
-    return this.enqueueSlashWrite(async () => {
+    return this.runWithSlashPriority(async () => {
       if (!this.wallet) {
         throw new Error("Blockchain not configured. Set ETH_PRIVATE_KEY environment variable.");
       }
@@ -1826,12 +1847,8 @@ export class BlockchainService {
         return DRY_RUN_TX_SENTINEL;
       }
       const fees = await bumpedFees(this.provider);
-      const tx: ethers.TransactionResponse = await contract.queueSlashWithProof(
-        operator,
-        slashLevel,
-        epoch,
-        proof,
-        fees
+      const tx: ethers.TransactionResponse = await this.enqueueWalletWrite(() =>
+        contract.queueSlashWithProof(operator, slashLevel, epoch, proof, fees)
       );
       this.logger.log(
         `queueSlashWithProof(${operator}, ${slashLevel}, epoch ${epoch}) submitted: ${tx.hash}`
@@ -1863,7 +1880,7 @@ export class BlockchainService {
     proof: string,
     dryRun = false
   ): Promise<string> {
-    return this.enqueueSlashWrite(async () => {
+    return this.runWithSlashPriority(async () => {
       if (!this.wallet) {
         throw new Error("Blockchain not configured. Set ETH_PRIVATE_KEY environment variable.");
       }
@@ -1895,13 +1912,8 @@ export class BlockchainService {
         return DRY_RUN_TX_SENTINEL;
       }
       const fees = await bumpedFees(this.provider);
-      const tx: ethers.TransactionResponse = await contract.executeWithProof(
-        id,
-        repUsers,
-        newScores,
-        epoch,
-        proof,
-        fees
+      const tx: ethers.TransactionResponse = await this.enqueueWalletWrite(() =>
+        contract.executeWithProof(id, repUsers, newScores, epoch, proof, fees)
       );
       this.logger.log(`executeWithProof(id ${id}, epoch ${epoch}) submitted: ${tx.hash}`);
       const receipt = await tx.wait();

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -111,9 +111,14 @@ export class BlockchainService {
    */
   protected runWithSlashPriority<T>(fn: () => Promise<T>): Promise<T> {
     this.slashPending++;
-    return fn().finally(() => {
-      this.slashPending--;
-    });
+    // `Promise.resolve().then(fn)` so a SYNCHRONOUS throw in fn (before it returns a promise) still
+    // routes through `.finally` and decrements — otherwise slashPending would leak and every future
+    // attest would yield forever (Codex r4 Low). The ++ stays synchronous, so priority is immediate.
+    return Promise.resolve()
+      .then(fn)
+      .finally(() => {
+        this.slashPending--;
+      });
   }
 
   private initializeProvider(): void {
@@ -796,6 +801,11 @@ export class BlockchainService {
           if (nonce === null) nonce = await this.provider.getTransactionCount(op, "pending");
           const fees = await this.nextAttestFees(prevFees);
           prevFees = fees;
+          // Recheck AFTER the nonce/fee awaits — a slash that arrived during them must still win the
+          // lower nonce (Codex r4 Medium). Narrows the priority race to the send itself (unavoidable).
+          if (sent.length === 0 && this.hasPendingSlashWrite()) {
+            throw new Error("attestLiveness yielded to a pending slash write");
+          }
           const t: ethers.TransactionResponse = await contract.attestLiveness(
             anchorBlock,
             anchorHash,


### PR DESCRIPTION
## What

DVT-side integration of SP's `LivenessRegistry` (CC-29, SP PR #346). Each DVT node self-proves liveness on-chain via `attestLiveness(anchorBlock, anchorHash)` from its operator EOA, so SP's **auto-jail** excludes only genuinely-silent operators. **Opt-in** (`AUDIT_ATTEST_ENABLED`, default off) — zero behavior change when disabled.

This is **inc-2 C1**. The originally-planned **C2** (adaptive live-set slash-quorum denominator) was **dropped by design** after self- + Codex challenge: the on-chain `BLSAggregator` reads its OWN fixed `slashThresholds[level]` (a DVT-lowered proof reverts) and never reads `LivenessRegistry` (a jailed key still co-signs → no deadlock), so an adaptive denominator was both ineffective on-chain and would open a self-jail-to-shrink-the-bar attack. Correct future path = fixed threshold + exclude jailed from the request-set (cross-repo SP change), not DVT-side.

## Components

- **`LivenessKeeperService`** — boot-attest + interval (~`livenessWindow/3`); wallet/registry/interval gates (fail-closed); never crashes on failure (retries next tick — a persistently-failing node *should* be jailed); ops-alert on failure; in-flight + shutdown guards.
- **`BlockchainService`** — LivenessRegistry read helpers (`getIsOffline`/`getAreOffline`/`getLastLive`/`getLivenessWindow`, `blockTag`-capable for observability + future soft request-set routing, NOT threshold math); `getAttestAnchor`; `attestLiveness` with staticCall preflight, strictly-increasing same-nonce fee replacement, guaranteed-resend budget, receipt reconciliation.
- **Shared operator-EOA nonce coordinator** — every wallet write (attest + 4 slash writes + register/revoke/batch/updatePrice) **broadcasts under a FIFO lock and waits OUTSIDE it**, so no write holds the lock during a receipt wait (deadlock-free) and nonces never race. Slash **priority** is a separate `slashPending` signal: a running attest yields the lower nonce to a pending slash.
- **Config:** `AUDIT_ATTEST_ENABLED`, `AUDIT_LIVENESS_REGISTRY_ADDRESS`, `AUDIT_ATTEST_INTERVAL_MS` (bounded [30s,6h] fail-closed), `AUDIT_ATTEST_ANCHOR_DEPTH` (clamped [1,255]).

## Review

Self-challenged, then **4 Codex adversarial rounds**, each fixing real issues:
- r1: shared wallet coordinator + slash priority + fee-replacement correctness
- r2: complete serialization + wait-outside-lock + guaranteed resend
- r3: **nonce head-of-line DEADLOCK** (slash held the FIFO through its wait, blocking a stuck-attest replacement) → split priority-signal from lock; broadcast-under-lock/wait-outside for all writes + equal-key `updatePrice` gap
- r4: **VERIFIED sound to open as PR** (deadlock + nonce-collision class fixed); applied recheck-before-send + sync-throw safety

**460 tests pass**, lint + type-check clean.

## Deferred follow-up (documented, not a blocker)

A shared **nonce-aware timeout/replacement** policy for ALL operator-EOA writes. Today only `attestLiveness` does timed same-nonce replacement; a stuck/dropped slash/register/`updatePrice` tx can head-of-line-block later nonces, and a hung slash keeps `slashPending` positive (attests yield → node eventually offline). This is an **availability** edge under stuck-RPC/dropped-tx — **not an integrity failure** (no wrong slash, no nonce collision). Tracked for a follow-up increment.

https://claude.ai/code/session_01JrdmiUk4A258FmhDSKn9aj