### PR TITLE
feat(CC-32): DK2 (STM32MP157F, armv7/512MB) DVT-only deploy path

### DIFF
--- a/deploy/dk2/README.md
+++ b/deploy/dk2/README.md
@@ -1,0 +1,131 @@
+# Run a DVT-only node on the STM32MP157F-DK2 (ARMv7, 512 MB, systemd)
+
+The deployment path for **node2** in the AAStar 3-node production topology
+(2-of-3 DVT + 1 KMS; see CC-30 / CC-32). The DK2 is a **different architecture**
+from the i.MX93 — 32-bit **ARMv7-A**, not arm64 — and has a **quarter of the
+RAM** (512 MB vs 2 GB). This directory is a thin delta over
+[`../imx93`](../imx93/README.md): same self-contained-bundle + systemd shape, but
+cross-packaged for `linux-armv7l` and tuned for 512 MB.
+
+> Why not just reuse the i.MX93 path? Two hard blockers: (1) an arm64 Node binary
+> gives **`Exec format error`** on ARMv7 — the bundle must be armv7l; (2) 512 MB
+> can't spare what an on-board `npm run build` (V8 + tsc) peaks at, so we
+> **cross-build on your Mac/CI** and the board only unpacks.
+
+## DK2 hardware profile
+
+| Item      | Value                                                                 |
+| --------- | --------------------------------------------------------------------- |
+| Board     | STM32MP157F-DK2                                                        |
+| CPU       | Dual Cortex-A7 @ 800 MHz                                               |
+| Arch      | **ARMv7-A 32-bit** + TrustZone (**not** arm64)                        |
+| RAM       | **512 MB** DDR3L (the main constraint)                                 |
+| Node role | **DVT-only** (no KMS co-located → local EIP-2335 keystore signing)     |
+| Network   | On-board WiFi 802.11 b/g/n; today USB-Eth direct to host `192.168.7.2` |
+| SSH       | `root@192.168.7.2` (passwordless)                                     |
+| Serial    | `screen /dev/ttyUSB0 115200` (UART adapter)                           |
+
+## Why this shape (DK2 / 512 MB / armv7)
+
+| Concern                              | How it's handled                                                                 |
+| ------------------------------------ | -------------------------------------------------------------------------------- |
+| 32-bit ARM, not arm64                | Bundle ships its **own** `linux-armv7l` glibc Node; `install-dk2.sh` refuses a mismatched-arch bundle before systemd ever runs it |
+| 512 MB RAM (build won't fit)         | **Never build on the board** — cross-package on your Mac; board only unpacks     |
+| 512 MB RAM (runtime)                 | `MemoryMax=320M` + `NODE_OPTIONS=--max-old-space-size=256`; leaves ~190 MB for OS + WiFi |
+| DVT-only (no KMS)                    | Local `node_state.json` BLS key; `RUST_SIGNER_URL` **unset** (that's node1 only) |
+| No Docker/Node in the image          | Pure systemd (present) + bundled Node                                             |
+| Self-heal                            | `Restart=always` (crash/OOM) **+** health-probe timer (hung-but-alive)           |
+
+All production deps are pure-JS (noble/ethers/nestjs), so the `node_modules` tree
+is cross-arch safe — the same tree that runs on arm64 runs on armv7l.
+
+## 1. Build the armv7l bundle (on your Mac / CI)
+
+```bash
+./deploy/dk2/build-bundle-dk2.sh
+# → dist-bundle/aastar-dvt-<version>-linux-armv7l.tar.gz  (Node runtime + app + prod deps)
+```
+
+Resolves the latest LTS `node-v20.x-linux-armv7l` (glibc), compiles the app,
+installs prod-only deps resolved for `linux/arm` (32-bit), stamps the target
+`ARCH`, and tars it up.
+
+## 2. Copy to the board
+
+```bash
+scp dist-bundle/aastar-dvt-*-linux-armv7l.tar.gz  root@192.168.7.2:/tmp/
+scp -r deploy/dk2  root@192.168.7.2:/tmp/dk2      # install script + units (self-contained)
+```
+
+## 3. Install on the board (creates the layout; won't start until configured)
+
+```bash
+ssh root@192.168.7.2
+cd /tmp/dk2
+./install-dk2.sh /tmp/aastar-dvt-*-linux-armv7l.tar.gz node2
+```
+
+`install-dk2.sh` arch-guards the bundle (armv7l stamp + `node -v` exec check, so an
+arm64 bundle fails fast) → stages + atomically swaps the release + `current` symlink
+→ seeds the DVT-only env template (PORT=4002, no `RUST_SIGNER_URL`) → locks the state
+dir to `0700` → installs the 512 MB-tuned systemd units → **enables for boot but does
+NOT start** while `ETH_RPC_URL` / the BLS key are still missing (it prints exactly
+what's left). This is why the key + env come next, not before install.
+
+## 4. Provision this node's OWN BLS key + finish env
+
+Generate an **independent** key on your Mac (the bundle ships no `scripts/`), copy it
+into the state dir the installer just created, and fill in the RPC:
+
+```bash
+node scripts/gen-node-state.mjs                    # → node_state.json (its OWN BLS12-381 key)
+# optional at-rest encryption (Cortex-A7 → use pbkdf2, scrypt is heavy here):
+#   KDF=pbkdf2 node scripts/encrypt-node-key.mjs
+scp node_state.json root@192.168.7.2:/opt/aastar-dvt/state/node2/node_state.json
+ssh root@192.168.7.2 'chmod 600 /opt/aastar-dvt/state/node2/node_state.json'
+# then set ETH_RPC_URL (validator/entrypoint are pre-filled):
+ssh root@192.168.7.2 'vi /opt/aastar-dvt/env/node2.env'
+```
+
+Never reuse a repo/test BLS key — each node must have its own.
+
+## 5. Start + verify
+
+```bash
+ssh root@192.168.7.2
+systemctl start aastar-dvt@node2 aastar-dvt-health@node2.timer
+# (re-running ./install-dk2.sh now also auto-starts, since env + key are present)
+
+curl -s http://127.0.0.1:4002/health            # {version:"<ver>", ...}
+curl -s http://127.0.0.1:4002/node/info         # this node's BLS public key
+journalctl -u aastar-dvt@node2 -f
+systemctl status aastar-dvt-health@node2.timer  # 30s self-heal probe
+free -m                                         # confirm headroom under the 320M cap
+```
+
+## Upgrade / rollback
+
+Same as i.MX93 — atomic `current` symlink:
+
+```bash
+# upgrade: install a newer bundle (keeps env + state)
+./install-dk2.sh /tmp/aastar-dvt-<newer>-linux-armv7l.tar.gz node2
+# rollback: repoint current at a prior release + restart
+ln -sfn /opt/aastar-dvt/releases/<old-ver> /opt/aastar-dvt/current
+systemctl restart aastar-dvt@node2
+```
+
+## Network (WiFi, later)
+
+The DK2 currently reaches the host over USB-Eth (`192.168.7.2`). The production
+plan is on-board WiFi onto the same restricted network as the KMS/MX93 nodes
+(per-device MAC registration + per-device iPSK) with a Cloudflare tunnel for
+public reachability, mirroring `kms1`. **WiFi credentials + tunnel token are
+provisioned locally by ops — they never enter the coordination hub or GitHub.**
+
+## Relation to the other paths
+
+- [`../imx93`](../imx93/README.md) — node1 (KMS+DVT co-located) & node3 (DVT-only), **arm64/2 GB**.
+- **This dir** — node2 (DVT-only), **armv7/512 MB**.
+- Validator address & network switch: `deploy/sdk-dvt-config.testnet.json` is the
+  single source of truth (flip `active` testnet→mainnet).

--- a/deploy/dk2/README.md
+++ b/deploy/dk2/README.md
@@ -4,40 +4,40 @@ The deployment path for **node2** in the AAStar 3-node production topology
 (2-of-3 DVT + 1 KMS; see CC-30 / CC-32). The DK2 is a **different architecture**
 from the i.MX93 — 32-bit **ARMv7-A**, not arm64 — and has a **quarter of the
 RAM** (512 MB vs 2 GB). This directory is a thin delta over
-[`../imx93`](../imx93/README.md): same self-contained-bundle + systemd shape, but
-cross-packaged for `linux-armv7l` and tuned for 512 MB.
+[`../imx93`](../imx93/README.md): same self-contained-bundle + systemd shape,
+but cross-packaged for `linux-armv7l` and tuned for 512 MB.
 
-> Why not just reuse the i.MX93 path? Two hard blockers: (1) an arm64 Node binary
-> gives **`Exec format error`** on ARMv7 — the bundle must be armv7l; (2) 512 MB
-> can't spare what an on-board `npm run build` (V8 + tsc) peaks at, so we
+> Why not just reuse the i.MX93 path? Two hard blockers: (1) an arm64 Node
+> binary gives **`Exec format error`** on ARMv7 — the bundle must be armv7l; (2)
+> 512 MB can't spare what an on-board `npm run build` (V8 + tsc) peaks at, so we
 > **cross-build on your Mac/CI** and the board only unpacks.
 
 ## DK2 hardware profile
 
-| Item      | Value                                                                 |
-| --------- | --------------------------------------------------------------------- |
+| Item      | Value                                                                  |
+| --------- | ---------------------------------------------------------------------- |
 | Board     | STM32MP157F-DK2                                                        |
 | CPU       | Dual Cortex-A7 @ 800 MHz                                               |
-| Arch      | **ARMv7-A 32-bit** + TrustZone (**not** arm64)                        |
+| Arch      | **ARMv7-A 32-bit** + TrustZone (**not** arm64)                         |
 | RAM       | **512 MB** DDR3L (the main constraint)                                 |
 | Node role | **DVT-only** (no KMS co-located → local EIP-2335 keystore signing)     |
 | Network   | On-board WiFi 802.11 b/g/n; today USB-Eth direct to host `192.168.7.2` |
-| SSH       | `root@192.168.7.2` (passwordless)                                     |
-| Serial    | `screen /dev/ttyUSB0 115200` (UART adapter)                           |
+| SSH       | `root@192.168.7.2` (passwordless)                                      |
+| Serial    | `screen /dev/ttyUSB0 115200` (UART adapter)                            |
 
 ## Why this shape (DK2 / 512 MB / armv7)
 
-| Concern                              | How it's handled                                                                 |
-| ------------------------------------ | -------------------------------------------------------------------------------- |
-| 32-bit ARM, not arm64                | Bundle ships its **own** `linux-armv7l` glibc Node; `install-dk2.sh` refuses a mismatched-arch bundle before systemd ever runs it |
-| 512 MB RAM (build won't fit)         | **Never build on the board** — cross-package on your Mac; board only unpacks     |
-| 512 MB RAM (runtime)                 | `MemoryMax=320M` + `NODE_OPTIONS=--max-old-space-size=256`; leaves ~190 MB for OS + WiFi |
-| DVT-only (no KMS)                    | Local `node_state.json` BLS key; `RUST_SIGNER_URL` **unset** (that's node1 only) |
-| No Docker/Node in the image          | Pure systemd (present) + bundled Node                                             |
-| Self-heal                            | `Restart=always` (crash/OOM) **+** health-probe timer (hung-but-alive)           |
+| Concern                      | How it's handled                                                                                                                  |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| 32-bit ARM, not arm64        | Bundle ships its **own** `linux-armv7l` glibc Node; `install-dk2.sh` refuses a mismatched-arch bundle before systemd ever runs it |
+| 512 MB RAM (build won't fit) | **Never build on the board** — cross-package on your Mac; board only unpacks                                                      |
+| 512 MB RAM (runtime)         | `MemoryMax=320M` + `NODE_OPTIONS=--max-old-space-size=224`; leaves ~190 MB for OS + WiFi (tune on real hardware)                  |
+| DVT-only (no KMS)            | Local `node_state.json` BLS key; `RUST_SIGNER_URL` **unset** (that's node1 only)                                                  |
+| No Docker/Node in the image  | Pure systemd (present) + bundled Node                                                                                             |
+| Self-heal                    | `Restart=always` (crash/OOM) **+** health-probe timer (hung-but-alive)                                                            |
 
-All production deps are pure-JS (noble/ethers/nestjs), so the `node_modules` tree
-is cross-arch safe — the same tree that runs on arm64 runs on armv7l.
+All production deps are pure-JS (noble/ethers/nestjs), so the `node_modules`
+tree is cross-arch safe — the same tree that runs on arm64 runs on armv7l.
 
 ## 1. Build the armv7l bundle (on your Mac / CI)
 
@@ -47,8 +47,13 @@ is cross-arch safe — the same tree that runs on arm64 runs on armv7l.
 ```
 
 Resolves the latest LTS `node-v20.x-linux-armv7l` (glibc), compiles the app,
-installs prod-only deps resolved for `linux/arm` (32-bit), stamps the target
-`ARCH`, and tars it up.
+installs prod-only deps resolved for `linux/arm` (32-bit), SHA-256-verifies the
+Node runtime, stamps the target `ARCH`, and tars it up. For a **reproducible**
+release bundle, pin the exact Node patch:
+
+```bash
+NODE_VERSION=20.20.2 ./deploy/dk2/build-bundle-dk2.sh   # locks the runtime; record it with the app tag
+```
 
 ## 2. Copy to the board
 
@@ -65,17 +70,18 @@ cd /tmp/dk2
 ./install-dk2.sh /tmp/aastar-dvt-*-linux-armv7l.tar.gz node2
 ```
 
-`install-dk2.sh` arch-guards the bundle (armv7l stamp + `node -v` exec check, so an
-arm64 bundle fails fast) → stages + atomically swaps the release + `current` symlink
-→ seeds the DVT-only env template (PORT=4002, no `RUST_SIGNER_URL`) → locks the state
-dir to `0700` → installs the 512 MB-tuned systemd units → **enables for boot but does
-NOT start** while `ETH_RPC_URL` / the BLS key are still missing (it prints exactly
-what's left). This is why the key + env come next, not before install.
+`install-dk2.sh` arch-guards the bundle (armv7l stamp + `node -v` exec check, so
+an arm64 bundle fails fast) → stages + atomically swaps the release + `current`
+symlink → seeds the DVT-only env template (PORT=4002, no `RUST_SIGNER_URL`) →
+locks the state dir to `0700` → installs the 512 MB-tuned systemd units →
+**enables for boot but does NOT start** while `ETH_RPC_URL` / the BLS key are
+still missing (it prints exactly what's left). This is why the key + env come
+next, not before install.
 
 ## 4. Provision this node's OWN BLS key + finish env
 
-Generate an **independent** key on your Mac (the bundle ships no `scripts/`), copy it
-into the state dir the installer just created, and fill in the RPC:
+Generate an **independent** key on your Mac (the bundle ships no `scripts/`),
+copy it into the state dir the installer just created, and fill in the RPC:
 
 ```bash
 node scripts/gen-node-state.mjs                    # → node_state.json (its OWN BLS12-381 key)
@@ -125,7 +131,8 @@ provisioned locally by ops — they never enter the coordination hub or GitHub.*
 
 ## Relation to the other paths
 
-- [`../imx93`](../imx93/README.md) — node1 (KMS+DVT co-located) & node3 (DVT-only), **arm64/2 GB**.
+- [`../imx93`](../imx93/README.md) — node1 (KMS+DVT co-located) & node3
+  (DVT-only), **arm64/2 GB**.
 - **This dir** — node2 (DVT-only), **armv7/512 MB**.
-- Validator address & network switch: `deploy/sdk-dvt-config.testnet.json` is the
-  single source of truth (flip `active` testnet→mainnet).
+- Validator address & network switch: `deploy/sdk-dvt-config.testnet.json` is
+  the single source of truth (flip `active` testnet→mainnet).

--- a/deploy/dk2/aastar-dvt-health@.service
+++ b/deploy/dk2/aastar-dvt-health@.service
@@ -13,4 +13,7 @@ Type=oneshot
 EnvironmentFile=/opt/aastar-dvt/env/%i.env
 # curl the node's own /health; on failure (non-2xx / refused / timeout) restart it.
 # --max-time guards against the probe itself hanging on a stuck socket.
-ExecStart=/bin/sh -c 'curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/health" >/dev/null || { echo "aastar-dvt@%i unhealthy — restarting"; systemctl restart aastar-dvt@%i.service; }'
+# ${PORT:-4002}: if the env somehow has an empty PORT the probe must not build a
+# malformed URL (http://127.0.0.1:/health) and restart-storm every 30s — fall back to
+# the DK2 default. install-dk2.sh also refuses to start a node with an empty PORT.
+ExecStart=/bin/sh -c 'curl -fsS --max-time 5 "http://127.0.0.1:${PORT:-4002}/health" >/dev/null || { echo "aastar-dvt@%i unhealthy — restarting"; systemctl restart aastar-dvt@%i.service; }'

--- a/deploy/dk2/aastar-dvt-health@.service
+++ b/deploy/dk2/aastar-dvt-health@.service
@@ -1,0 +1,16 @@
+# Self-heal layer 2 (the "autoheal" equivalent): probe the node's /health and
+# restart it if it's UP-but-not-serving (hung process — Restart=always alone can't
+# catch that). Driven by aastar-dvt-health@.timer. Instance = node id (aastar-dvt@%i).
+#
+# Identical to deploy/imx93/aastar-dvt-health@.service — kept here so the DK2 can be
+# provisioned from `scp -r deploy/dk2` alone (self-contained, no cross-dir copy).
+[Unit]
+Description=Health probe + restart for aastar-dvt@%i
+After=aastar-dvt@%i.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=/opt/aastar-dvt/env/%i.env
+# curl the node's own /health; on failure (non-2xx / refused / timeout) restart it.
+# --max-time guards against the probe itself hanging on a stuck socket.
+ExecStart=/bin/sh -c 'curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/health" >/dev/null || { echo "aastar-dvt@%i unhealthy — restarting"; systemctl restart aastar-dvt@%i.service; }'

--- a/deploy/dk2/aastar-dvt-health@.timer
+++ b/deploy/dk2/aastar-dvt-health@.timer
@@ -1,0 +1,17 @@
+# Fires the health probe every 30s (mirrors the Docker healthcheck cadence).
+# Enable per node:  systemctl enable --now aastar-dvt-health@node2.timer
+#
+# Identical to deploy/imx93/aastar-dvt-health@.timer — kept here so the DK2 can be
+# provisioned from `scp -r deploy/dk2` alone (self-contained, no cross-dir copy).
+[Unit]
+Description=Periodic health probe for aastar-dvt@%i
+
+[Timer]
+# First check 30s after boot, then every 30s. Persistent=false — no catch-up bursts.
+OnBootSec=30s
+OnUnitActiveSec=30s
+AccuracySec=5s
+Unit=aastar-dvt-health@%i.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/dk2/aastar-dvt@.service
+++ b/deploy/dk2/aastar-dvt@.service
@@ -25,8 +25,11 @@ Type=simple
 # EIP-2335 keystore / node_state.json (no KMS-TEE custody on the DK2).
 EnvironmentFile=/opt/aastar-dvt/env/%i.env
 # 512 MB board: bound V8's old-space so a leak/burst can't OOM-kill the box.
-# ~256 MB heap + overhead sits under the MemoryMax cap below with room for the OS.
-Environment=NODE_OPTIONS=--max-old-space-size=256
+# 224 MB heap ceiling keeps RSS (heap + ~60 MB binary/buffers) comfortably under the
+# 320 MB MemoryMax below, vs 256 which left only ~64 MB non-heap headroom. Baseline RSS
+# is ~103-110 MB so this is a guard rail, not a working limit. TUNE on real hardware:
+# watch `systemctl show -p MemoryPeak aastar-dvt@node2` under gossip/audit load.
+Environment=NODE_OPTIONS=--max-old-space-size=224
 # The BLS private key for THIS node (its own node_state.json). cwd = state dir so the
 # app finds ./node_state.json exactly like the dev/script deployments.
 WorkingDirectory=/opt/aastar-dvt/state/%i

--- a/deploy/dk2/aastar-dvt@.service
+++ b/deploy/dk2/aastar-dvt@.service
@@ -1,0 +1,58 @@
+# systemd template unit for an AAStar DVT node on the STM32MP157F-DK2
+# (ARMv7-A, 512 MB, DVT-ONLY — no KMS co-located). Instance name = node id,
+# e.g. `aastar-dvt@node2`. Enable/start:
+#   systemctl enable --now aastar-dvt@node2
+#
+# Same unit name as the i.MX93 path (aastar-dvt@%i) on purpose: units are
+# per-board, so the shared health probe (aastar-dvt-health@%i) works unchanged.
+# The ONLY delta vs deploy/imx93/aastar-dvt@.service is the 512 MB memory tuning
+# below — the DK2 has a quarter of the i.MX93's RAM and must leave headroom for
+# the OS, so the caps are tighter and V8's heap is bounded explicitly.
+#
+# Self-heal layer 1: Restart=always → recover from crash / OOM / non-zero exit,
+# and (via `enable`) auto-start on boot. The hung-but-alive case is handled by the
+# companion aastar-dvt-health@.timer (probes /health, restarts on failure).
+[Unit]
+Description=AAStar DVT signer node (%i) — DK2 armv7
+Documentation=https://github.com/AAStarCommunity/YetAnotherAA-Validator
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Per-node config: PORT, ETH_RPC_URL, VALIDATOR_CONTRACT_ADDRESS…
+# DVT-only: do NOT set RUST_SIGNER_URL — this node signs with its OWN local
+# EIP-2335 keystore / node_state.json (no KMS-TEE custody on the DK2).
+EnvironmentFile=/opt/aastar-dvt/env/%i.env
+# 512 MB board: bound V8's old-space so a leak/burst can't OOM-kill the box.
+# ~256 MB heap + overhead sits under the MemoryMax cap below with room for the OS.
+Environment=NODE_OPTIONS=--max-old-space-size=256
+# The BLS private key for THIS node (its own node_state.json). cwd = state dir so the
+# app finds ./node_state.json exactly like the dev/script deployments.
+WorkingDirectory=/opt/aastar-dvt/state/%i
+ExecStart=/opt/aastar-dvt/current/node /opt/aastar-dvt/current/dist/main.js
+
+Restart=always
+RestartSec=3
+# Don't let a crash-loop hammer the flash/CPU: cap restarts, back off if it storms.
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+# --- hardening (defence in depth for a key-holding process) ---
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+# Only the state dir is writable; everything else read-only.
+ReadWritePaths=/opt/aastar-dvt/state/%i
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+# Resource guard rails for a 512 MB board running ONE DVT-only node.
+# MemoryMax is a hard cap (kernel OOM-kills the cgroup above it); MemoryHigh is the
+# soft throttle where the kernel starts reclaiming. Leaves ~190 MB for OS + WiFi.
+MemoryMax=320M
+MemoryHigh=256M
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/dk2/build-bundle-dk2.sh
+++ b/deploy/dk2/build-bundle-dk2.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Build a self-contained ARMv7 (32-bit) DVT bundle for the STM32MP157F-DK2
+# (Dual Cortex-A7, ARMv7-A, 512 MB, OP-TEE). DVT-only node — no KMS co-located.
+#
+# Runs on your dev Mac / CI — NOT on the board. This is the whole point: the DK2
+# has only 512 MB RAM, so `npm ci && npm run build` on-board is risky (V8 + tsc
+# peak easily blow past what's free). We CROSS-PACKAGE here and the board only
+# unpacks — zero compile, zero firmware change. Produces a tarball with:
+#   - a glibc linux-armv7l Node runtime  (DK2 image has no Node)
+#   - dist/            (compiled app)
+#   - node_modules/    (production deps only — all pure-JS, cross-arch safe)
+#   - package.json
+#
+#   ./deploy/dk2/build-bundle-dk2.sh               # → dist-bundle/aastar-dvt-<ver>-linux-armv7l.tar.gz
+#   NODE_MAJOR=20 OUT=/tmp ./deploy/dk2/build-bundle-dk2.sh
+#
+# Delta vs deploy/imx93/build-bundle.sh: target arch is linux-armv7l (npm --cpu=arm,
+# 32-bit) instead of linux-arm64. Everything else is identical — our prod deps
+# (@noble/curves, ethers, nestjs) are pure JS with no native addon, so the same
+# node_modules tree runs on armv7l as-is.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO"
+
+NODE_MAJOR="${NODE_MAJOR:-20}" # match the repo's Node line (Dockerfile: node:20)
+OUT="${OUT:-$REPO/dist-bundle}"
+VERSION="$(node -p "require('./package.json').version")"
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+echo "▶ building DVT bundle v$VERSION for linux-armv7l (Node $NODE_MAJOR, 32-bit ARM)"
+
+# 1. Compile the app.
+echo "  • nest build"
+npm run build >/dev/null
+
+# 2. Production node_modules for the TARGET platform. --os=linux --cpu=arm makes npm
+#    resolve optional deps for 32-bit ARM (process.arch === 'arm' on armv7l), not the
+#    host Mac. All our prod deps are pure-JS so this tree runs as-is on the DK2.
+echo "  • npm ci --omit=dev (linux/arm — 32-bit)"
+cp package.json package-lock.json "$STAGE/"
+( cd "$STAGE" && npm ci --omit=dev --os=linux --cpu=arm --ignore-scripts >/dev/null )
+
+# 3. Fetch the glibc linux-armv7l Node runtime. latest-vNN.x always points at the
+#    newest LTS patch, so we never pin a dead URL. (Verified upstream: e.g.
+#    node-v20.20.2-linux-armv7l.tar.xz exists.)
+BASE="https://nodejs.org/dist/latest-v${NODE_MAJOR}.x"
+TARBALL="$(curl -fsSL "$BASE/" | grep -oE "node-v${NODE_MAJOR}\.[0-9]+\.[0-9]+-linux-armv7l\.tar\.xz" | head -1)"
+[ -n "$TARBALL" ] || { echo "‼ could not resolve Node linux-armv7l tarball from $BASE"; exit 1; }
+echo "  • fetching $TARBALL"
+curl -fsSL "$BASE/$TARBALL" -o "$STAGE/node.tar.xz"
+# Verify the runtime against Node's published SHASUMS256 — this binary runs as root
+# under systemd on the board, so a tampered/corrupted download must not slip through.
+echo "  • verifying SHA-256"
+curl -fsSL "$BASE/SHASUMS256.txt" -o "$STAGE/SHASUMS256.txt"
+EXPECTED="$(grep " $TARBALL\$" "$STAGE/SHASUMS256.txt" | awk '{print $1}')"
+[ -n "$EXPECTED" ] || { echo "‼ $TARBALL not found in SHASUMS256.txt"; exit 1; }
+ACTUAL="$(shasum -a 256 "$STAGE/node.tar.xz" | awk '{print $1}')"
+[ "$EXPECTED" = "$ACTUAL" ] || { echo "‼ SHA-256 mismatch for $TARBALL (expected $EXPECTED, got $ACTUAL)"; exit 1; }
+tar -xJf "$STAGE/node.tar.xz" -C "$STAGE"
+NODE_BIN="$STAGE/${TARBALL%.tar.xz}/bin/node"
+[ -x "$NODE_BIN" ] || { echo "‼ node binary not found after extract"; exit 1; }
+
+# 4. Assemble the bundle.
+BUNDLE="$STAGE/bundle"
+mkdir -p "$BUNDLE"
+cp "$NODE_BIN" "$BUNDLE/node"
+cp -R dist "$BUNDLE/dist"
+cp -R "$STAGE/node_modules" "$BUNDLE/node_modules"
+cp package.json "$BUNDLE/package.json"
+printf '%s\n' "$VERSION" >"$BUNDLE/VERSION"
+# Stamp the target arch so install-dk2.sh can sanity-check before starting systemd.
+printf 'linux-armv7l\n' >"$BUNDLE/ARCH"
+
+# 5. Tar it up.
+mkdir -p "$OUT"
+ARCHIVE="$OUT/aastar-dvt-${VERSION}-linux-armv7l.tar.gz"
+tar -czf "$ARCHIVE" -C "$BUNDLE" .
+SIZE="$(du -h "$ARCHIVE" | cut -f1)"
+
+# Node version comes from the tarball name — we CAN'T exec the linux-armv7l binary
+# on the (macOS/x86) build host to ask it.
+NODE_VER="${TARBALL#node-}"; NODE_VER="${NODE_VER%%-linux-armv7l*}"
+echo "✅ $ARCHIVE ($SIZE)"
+echo "   node: $NODE_VER (linux-armv7l/glibc, 32-bit)  |  app: v$VERSION"
+echo "   copy to the DK2, then run deploy/dk2/install-dk2.sh there."

--- a/deploy/dk2/build-bundle-dk2.sh
+++ b/deploy/dk2/build-bundle-dk2.sh
@@ -42,16 +42,28 @@ echo "  • npm ci --omit=dev (linux/arm — 32-bit)"
 cp package.json package-lock.json "$STAGE/"
 ( cd "$STAGE" && npm ci --omit=dev --os=linux --cpu=arm --ignore-scripts >/dev/null )
 
-# 3. Fetch the glibc linux-armv7l Node runtime. latest-vNN.x always points at the
-#    newest LTS patch, so we never pin a dead URL. (Verified upstream: e.g.
-#    node-v20.20.2-linux-armv7l.tar.xz exists.)
-BASE="https://nodejs.org/dist/latest-v${NODE_MAJOR}.x"
-TARBALL="$(curl -fsSL "$BASE/" | grep -oE "node-v${NODE_MAJOR}\.[0-9]+\.[0-9]+-linux-armv7l\.tar\.xz" | head -1)"
-[ -n "$TARBALL" ] || { echo "‼ could not resolve Node linux-armv7l tarball from $BASE"; exit 1; }
+# 3. Fetch the glibc linux-armv7l Node runtime.
+#    - Default: latest-vNN.x → newest LTS patch (never a dead URL), but the exact
+#      version floats, so two builds weeks apart can ship different Node patches.
+#    - Reproducible: pin NODE_VERSION=20.20.2 to lock the exact patch (recommended
+#      for a release bundle / CI — record the pinned version alongside the app tag).
+if [ -n "${NODE_VERSION:-}" ]; then
+  BASE="https://nodejs.org/dist/v${NODE_VERSION}"
+  TARBALL="node-v${NODE_VERSION}-linux-armv7l.tar.xz"
+  echo "  • Node pinned to v${NODE_VERSION} (reproducible)"
+else
+  BASE="https://nodejs.org/dist/latest-v${NODE_MAJOR}.x"
+  TARBALL="$(curl -fsSL "$BASE/" | grep -oE "node-v${NODE_MAJOR}\.[0-9]+\.[0-9]+-linux-armv7l\.tar\.xz" | head -1)"
+  [ -n "$TARBALL" ] || { echo "‼ could not resolve Node linux-armv7l tarball from $BASE"; exit 1; }
+fi
 echo "  • fetching $TARBALL"
 curl -fsSL "$BASE/$TARBALL" -o "$STAGE/node.tar.xz"
 # Verify the runtime against Node's published SHASUMS256 — this binary runs as root
 # under systemd on the board, so a tampered/corrupted download must not slip through.
+# Integrity boundary here is HTTPS + this SHA-256. Note: we do NOT GPG-verify SHASUMS256
+# itself, so this defends against a corrupted/MITM'd tarball but not a full nodejs.org
+# release-signing compromise — pin NODE_VERSION + record the hash for release builds if
+# that threat is in scope.
 echo "  • verifying SHA-256"
 curl -fsSL "$BASE/SHASUMS256.txt" -o "$STAGE/SHASUMS256.txt"
 EXPECTED="$(grep " $TARBALL\$" "$STAGE/SHASUMS256.txt" | awk '{print $1}')"

--- a/deploy/dk2/install-dk2.sh
+++ b/deploy/dk2/install-dk2.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Install / upgrade a DVT-only AAStar node on the STM32MP157F-DK2 (ARMv7, 512 MB).
+# Runs ON THE BOARD. No compiler, no Docker, no firmware change — just unpack a
+# self-contained armv7l bundle (built on your Mac via build-bundle-dk2.sh) and
+# wire up systemd.
+#
+#   ./install-dk2.sh aastar-dvt-1.11.0-linux-armv7l.tar.gz [node2]
+#
+# node2 is the DK2's slot in the AAStar 3-node topology (2-of-3 DVT + 1 KMS; see
+# CC-30 / CC-32). Layout it creates under /opt/aastar-dvt is identical to the i.MX93
+# path (releases/ + current-> + env/ + state/), so upgrade/rollback work the same.
+#
+# Delta vs deploy/imx93/install.sh:
+#   - refuses to start on an arch mismatch (arm64 bundle on armv7 → "Exec format
+#     error" is the #1 DK2 footgun) by exec-checking the bundled node first;
+#   - DVT-only env template (PORT=4002, no RUST_SIGNER_URL — local keystore signing);
+#   - installs this dir's 512 MB-tuned aastar-dvt@.service.
+set -euo pipefail
+
+TARBALL="${1:?usage: install-dk2.sh <bundle-linux-armv7l.tar.gz> [node-id]}"
+NODE_ID="${2:-node2}"
+ROOT="/opt/aastar-dvt"
+UNIT_DIR="/etc/systemd/system"
+
+[ -f "$TARBALL" ] || { echo "‼ bundle not found: $TARBALL"; exit 1; }
+
+# Preflight: rootfs must be writable here. Some hardened images ship a read-only
+# rootfs — then point ROOT at a writable data partition and bind the units.
+for d in "$ROOT" "$UNIT_DIR"; do
+  mkdir -p "$d" 2>/dev/null || { echo "‼ $d not writable — read-only rootfs? use a writable partition"; exit 1; }
+done
+
+SELF="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+mkdir -p "$ROOT/releases" "$ROOT/env" "$ROOT/state/$NODE_ID"
+
+# 1. Unpack the bundle into releases/<VERSION>.
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+tar -xzf "$TARBALL" -C "$TMP"
+VER="$(cat "$TMP/VERSION")"
+
+# 1a. ARCH GUARD (the DK2 footgun): the bundle must be armv7l and its node binary
+#     must actually exec on this board. An arm64 bundle here dies with
+#     "Exec format error" only once systemd tries to start it — catch it now.
+BUNDLE_ARCH="$(cat "$TMP/ARCH" 2>/dev/null || echo unknown)"
+BOARD_ARCH="$(uname -m)"   # DK2 → armv7l
+if [ "$BUNDLE_ARCH" != "linux-armv7l" ]; then
+  echo "‼ bundle arch is '$BUNDLE_ARCH', expected 'linux-armv7l' for the DK2."
+  echo "  Rebuild with deploy/dk2/build-bundle-dk2.sh (NOT the arm64 imx93 build-bundle.sh)."
+  exit 1
+fi
+if ! "$TMP/node" -v >/dev/null 2>&1; then
+  echo "‼ bundled node does not exec on this board (uname -m = $BOARD_ARCH)."
+  echo "  This is the classic arm64-bundle-on-armv7 'Exec format error'. Rebuild for armv7l."
+  exit 1
+fi
+echo "• arch OK: bundle=$BUNDLE_ARCH, board=$BOARD_ARCH, node $("$TMP/node" -v)"
+
+REL="$ROOT/releases/$VER"
+# Stage into a scratch dir on the SAME filesystem, validate the payload, then atomically
+# mv into place. Reinstalling the ACTIVE version must not clobber it if the copy fails
+# — otherwise a bad/partial reinstall takes the running signer down with no rollback.
+STAGE_REL="$ROOT/releases/.stage-$VER.$$"
+rm -rf "$STAGE_REL"; mkdir -p "$STAGE_REL"
+cp -R "$TMP"/. "$STAGE_REL/"
+chmod +x "$STAGE_REL/node"
+{ [ -x "$STAGE_REL/node" ] && [ -f "$STAGE_REL/dist/main.js" ] && [ -d "$STAGE_REL/node_modules" ]; } || {
+  echo "‼ staged release incomplete (missing node/dist/node_modules) — aborting, active release untouched"
+  rm -rf "$STAGE_REL"; exit 1
+}
+[ -e "$REL" ] && { rm -rf "$REL.prev"; mv "$REL" "$REL.prev"; }
+mv "$STAGE_REL" "$REL"
+echo "• unpacked v$VER → $REL"
+
+# 2. Atomic switch: current -> this release (rollback = repoint at releases/<old> + restart).
+ln -sfn "$REL" "$ROOT/current"
+echo "• current → v$VER"
+
+# 3. Seed per-node env + state if absent (never overwrite existing secrets/config).
+ENVF="$ROOT/env/$NODE_ID.env"
+if [ ! -f "$ENVF" ]; then
+  cat >"$ENVF" <<EOF
+# AAStar DVT — $NODE_ID (DK2, DVT-only). Fill these in.
+PORT=4002
+ETH_RPC_URL=
+# v1.9.0+ authoritative Sepolia validator (deploy/sdk-dvt-config.testnet.json):
+VALIDATOR_CONTRACT_ADDRESS=0x539B9681aFd5BFbCaa655Fe4c6BdcFe1fa7864bC
+ENTRY_POINT_ADDRESS=0x0000000071727De22E5E9d8BAf0edAc6f37da032
+# DVT-only: this node signs with its OWN local BLS key (state/$NODE_ID/node_state.json).
+# Do NOT set RUST_SIGNER_URL — that is only for the KMS-TEE co-located node (node1).
+# Optional capabilities (need their OWN funded keys — keep separate from the BLS key):
+# RELAY_ENABLED=false
+# RELAY_OPERATOR_PK=
+# KEEPER_ENABLED=false
+# KEEPER_PRIVATE_KEY=
+EOF
+  chmod 600 "$ENVF"
+  echo "• wrote env template → $ENVF  (EDIT IT before starting: set ETH_RPC_URL)"
+fi
+STATEF="$ROOT/state/$NODE_ID/node_state.json"
+# Lock down the state dir; if a key is already present (e.g. scp'd from a Mac at 0644),
+# tighten it — this file is a raw BLS private key and must never be world-readable.
+chmod 700 "$ROOT/state/$NODE_ID" 2>/dev/null || true
+if [ -f "$STATEF" ]; then
+  chmod 600 "$STATEF" 2>/dev/null || true
+else
+  # The bundle ships only node/dist/node_modules — NOT scripts/ — so gen-node-state.mjs
+  # is not runnable on the board. Generate on your Mac (repo has the script) and scp it in.
+  echo "⚠ missing $STATEF — this node's OWN BLS key."
+  echo "  On your Mac (in the repo): node scripts/gen-node-state.mjs"
+  echo "  then: scp node_state.json root@<board>:$STATEF   (chmod 600 — never reuse a repo/test key)"
+fi
+
+# 4. Install systemd units (idempotent) — this dir's 512 MB-tuned service + health.
+cp "$SELF/aastar-dvt@.service" "$SELF/aastar-dvt-health@.service" "$SELF/aastar-dvt-health@.timer" "$UNIT_DIR/"
+chmod 600 "$ENVF" 2>/dev/null || true
+systemctl daemon-reload
+echo "• installed systemd units (MemoryMax=320M, --max-old-space-size=256)"
+
+# 5. Enable for boot. Only START when actually configured — starting with an empty
+#    ETH_RPC_URL (config validation throws) or a missing node_state.json (node.service
+#    errors on boot) would just crash-loop until StartLimitBurst trips, which on a
+#    headless board reads as "install failed". So gate the start on both being present;
+#    on a first provision we enable + print the next steps instead of thrashing systemd.
+systemctl enable "aastar-dvt@$NODE_ID.service" "aastar-dvt-health@$NODE_ID.timer" >/dev/null 2>&1 || true
+
+# Read env values with sed (not `grep | cut`): a missing key makes grep exit 1, which
+# under `set -o pipefail` would abort the installer before the helpful branch below.
+# sed prints nothing and exits 0 for an absent key.
+env_val() { sed -n "s/^$1=//p" "$ENVF" | tail -n1; }
+RPC_VAL="$(env_val ETH_RPC_URL)"
+VALIDATOR_VAL="$(env_val VALIDATOR_CONTRACT_ADDRESS)"
+PORT_VAL="$(env_val PORT)"
+
+# App startup (config/configuration.ts) throws without BOTH ETH_RPC_URL and
+# VALIDATOR_CONTRACT_ADDRESS, and node.service errors without node_state.json. Only
+# start when all three are present — otherwise enable-for-boot and print what's missing.
+if [ -n "$RPC_VAL" ] && [ -n "$VALIDATOR_VAL" ] && [ -f "$STATEF" ]; then
+  systemctl restart "aastar-dvt@$NODE_ID.service"
+  systemctl restart "aastar-dvt-health@$NODE_ID.timer"
+  echo ""
+  echo "✅ v$VER active for $NODE_ID (DK2 armv7, DVT-only)"
+  echo "   systemctl status aastar-dvt@$NODE_ID"
+  echo "   journalctl -u aastar-dvt@$NODE_ID -f"
+  echo "   curl -s http://127.0.0.1:${PORT_VAL:-4002}/health   # {version:\"$VER\",...}"
+else
+  echo ""
+  echo "✅ v$VER installed + enabled for boot — NOT started yet (needs config):"
+  [ -z "$RPC_VAL" ]       && echo "   • set ETH_RPC_URL in $ENVF"
+  [ -z "$VALIDATOR_VAL" ] && echo "   • set VALIDATOR_CONTRACT_ADDRESS in $ENVF"
+  [ ! -f "$STATEF" ]      && echo "   • put this node's BLS key at $STATEF (see the ⚠ above)"
+  echo "   then start:  systemctl start aastar-dvt@$NODE_ID aastar-dvt-health@$NODE_ID.timer"
+  echo "   verify:      curl -s http://127.0.0.1:${PORT_VAL:-4002}/health"
+fi

--- a/deploy/dk2/install-dk2.sh
+++ b/deploy/dk2/install-dk2.sh
@@ -115,7 +115,7 @@ fi
 cp "$SELF/aastar-dvt@.service" "$SELF/aastar-dvt-health@.service" "$SELF/aastar-dvt-health@.timer" "$UNIT_DIR/"
 chmod 600 "$ENVF" 2>/dev/null || true
 systemctl daemon-reload
-echo "• installed systemd units (MemoryMax=320M, --max-old-space-size=256)"
+echo "• installed systemd units (MemoryMax=320M, --max-old-space-size=224)"
 
 # 5. Enable for boot. Only START when actually configured — starting with an empty
 #    ETH_RPC_URL (config validation throws) or a missing node_state.json (node.service
@@ -132,22 +132,25 @@ RPC_VAL="$(env_val ETH_RPC_URL)"
 VALIDATOR_VAL="$(env_val VALIDATOR_CONTRACT_ADDRESS)"
 PORT_VAL="$(env_val PORT)"
 
-# App startup (config/configuration.ts) throws without BOTH ETH_RPC_URL and
-# VALIDATOR_CONTRACT_ADDRESS, and node.service errors without node_state.json. Only
-# start when all three are present — otherwise enable-for-boot and print what's missing.
-if [ -n "$RPC_VAL" ] && [ -n "$VALIDATOR_VAL" ] && [ -f "$STATEF" ]; then
+# App startup (config/configuration.ts) throws without ETH_RPC_URL /
+# VALIDATOR_CONTRACT_ADDRESS, node.service errors without node_state.json, and an empty
+# PORT makes the app fall back to :3000 while the health probe expects 4002 (30s restart
+# storm). Only start when all four are present — otherwise enable-for-boot and print what's
+# missing.
+if [ -n "$RPC_VAL" ] && [ -n "$VALIDATOR_VAL" ] && [ -n "$PORT_VAL" ] && [ -f "$STATEF" ]; then
   systemctl restart "aastar-dvt@$NODE_ID.service"
   systemctl restart "aastar-dvt-health@$NODE_ID.timer"
   echo ""
   echo "✅ v$VER active for $NODE_ID (DK2 armv7, DVT-only)"
   echo "   systemctl status aastar-dvt@$NODE_ID"
   echo "   journalctl -u aastar-dvt@$NODE_ID -f"
-  echo "   curl -s http://127.0.0.1:${PORT_VAL:-4002}/health   # {version:\"$VER\",...}"
+  echo "   curl -s http://127.0.0.1:${PORT_VAL}/health   # {version:\"$VER\",...}"
 else
   echo ""
   echo "✅ v$VER installed + enabled for boot — NOT started yet (needs config):"
   [ -z "$RPC_VAL" ]       && echo "   • set ETH_RPC_URL in $ENVF"
   [ -z "$VALIDATOR_VAL" ] && echo "   • set VALIDATOR_CONTRACT_ADDRESS in $ENVF"
+  [ -z "$PORT_VAL" ]      && echo "   • set PORT in $ENVF (probe + app must agree)"
   [ ! -f "$STATEF" ]      && echo "   • put this node's BLS key at $STATEF (see the ⚠ above)"
   echo "   then start:  systemctl start aastar-dvt@$NODE_ID aastar-dvt-health@$NODE_ID.timer"
   echo "   verify:      curl -s http://127.0.0.1:${PORT_VAL:-4002}/health"

--- a/deploy/imx93/aastar-dvt-health@.service
+++ b/deploy/imx93/aastar-dvt-health@.service
@@ -10,4 +10,6 @@ Type=oneshot
 EnvironmentFile=/opt/aastar-dvt/env/%i.env
 # curl the node's own /health; on failure (non-2xx / refused / timeout) restart it.
 # --max-time guards against the probe itself hanging on a stuck socket.
-ExecStart=/bin/sh -c 'curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/health" >/dev/null || { echo "aastar-dvt@%i unhealthy — restarting"; systemctl restart aastar-dvt@%i.service; }'
+# ${PORT:-4001}: an empty PORT must not build a malformed URL (http://127.0.0.1:/health)
+# and restart-storm every 30s — fall back to the imx93 default.
+ExecStart=/bin/sh -c 'curl -fsS --max-time 5 "http://127.0.0.1:${PORT:-4001}/health" >/dev/null || { echo "aastar-dvt@%i unhealthy — restarting"; systemctl restart aastar-dvt@%i.service; }'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "yetanotheraa-validator",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yetanotheraa-validator",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
-        "@nestjs/cli": "^11.0.23",
         "@nestjs/common": "^11.1.27",
         "@nestjs/config": "^4.0.4",
         "@nestjs/core": "^11.1.27",
@@ -17,9 +16,6 @@
         "@nestjs/swagger": "^11.4.5",
         "@noble/curves": "^2.2.0",
         "@noble/hashes": "^2.2.0",
-        "@types/node": "^26.1.0",
-        "@types/uuid": "^11.0.0",
-        "@types/ws": "^8.18.1",
         "axios": "^1.18.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
@@ -27,23 +23,27 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",
         "swagger-ui-express": "^5.0.1",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.9.2",
         "uuid": "^14.0.1",
         "ws": "^8.21.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@jest/globals": "^30.4.1",
+        "@nestjs/cli": "^11.0.23",
         "@types/express": "^5.0.6",
         "@types/jest": "^30.0.0",
+        "@types/node": "^26.1.0",
+        "@types/uuid": "^11.0.0",
+        "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^8.63.0",
         "@typescript-eslint/parser": "^8.62.1",
         "eslint": "^10.6.0",
         "jest": "^30.4.2",
         "prettier": "^3.9.4",
         "prettier-plugin-solidity": "^2.3.1",
-        "ts-jest": "^29.4.11"
+        "ts-jest": "^29.4.11",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.9.2"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -56,6 +56,7 @@
       "version": "19.2.27",
       "resolved": "https://registry.npmmirror.com/@angular-devkit/core/-/core-19.2.27.tgz",
       "integrity": "sha512-3amNzoCVSKd7ah6l6lBQL4onwwJvqvam7FMoQBILrxtW5LB5ezh8gMSPuA4zJjKjoRzf9uoWdlzqv/84I52xZA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "8.18.0",
@@ -83,6 +84,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmmirror.com/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -99,6 +101,7 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmmirror.com/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -108,6 +111,7 @@
       "version": "19.2.27",
       "resolved": "https://registry.npmmirror.com/@angular-devkit/schematics/-/schematics-19.2.27.tgz",
       "integrity": "sha512-/PZmyAlb2NGWPikRRuiWLdfHQd8Wrx6lX4HqvTcaDhlU43M3T0ud4PH2T3QDp7BzHYY92xtD8iPxX2asg67G1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/core": "19.2.27",
@@ -126,6 +130,7 @@
       "version": "19.2.27",
       "resolved": "https://registry.npmmirror.com/@angular-devkit/schematics-cli/-/schematics-cli-19.2.27.tgz",
       "integrity": "sha512-wHYH6SVXVykhLzovUHtYor3Nl4SpIiITi7r9DQDaKYUD4hpRBx25W6N9eGuakT9Vd5tV/x6wmvQFWQZQwFB7eA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/core": "19.2.27",
@@ -148,6 +153,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmmirror.com/@inquirer/prompts/-/prompts-7.3.2.tgz",
       "integrity": "sha512-G1ytyOoHh5BphmEBxSwALin3n1KGNYB6yImbICcRQdzXfOGbuJ9Jske/Of5Sebk339NSGGNfUshnzK8YWkTPsQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/checkbox": "^4.1.2",
@@ -177,6 +183,7 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmmirror.com/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -186,6 +193,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -378,6 +386,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
       "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -738,6 +747,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -748,6 +758,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -1000,6 +1011,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
       "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1009,6 +1021,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
       "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
@@ -1033,6 +1046,7 @@
       "version": "5.1.21",
       "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
       "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -1054,6 +1068,7 @@
       "version": "10.3.2",
       "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
       "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
@@ -1081,6 +1096,7 @@
       "version": "4.2.23",
       "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
       "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -1103,6 +1119,7 @@
       "version": "4.0.23",
       "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
       "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -1125,6 +1142,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
       "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chardet": "^2.1.1",
@@ -1146,6 +1164,7 @@
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
       "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1155,6 +1174,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
       "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -1176,6 +1196,7 @@
       "version": "3.0.23",
       "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
       "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -1197,6 +1218,7 @@
       "version": "4.0.23",
       "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
       "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
@@ -1219,6 +1241,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
       "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/checkbox": "^4.3.2",
@@ -1248,6 +1271,7 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
       "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -1270,6 +1294,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
       "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -1293,6 +1318,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
       "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
@@ -1317,6 +1343,7 @@
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
       "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1932,6 +1959,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1942,6 +1970,7 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1974,6 +2003,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1983,6 +2013,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1993,6 +2024,7 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2003,12 +2035,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -2053,6 +2087,7 @@
       "version": "11.0.23",
       "resolved": "https://registry.npmmirror.com/@nestjs/cli/-/cli-11.0.23.tgz",
       "integrity": "sha512-2V0Bf5jz0KXhUZk3eJi9GljIyqH04otwsE/mYLbqJR+X0iiYx+6bkNJ2Qz28uHNFj1cpHgimf9xDzHkqarie0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/core": "19.2.27",
@@ -2097,6 +2132,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmmirror.com/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2106,6 +2142,7 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-5.0.6.tgz",
       "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2118,6 +2155,7 @@
       "version": "13.0.6",
       "resolved": "https://registry.npmmirror.com/glob/-/glob-13.0.6.tgz",
       "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "minimatch": "^10.2.2",
@@ -2135,6 +2173,7 @@
       "version": "11.5.1",
       "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-11.5.1.tgz",
       "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -2144,6 +2183,7 @@
       "version": "10.2.5",
       "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -2159,6 +2199,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmmirror.com/path-scurry/-/path-scurry-2.0.2.tgz",
       "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -2301,6 +2342,7 @@
       "version": "11.0.9",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.9.tgz",
       "integrity": "sha512-0NfPbPlEaGwIT8/TCThxLzrlz3yzDNkfRNpbL7FiplKq3w4qXpJg0JYwqgMEJnLQZm3L/L/5XjoyfJHUO3qX9g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/core": "19.2.17",
@@ -2317,6 +2359,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.17.tgz",
       "integrity": "sha512-Ah008x2RJkd0F+NLKqIpA34/vUGwjlprRCkvddjDopAWRzYn6xCkz1Tqwuhn0nR1Dy47wTLKYD999TYl5ONOAQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "8.17.1",
@@ -2344,6 +2387,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.17.tgz",
       "integrity": "sha512-ADfbaBsrG8mBF6Mfs+crKA/2ykB8AJI50Cv9tKmZfwcUcyAdmTr+vVvhsBCfvUAEokigSsgqgpYxfkJVxhJYeg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/core": "19.2.17",
@@ -2362,6 +2406,7 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -2529,24 +2574,28 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
       "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -2630,6 +2679,7 @@
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "*",
@@ -2640,6 +2690,7 @@
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
       "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/eslint": "*",
@@ -2657,6 +2708,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/express": {
@@ -2733,12 +2785,14 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
       "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -2791,6 +2845,7 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
       "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
       "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "uuid": "*"
@@ -2806,6 +2861,7 @@
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -3424,6 +3480,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
       "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
@@ -3434,24 +3491,28 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
       "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
       "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
       "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
       "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
@@ -3463,12 +3524,14 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
       "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
       "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -3481,6 +3544,7 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
       "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
@@ -3490,6 +3554,7 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
       "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@xtuc/long": "4.2.2"
@@ -3499,12 +3564,14 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
       "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
       "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -3521,6 +3588,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
       "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -3534,6 +3602,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
       "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -3546,6 +3615,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
       "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -3560,6 +3630,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
       "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -3570,12 +3641,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/accepts": {
@@ -3595,6 +3668,7 @@
       "version": "8.17.0",
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3607,6 +3681,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
@@ -3629,6 +3704,7 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -3659,6 +3735,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3675,6 +3752,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -3692,6 +3770,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
@@ -3704,6 +3783,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmmirror.com/ansi-colors/-/ansi-colors-4.1.3.tgz",
       "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3742,6 +3822,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3757,6 +3838,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
       "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -3786,6 +3868,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -3798,6 +3881,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
       "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/asynckit": {
@@ -3921,12 +4005,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3947,6 +4033,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
       "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -3959,6 +4046,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -4004,6 +4092,7 @@
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4060,6 +4149,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4139,6 +4229,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4158,6 +4249,7 @@
       "version": "1.0.30001776",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001776.tgz",
       "integrity": "sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4178,6 +4270,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4204,12 +4297,14 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -4225,6 +4320,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
@@ -4274,6 +4370,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^3.1.0"
@@ -4286,6 +4383,7 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4298,6 +4396,7 @@
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
       "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "string-width": "^4.2.0"
@@ -4313,6 +4412,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
       "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 12"
@@ -4378,6 +4478,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
@@ -4405,6 +4506,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4417,6 +4519,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -4435,6 +4538,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4444,6 +4548,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.4.1.tgz",
       "integrity": "sha512-r1To31BQD5060QdkC+Iheai7gHwoSZobzunqkf2/kQ6xIAfJyrKNAFUwdKvkK7Qgu7pVTKQEa7ok7Ed3ycAJgg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-timsort": "^1.0.3",
@@ -4458,6 +4563,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -4525,6 +4631,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -4548,6 +4655,7 @@
       "version": "8.3.6",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
       "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "import-fresh": "^3.3.0",
@@ -4574,6 +4682,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -4634,6 +4743,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4643,6 +4753,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
       "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone": "^1.0.2"
@@ -4683,6 +4794,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
       "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -4758,6 +4870,7 @@
       "version": "1.5.307",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
       "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -4777,6 +4890,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -4792,6 +4906,7 @@
       "version": "5.24.1",
       "resolved": "https://registry.npmmirror.com/enhanced-resolve/-/enhanced-resolve-5.24.1.tgz",
       "integrity": "sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -4805,6 +4920,7 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -4832,6 +4948,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -4865,6 +4982,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5101,6 +5219,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -5127,6 +5246,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -5139,6 +5259,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -5240,6 +5361,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
@@ -5351,12 +5473,14 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -5376,6 +5500,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/fast-uri/-/fast-uri-4.0.0.tgz",
       "integrity": "sha512-l90y339r2DkZs/ldcWQXcwTjkbp/NbuJDGYoQ3awBgaT3GXOFkm3OkVpz6Z86TywYcya0eVP2r1kTV90f3krGQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5543,6 +5668,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-9.1.0.tgz",
       "integrity": "sha512-mpafl89VFPJmhnJ1ssH+8wmM2b50n+Rew5x42NeI2U78aRWgtkEtGmctp7iT16UjquJTjorEmIfESj3DxdW84Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.16.7",
@@ -5570,6 +5696,7 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5580,6 +5707,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -5647,6 +5775,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -5661,6 +5790,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.1.0.tgz",
       "integrity": "sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==",
+      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/fs.realpath": {
@@ -5813,6 +5943,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmmirror.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/gopd": {
@@ -5831,6 +5962,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/handlebars": {
@@ -5869,6 +6001,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6013,6 +6146,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -6086,6 +6220,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-extglob": {
@@ -6102,6 +6237,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6134,6 +6270,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6162,6 +6299,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -6932,6 +7070,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -6946,6 +7085,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -6961,6 +7101,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -7009,12 +7150,14 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -7028,6 +7171,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -7040,12 +7184,14 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -7098,6 +7244,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/load-esm": {
@@ -7123,6 +7270,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
       "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
@@ -7165,6 +7313,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
@@ -7188,6 +7337,7 @@
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
       "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
@@ -7213,6 +7363,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
@@ -7247,6 +7398,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
       "integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
+      "dev": true,
       "license": "Unlicense",
       "dependencies": {
         "fs-monkey": "^1.0.4"
@@ -7271,6 +7423,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mime-db": {
@@ -7298,6 +7451,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7323,6 +7477,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7332,6 +7487,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmmirror.com/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -7409,6 +7565,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
       "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -7450,18 +7607,21 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-emoji": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"
@@ -7478,6 +7638,7 @@
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-path": {
@@ -7549,6 +7710,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -7582,6 +7744,7 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
       "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bl": "^4.1.0",
@@ -7605,6 +7768,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7614,6 +7778,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7675,6 +7840,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -7687,6 +7853,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -7771,6 +7938,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7780,12 +7948,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7877,6 +8047,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7981,6 +8152,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8076,6 +8248,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -8105,6 +8278,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8137,6 +8311,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -8146,6 +8321,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "onetime": "^5.1.0",
@@ -8159,6 +8335,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/router": {
@@ -8216,6 +8393,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
       "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.8",
@@ -8234,6 +8412,7 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -8250,6 +8429,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "ajv": "^6.9.1"
@@ -8259,12 +8439,14 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmmirror.com/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8415,6 +8597,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -8437,6 +8620,7 @@
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
       "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 8"
@@ -8446,6 +8630,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -8456,6 +8641,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -8558,6 +8744,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -8611,6 +8798,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8620,6 +8808,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -8672,6 +8861,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -8720,6 +8910,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -8756,6 +8947,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/symbol-observable/-/symbol-observable-4.0.0.tgz",
       "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
@@ -8781,6 +8973,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmmirror.com/tapable/-/tapable-2.3.3.tgz",
       "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8794,6 +8987,7 @@
       "version": "5.46.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
       "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -8812,6 +9006,7 @@
       "version": "5.3.17",
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.17.tgz",
       "integrity": "sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
@@ -8845,6 +9040,7 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -8855,6 +9051,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -8872,6 +9069,7 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
@@ -8891,6 +9089,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/test-exclude": {
@@ -9088,6 +9287,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -9131,6 +9331,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
       "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json5": "^2.2.2",
@@ -9145,6 +9346,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz",
       "integrity": "sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
@@ -9222,6 +9424,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -9273,12 +9476,14 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -9335,6 +9540,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9365,6 +9571,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -9393,6 +9600,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -9453,6 +9661,7 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmmirror.com/watchpack/-/watchpack-2.5.2.tgz",
       "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2"
@@ -9465,6 +9674,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
@@ -9474,6 +9684,7 @@
       "version": "5.106.2",
       "resolved": "https://registry.npmmirror.com/webpack/-/webpack-5.106.2.tgz",
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
@@ -9521,6 +9732,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz",
       "integrity": "sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9530,6 +9742,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmmirror.com/webpack-sources/-/webpack-sources-3.5.0.tgz",
       "integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
@@ -9539,6 +9752,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -9556,6 +9770,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -9569,6 +9784,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -9578,6 +9794,7 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
@@ -9630,6 +9847,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -9686,6 +9904,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9695,6 +9914,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -9784,6 +10004,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -9793,6 +10014,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9815,6 +10037,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
       "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "release:patch": "npm version patch --no-git-tag-version && npm run build && echo '✅ Bumped to '$(jq -r .version package.json)"
   },
   "dependencies": {
-    "@nestjs/cli": "^11.0.23",
     "@nestjs/common": "^11.1.27",
     "@nestjs/config": "^4.0.4",
     "@nestjs/core": "^11.1.27",
@@ -43,9 +42,6 @@
     "@nestjs/swagger": "^11.4.5",
     "@noble/curves": "^2.2.0",
     "@noble/hashes": "^2.2.0",
-    "@types/node": "^26.1.0",
-    "@types/uuid": "^11.0.0",
-    "@types/ws": "^8.18.1",
     "axios": "^1.18.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
@@ -53,8 +49,6 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
     "swagger-ui-express": "^5.0.1",
-    "ts-node": "^10.9.2",
-    "typescript": "^5.9.2",
     "uuid": "^14.0.1",
     "ws": "^8.21.0"
   },
@@ -86,14 +80,20 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@jest/globals": "^30.4.1",
+    "@nestjs/cli": "^11.0.23",
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",
+    "@types/node": "^26.1.0",
+    "@types/uuid": "^11.0.0",
+    "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^8.63.0",
     "@typescript-eslint/parser": "^8.62.1",
     "eslint": "^10.6.0",
     "jest": "^30.4.2",
     "prettier": "^3.9.4",
     "prettier-plugin-solidity": "^2.3.1",
-    "ts-jest": "^29.4.11"
+    "ts-jest": "^29.4.11",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.2"
   }
 }


### PR DESCRIPTION
## What

`deploy/dk2/` — a self-contained deployment path for **node2** in the AAStar 3-node production topology (2-of-3 DVT + 1 KMS; CC-30 / CC-32). The DK2 is **STM32MP157F — 32-bit ARMv7-A, 512 MB, DVT-only** (no KMS co-located), a different arch + a quarter of the RAM vs the existing `deploy/imx93` (arm64/2 GB) path.

Two hard blockers made imx93 unusable as-is, both handled here:
1. an arm64 Node binary gives **`Exec format error`** on armv7 → the bundle is cross-packaged for `linux-armv7l` and `install-dk2.sh` arch-guards it before systemd ever runs it;
2. 512 MB can't spare what an on-board `npm run build` peaks at → we **cross-build on Mac/CI**, the board only unpacks.

## Files (thin delta over `deploy/imx93/`)

| file | role |
|---|---|
| `build-bundle-dk2.sh` | Mac/CI: cross-package `linux-armv7l` bundle (`npm --cpu=arm`, glibc Node 20 + SHASUMS256 verify) |
| `install-dk2.sh` | board: arch-guard → stage+atomic-swap release → seed DVT-only env → lock key perms → enable, start only when configured |
| `aastar-dvt@.service` | 512 MB-tuned unit: `MemoryMax=320M` + `--max-old-space-size=256` (only delta vs imx93) |
| `aastar-dvt-health@.{service,timer}` | self-heal probe (imx93 copies, self-contained) |
| `README.md` | build → install → provision key → start → verify; armv7/512 MB caveats; WiFi/serial |

## Verification

- **Cross-package build ran end-to-end** (twice): produces a 64M bundle whose `node` is confirmed `ELF 32-bit LSB executable, ARM`; SHA-256 verify against Node's `SHASUMS256.txt` passes.
- `bash -n` clean on both scripts; `env_val` unit-tested under `set -euo pipefail` (absent key → empty, no abort).
- Board-side `install-dk2.sh` (systemctl/root paths) not runnable off-board — devices arrive shortly; the arch guard reads the verified `ARCH=linux-armv7l` stamp + exec-checks node.

## Review rounds

- **Self-adversarial**: fixed premature auto-start crash-loop on first provision; fixed a broken on-board key-gen hint (bundle ships no `scripts/`).
- **Codex adversarial**: fixed BLS key/dir perms not enforced (High); start-gate missing `VALIDATOR_CONTRACT_ADDRESS` + `grep|cut` pipefail abort (Med); non-atomic same-version reinstall clobbering `current` (Med); README key-copy-before-dir-exists ordering (Med); Node runtime checksum (Low).

Validator/entrypoint pre-filled to the v1.9.0+ authoritative Sepolia values; `deploy/sdk-dvt-config.testnet.json` stays the single source of truth.

Closes the DVT side of CC-32.

https://claude.ai/code/session_01JrdmiUk4A258FmhDSKn9aj