### PR TITLE
docs: test→prod switch runbook + KMS-TEE keeper ECDSA signing proposal

### DIFF
--- a/deploy/TESTNET-TO-MAINNET.md
+++ b/deploy/TESTNET-TO-MAINNET.md
@@ -2,32 +2,33 @@
 
 > Principle (confirmed against code): **KMS has no on-chain dependency; the DVT
 > carries the chain dependencies.** So a network switch is a DVT-config change —
-> **plus one external-dependency action the config alone can't do: registering the
-> node's BLS pubkey on the target network's validator.** Code is identical across
-> networks (`configuration.ts` just reads different env); see CLAUDE.md.
+> **plus one external-dependency action the config alone can't do: registering
+> the node's BLS pubkey on the target network's validator.** Code is identical
+> across networks (`configuration.ts` just reads different env); see CLAUDE.md.
 
 ## What actually differs between networks (the only things to change)
 
-| Knob | Where | Note |
-|---|---|---|
-| `ETH_RPC_URL` | `dvt.env` | target network RPC |
-| `VALIDATOR_CONTRACT_ADDRESS` | `dvt.env` | **authoritative source = `deploy/sdk-dvt-config.testnet.json` → `environments[active].validator`** (this repo owns the `AAStarValidator`; that file declares itself the single source of truth). Testnet today = `0x539B9681aFd5BFbCaa655Fe4c6BdcFe1fa7864bC` (Plan A v3, LIVE on Sepolia). |
-| `ENTRY_POINT_ADDRESS` | `dvt.env` | canonical v0.7 `0x0000000071727De22E5E9d8BAf0edAc6f37da032` (same both nets) |
-| BLS key registration | **on-chain** | `registerPublicKey(nodeId, pubkey)` on the **target** validator — see step 3 |
+| Knob                         | Where        | Note                                                                                                                                                                                                                                                                                        |
+| ---------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ETH_RPC_URL`                | `dvt.env`    | target network RPC                                                                                                                                                                                                                                                                          |
+| `VALIDATOR_CONTRACT_ADDRESS` | `dvt.env`    | **authoritative source = `deploy/sdk-dvt-config.testnet.json` → `environments[active].validator`** (this repo owns the `AAStarValidator`; that file declares itself the single source of truth). Testnet today = `0x539B9681aFd5BFbCaa655Fe4c6BdcFe1fa7864bC` (Plan A v3, LIVE on Sepolia). |
+| `ENTRY_POINT_ADDRESS`        | `dvt.env`    | canonical v0.7 `0x0000000071727De22E5E9d8BAf0edAc6f37da032` (same both nets)                                                                                                                                                                                                                |
+| BLS key registration         | **on-chain** | `registerPublicKey(nodeId, pubkey)` on the **target** validator — see step 3                                                                                                                                                                                                                |
 
 Everything else (the app, node_modules, systemd) is byte-identical.
 
 ## Steps
 
 1. **Confirm the target validator address.** It is DVT-owned; read it from
-   `deploy/sdk-dvt-config.testnet.json` (flip `active` for mainnet once deployed).
-   Cross-repo coupling to watch: the validator is mounted in airaccount's
-   `ValidatorRouter 0xe68d6A7Bb60DA4caE62ceC2439722fc5eEF87a5c` — a validator
-   redeploy means airaccount re-mounts it. If it ever changes, update that file
-   (single source) and notify consumers (SDK `aastar-sdk#274`, KMS, this board).
+   `deploy/sdk-dvt-config.testnet.json` (flip `active` for mainnet once
+   deployed). Cross-repo coupling to watch: the validator is mounted in
+   airaccount's `ValidatorRouter 0xe68d6A7Bb60DA4caE62ceC2439722fc5eEF87a5c` — a
+   validator redeploy means airaccount re-mounts it. If it ever changes, update
+   that file (single source) and notify consumers (SDK `aastar-sdk#274`, KMS,
+   this board).
 
-2. **Point the node at the target network** — edit `dvt.env`:
-   `ETH_RPC_URL`, `VALIDATOR_CONTRACT_ADDRESS`, `ENTRY_POINT_ADDRESS`. No code change.
+2. **Point the node at the target network** — edit `dvt.env`: `ETH_RPC_URL`,
+   `VALIDATOR_CONTRACT_ADDRESS`, `ENTRY_POINT_ADDRESS`. No code change.
 
 3. **Register this node's BLS pubkey on the target validator** (one-time, per
    network — the config switch can't do this). Needs `ETH_PRIVATE_KEY` (operator
@@ -37,7 +38,8 @@ Everything else (the app, node_modules, systemd) is byte-identical.
 
 4. **Restart + verify.** `systemctl restart dvt` → `curl /health` (version) →
    `curl /node/info` (pubkey) → a co-sign E2E that ends in
-   `AAStarValidator.validate === 0` on the target net (see COMMUNITY_OPERATORS.md).
+   `AAStarValidator.validate === 0` on the target net (see
+   COMMUNITY_OPERATORS.md).
 
 ## KMS side (for contrast — no chain action)
 
@@ -51,7 +53,7 @@ AirAccount/KMS repo, not here.
   (`RUST_SIGNER_URL` + `RUST_SIGNER_REQUIRED=true`, key-less `node_state.json` —
   needs DVT ≥ v1.10.0). KMS-TEE is required for unattended power-on (no tmpfs
   passphrase to re-enter).
-- **Operator/keeper ECDSA key** (`ETH_PRIVATE_KEY` / `KEEPER_PRIVATE_KEY`): today
-  a plaintext `.env` EOA — **KMS-TEE custody of the BLS key does NOT protect it**.
-  Routing it through KMS's secp256k1 signer is a separate feature (see
-  `docs/KEEPER-KMS-SIGNING.md` proposal).
+- **Operator/keeper ECDSA key** (`ETH_PRIVATE_KEY` / `KEEPER_PRIVATE_KEY`):
+  today a plaintext `.env` EOA — **KMS-TEE custody of the BLS key does NOT
+  protect it**. Routing it through KMS's secp256k1 signer is a separate feature
+  (see `docs/KEEPER-KMS-SIGNING.md` proposal).

--- a/deploy/TESTNET-TO-MAINNET.md
+++ b/deploy/TESTNET-TO-MAINNET.md
@@ -1,0 +1,57 @@
+# DVT test → prod (testnet → mainnet) switch — runbook
+
+> Principle (confirmed against code): **KMS has no on-chain dependency; the DVT
+> carries the chain dependencies.** So a network switch is a DVT-config change —
+> **plus one external-dependency action the config alone can't do: registering the
+> node's BLS pubkey on the target network's validator.** Code is identical across
+> networks (`configuration.ts` just reads different env); see CLAUDE.md.
+
+## What actually differs between networks (the only things to change)
+
+| Knob | Where | Note |
+|---|---|---|
+| `ETH_RPC_URL` | `dvt.env` | target network RPC |
+| `VALIDATOR_CONTRACT_ADDRESS` | `dvt.env` | **authoritative source = `deploy/sdk-dvt-config.testnet.json` → `environments[active].validator`** (this repo owns the `AAStarValidator`; that file declares itself the single source of truth). Testnet today = `0x539B9681aFd5BFbCaa655Fe4c6BdcFe1fa7864bC` (Plan A v3, LIVE on Sepolia). |
+| `ENTRY_POINT_ADDRESS` | `dvt.env` | canonical v0.7 `0x0000000071727De22E5E9d8BAf0edAc6f37da032` (same both nets) |
+| BLS key registration | **on-chain** | `registerPublicKey(nodeId, pubkey)` on the **target** validator — see step 3 |
+
+Everything else (the app, node_modules, systemd) is byte-identical.
+
+## Steps
+
+1. **Confirm the target validator address.** It is DVT-owned; read it from
+   `deploy/sdk-dvt-config.testnet.json` (flip `active` for mainnet once deployed).
+   Cross-repo coupling to watch: the validator is mounted in airaccount's
+   `ValidatorRouter 0xe68d6A7Bb60DA4caE62ceC2439722fc5eEF87a5c` — a validator
+   redeploy means airaccount re-mounts it. If it ever changes, update that file
+   (single source) and notify consumers (SDK `aastar-sdk#274`, KMS, this board).
+
+2. **Point the node at the target network** — edit `dvt.env`:
+   `ETH_RPC_URL`, `VALIDATOR_CONTRACT_ADDRESS`, `ENTRY_POINT_ADDRESS`. No code change.
+
+3. **Register this node's BLS pubkey on the target validator** (one-time, per
+   network — the config switch can't do this). Needs `ETH_PRIVATE_KEY` (operator
+   EOA, funded on the target net) → `POST /node/register` (calls
+   `blockchain.service.ts registerPublicKey`). Skip only if the same pubkey is
+   already registered there.
+
+4. **Restart + verify.** `systemctl restart dvt` → `curl /health` (version) →
+   `curl /node/info` (pubkey) → a co-sign E2E that ends in
+   `AAStarValidator.validate === 0` on the target net (see COMMUNITY_OPERATORS.md).
+
+## KMS side (for contrast — no chain action)
+
+KMS switch = rpId/Origin + production build only (remove passkey-export +
+localhost-rpid-accept). No RPC, no contract, no registration. Owned by the
+AirAccount/KMS repo, not here.
+
+## Signing-key custody (orthogonal to the network switch)
+
+- **BLS key** (co-signing): local encrypted keystore **or** KMS-TEE custody
+  (`RUST_SIGNER_URL` + `RUST_SIGNER_REQUIRED=true`, key-less `node_state.json` —
+  needs DVT ≥ v1.10.0). KMS-TEE is required for unattended power-on (no tmpfs
+  passphrase to re-enter).
+- **Operator/keeper ECDSA key** (`ETH_PRIVATE_KEY` / `KEEPER_PRIVATE_KEY`): today
+  a plaintext `.env` EOA — **KMS-TEE custody of the BLS key does NOT protect it**.
+  Routing it through KMS's secp256k1 signer is a separate feature (see
+  `docs/KEEPER-KMS-SIGNING.md` proposal).

--- a/docs/KEEPER-KMS-SIGNING.md
+++ b/docs/KEEPER-KMS-SIGNING.md
@@ -44,14 +44,29 @@ ECDSA (new):    no local EOA key     + KEEPER_SIGNER_URL  → KMS /kms/sign (sec
   (standalone / non-co-located boards keep working — "允许降级为独立 env").
 - `enqueueWalletWrite` nonce FIFO is unchanged (the signer swap is transparent to it).
 
-## Provisioning flow (the operator's UX)
+## Provisioning flow — DVT-driven self-service (not KMS-manual)
 
-1. KMS `gen keeper k1 key` (TEE-sealed) → returns the **keeper EOA address**.
-2. Operator funds that address with ETH on the target network.
-3. `dvt.env`: `KEEPER_SIGNER_URL=http://127.0.0.1:3100`, `KEEPER_ADDRESS=0x…`,
+The node **drives** provisioning; KMS is the key-custody backend it calls. One
+`dvt init-kms` command / admin endpoint does the whole thing so it works the same
+on any board (not a KMS operator hand-running commands on each box):
+
+1. DVT → KMS `gen-bls-key` (TEE-sealed) → BLS pubkey → write key-less
+   `node_state.json` → on-chain `registerPublicKey` on the target validator.
+2. DVT → KMS `gen-keeper-eoa` (TEE-sealed secp256k1) → **keeper EOA address**.
+3. DVT records the full pubkey + keeper EOA in its **config** (single source), and
+   **displays them on the dashboard** (`dvt.aastar.io` / `/admin`) **masked in the
+   middle** (e.g. `0x539B…64bC`) so the operator can read enough to act without the
+   panel leaking full values. The full keeper EOA is in config so the operator can
+   **fund it with ETH**.
+4. `dvt.env`: `KEEPER_SIGNER_URL=http://127.0.0.1:3100`, `KEEPER_ADDRESS=0x…`,
    `KEEPER_ENABLED=true` (no `KEEPER_PRIVATE_KEY`).
-4. Keeper runs; every `attestLiveness`/`updatePrice`/`registerPublicKey` tx is
-   signed in the TEE. Unattended-boot safe (no plaintext key, no tmpfs passphrase).
+5. Operator funds the keeper EOA. Keeper runs; every
+   `attestLiveness`/`updatePrice`/`registerPublicKey` tx is signed in the TEE.
+   Unattended-boot safe (no plaintext key, no tmpfs passphrase).
+
+> Masking is display-only. Full values live in the node's config (readable by the
+> operator on the box), never only-on-screen — the operator must be able to copy the
+> keeper EOA to fund it.
 
 ## Cross-repo dependency (KMS side — must land first)
 

--- a/docs/KEEPER-KMS-SIGNING.md
+++ b/docs/KEEPER-KMS-SIGNING.md
@@ -1,0 +1,78 @@
+# Proposal — route operator/keeper ECDSA signing through KMS-TEE
+
+Status: **evaluation + plan** (not built). Owner: DVT + KMS (cross-repo).
+
+## Problem
+
+KMS-TEE custody protects the **BLS** co-signing key (key-less `node_state.json` +
+`RUST_SIGNER_URL` → KMS `/sign`). It does **not** protect the **operator/keeper
+ECDSA key**: today all on-chain writes sign with a plaintext EOA from `.env`.
+
+Evidence:
+- `blockchain.service.ts:136` `this.wallet = new ethers.Wallet(ETH_PRIVATE_KEY)`
+- `blockchain.service.ts:148` `keeperWallet = new ethers.Wallet(KEEPER_PRIVATE_KEY)`
+- `liveness-keeper.service.ts:21` — `attestLiveness()` from the **operator EOA**
+- The only remote-signer seam that exists is **BLS-only** (`RUST_SIGNER_URL`,
+  `bls.service.ts signViaRust`). There is **no ECDSA remote seam**.
+
+So on a KMS-co-located board that runs a keeper, the operator k1 key is the last
+plaintext secret on disk.
+
+## Feasibility
+
+**Yes.** KMS (AirAccount) already signs secp256k1 (`/kms/sign` supports
+`secp256k1`/`p256`; keys sealed in OP-TEE). ethers v6 lets us drop in a custom
+`AbstractSigner` whose `signTransaction`/`signMessage`/`signTypedData` call KMS
+instead of holding a key. So **"the TEE key IS the keeper's EOA"** is exactly
+right: KMS seals a k1 key, its derived address = the funded keeper EOA, and KMS
+signs every tx in the TEE. The key never touches disk.
+
+## Design (mirror the BLS seam — reuse, don't reinvent)
+
+```
+BLS   (today):  node_state key-less  + RUST_SIGNER_URL   → KMS /sign  (BLS12-381)
+ECDSA (new):    no local EOA key     + KEEPER_SIGNER_URL  → KMS /kms/sign (secp256k1)
+```
+
+- New `KmsEcdsaSigner extends ethers.AbstractSigner`: `getAddress()` from a
+  configured keeper address; `signTransaction(tx)` → serialize unsigned →
+  KMS `/kms/sign` (keyId=keeper) → assemble `{r,s,v}` → return signed tx.
+  Same `X-Signer-Token` auth as the BLS seam (`#182`).
+- `BlockchainService.initializeProvider()`: when `KEEPER_SIGNER_URL` is set, build
+  `wallet`/`keeperWallet` as `KmsEcdsaSigner` instead of `new ethers.Wallet(pk)`.
+  **Fallback preserved**: `KEEPER_SIGNER_URL` unset → today's `.env` EOA path
+  (standalone / non-co-located boards keep working — "允许降级为独立 env").
+- `enqueueWalletWrite` nonce FIFO is unchanged (the signer swap is transparent to it).
+
+## Provisioning flow (the operator's UX)
+
+1. KMS `gen keeper k1 key` (TEE-sealed) → returns the **keeper EOA address**.
+2. Operator funds that address with ETH on the target network.
+3. `dvt.env`: `KEEPER_SIGNER_URL=http://127.0.0.1:3100`, `KEEPER_ADDRESS=0x…`,
+   `KEEPER_ENABLED=true` (no `KEEPER_PRIVATE_KEY`).
+4. Keeper runs; every `attestLiveness`/`updatePrice`/`registerPublicKey` tx is
+   signed in the TEE. Unattended-boot safe (no plaintext key, no tmpfs passphrase).
+
+## Cross-repo dependency (KMS side — must land first)
+
+- KMS `/kms/sign` for secp256k1 reachable on the loopback `:3100` contract (like
+  BLS `/sign`): `{keyId, digest}` → `{r,s,v}` (or `{signature}`). Confirm exact
+  wire + whether it signs a raw 32-byte digest (needed for `signTransaction`).
+- KMS `gen-keeper-key` provisioning (behind the same `KMS_BLS_PROVISIONING`-style
+  gate) that returns the k1 address.
+
+## Phases
+
+1. **KMS**: expose secp256k1 `/kms/sign` (raw-digest) + `gen-keeper-key` on `:3100`.
+2. **DVT**: `KmsEcdsaSigner` + `KEEPER_SIGNER_URL` seam in `BlockchainService`
+   (fallback to `.env` when unset). Unit tests: byte-identical signature vs a
+   local `ethers.Wallet` for the same key/digest.
+3. **DVT**: provisioning docs + `dvt.env` wiring; real-board E2E (funded keeper
+   EOA → attestLiveness tx signed via KMS).
+4. Optional: extend to the operator wallet (`ETH_PRIVATE_KEY`) so registration
+   also signs via KMS → **zero plaintext keys on the co-located board**.
+
+## Payoff
+
+A KMS-co-located DVT node holds **no plaintext secrets**: BLS via KMS-TEE, ECDSA
+via KMS-TEE, both unattended-boot safe. Standalone nodes fall back to `.env`.

--- a/docs/KEEPER-KMS-SIGNING.md
+++ b/docs/KEEPER-KMS-SIGNING.md
@@ -4,13 +4,16 @@ Status: **evaluation + plan** (not built). Owner: DVT + KMS (cross-repo).
 
 ## Problem
 
-KMS-TEE custody protects the **BLS** co-signing key (key-less `node_state.json` +
-`RUST_SIGNER_URL` → KMS `/sign`). It does **not** protect the **operator/keeper
-ECDSA key**: today all on-chain writes sign with a plaintext EOA from `.env`.
+KMS-TEE custody protects the **BLS** co-signing key (key-less
+`node_state.json` + `RUST_SIGNER_URL` → KMS `/sign`). It does **not** protect
+the **operator/keeper ECDSA key**: today all on-chain writes sign with a
+plaintext EOA from `.env`.
 
 Evidence:
+
 - `blockchain.service.ts:136` `this.wallet = new ethers.Wallet(ETH_PRIVATE_KEY)`
-- `blockchain.service.ts:148` `keeperWallet = new ethers.Wallet(KEEPER_PRIVATE_KEY)`
+- `blockchain.service.ts:148`
+  `keeperWallet = new ethers.Wallet(KEEPER_PRIVATE_KEY)`
 - `liveness-keeper.service.ts:21` — `attestLiveness()` from the **operator EOA**
 - The only remote-signer seam that exists is **BLS-only** (`RUST_SIGNER_URL`,
   `bls.service.ts signViaRust`). There is **no ECDSA remote seam**.
@@ -35,50 +38,53 @@ ECDSA (new):    no local EOA key     + KEEPER_SIGNER_URL  → KMS /kms/sign (sec
 ```
 
 - New `KmsEcdsaSigner extends ethers.AbstractSigner`: `getAddress()` from a
-  configured keeper address; `signTransaction(tx)` → serialize unsigned →
-  KMS `/kms/sign` (keyId=keeper) → assemble `{r,s,v}` → return signed tx.
-  Same `X-Signer-Token` auth as the BLS seam (`#182`).
-- `BlockchainService.initializeProvider()`: when `KEEPER_SIGNER_URL` is set, build
-  `wallet`/`keeperWallet` as `KmsEcdsaSigner` instead of `new ethers.Wallet(pk)`.
-  **Fallback preserved**: `KEEPER_SIGNER_URL` unset → today's `.env` EOA path
-  (standalone / non-co-located boards keep working — "允许降级为独立 env").
-- `enqueueWalletWrite` nonce FIFO is unchanged (the signer swap is transparent to it).
+  configured keeper address; `signTransaction(tx)` → serialize unsigned → KMS
+  `/kms/sign` (keyId=keeper) → assemble `{r,s,v}` → return signed tx. Same
+  `X-Signer-Token` auth as the BLS seam (`#182`).
+- `BlockchainService.initializeProvider()`: when `KEEPER_SIGNER_URL` is set,
+  build `wallet`/`keeperWallet` as `KmsEcdsaSigner` instead of
+  `new ethers.Wallet(pk)`. **Fallback preserved**: `KEEPER_SIGNER_URL` unset →
+  today's `.env` EOA path (standalone / non-co-located boards keep working —
+  "允许降级为独立 env").
+- `enqueueWalletWrite` nonce FIFO is unchanged (the signer swap is transparent
+  to it).
 
 ## Provisioning flow — DVT-driven self-service (not KMS-manual)
 
 The node **drives** provisioning; KMS is the key-custody backend it calls. One
-`dvt init-kms` command / admin endpoint does the whole thing so it works the same
-on any board (not a KMS operator hand-running commands on each box):
+`dvt init-kms` command / admin endpoint does the whole thing so it works the
+same on any board (not a KMS operator hand-running commands on each box):
 
 1. DVT → KMS `gen-bls-key` (TEE-sealed) → BLS pubkey → write key-less
    `node_state.json` → on-chain `registerPublicKey` on the target validator.
 2. DVT → KMS `gen-keeper-eoa` (TEE-sealed secp256k1) → **keeper EOA address**.
-3. DVT records the full pubkey + keeper EOA in its **config** (single source), and
-   **displays them on the dashboard** (`dvt.aastar.io` / `/admin`) **masked in the
-   middle** (e.g. `0x539B…64bC`) so the operator can read enough to act without the
-   panel leaking full values. The full keeper EOA is in config so the operator can
-   **fund it with ETH**.
+3. DVT records the full pubkey + keeper EOA in its **config** (single source),
+   and **displays them on the dashboard** (`dvt.aastar.io` / `/admin`) **masked
+   in the middle** (e.g. `0x539B…64bC`) so the operator can read enough to act
+   without the panel leaking full values. The full keeper EOA is in config so
+   the operator can **fund it with ETH**.
 4. `dvt.env`: `KEEPER_SIGNER_URL=http://127.0.0.1:3100`, `KEEPER_ADDRESS=0x…`,
    `KEEPER_ENABLED=true` (no `KEEPER_PRIVATE_KEY`).
 5. Operator funds the keeper EOA. Keeper runs; every
    `attestLiveness`/`updatePrice`/`registerPublicKey` tx is signed in the TEE.
    Unattended-boot safe (no plaintext key, no tmpfs passphrase).
 
-> Masking is display-only. Full values live in the node's config (readable by the
-> operator on the box), never only-on-screen — the operator must be able to copy the
-> keeper EOA to fund it.
+> Masking is display-only. Full values live in the node's config (readable by
+> the operator on the box), never only-on-screen — the operator must be able to
+> copy the keeper EOA to fund it.
 
 ## Cross-repo dependency (KMS side — must land first)
 
 - KMS `/kms/sign` for secp256k1 reachable on the loopback `:3100` contract (like
   BLS `/sign`): `{keyId, digest}` → `{r,s,v}` (or `{signature}`). Confirm exact
   wire + whether it signs a raw 32-byte digest (needed for `signTransaction`).
-- KMS `gen-keeper-key` provisioning (behind the same `KMS_BLS_PROVISIONING`-style
-  gate) that returns the k1 address.
+- KMS `gen-keeper-key` provisioning (behind the same
+  `KMS_BLS_PROVISIONING`-style gate) that returns the k1 address.
 
 ## Phases
 
-1. **KMS**: expose secp256k1 `/kms/sign` (raw-digest) + `gen-keeper-key` on `:3100`.
+1. **KMS**: expose secp256k1 `/kms/sign` (raw-digest) + `gen-keeper-key` on
+   `:3100`.
 2. **DVT**: `KmsEcdsaSigner` + `KEEPER_SIGNER_URL` seam in `BlockchainService`
    (fallback to `.env` when unset). Unit tests: byte-identical signature vs a
    local `ethers.Wallet` for the same key/digest.


### PR DESCRIPTION
Two records from the 机房 board bring-up (see commit). The keeper-KMS proposal is a plan for review, not yet built — its Phase 1 depends on KMS exposing a secp256k1 `/kms/sign` (raw-digest) + gen-keeper-key on :3100.

https://claude.ai/code/session_01JrdmiUk4A258FmhDSKn9aj