### PR TITLE
feat(CC-34): KmsEcdsaSigner — route keeper ECDSA signing through KMS-TEE

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,6 +33,7 @@ export default [
         atob: "readonly",
         btoa: "readonly",
         fetch: "readonly", // Node 18+ global fetch (used by notification.service.ts)
+        AbortController: "readonly", // Node 18+ global (kms-ecdsa-signer.ts fetch timeout)
         jest: "readonly",
         describe: "readonly",
         it: "readonly",

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -131,6 +131,14 @@ export default () => {
     // keeper's updatePrice() nonce queue can't contend with relay submissions on
     // one EOA. Falls back to ETH_PRIVATE_KEY only when unset.
     keeperPrivateKey: process.env.KEEPER_PRIVATE_KEY || undefined,
+    // KMS-TEE keeper signer (CC-34) — takes precedence over KEEPER_PRIVATE_KEY. The secp256k1
+    // key is sealed in the co-located KMS; DVT signs raw 32B digests via loopback :3100 and never
+    // holds the key. KEEPER_ADDRESS is the funded keeper EOA (from KMS provisioning). Fail-closed:
+    // KMS rejects signing without KEEPER_SIGNER_TOKEN. Unset KEEPER_SIGNER_URL → plaintext fallback.
+    keeperSignerUrl: process.env.KEEPER_SIGNER_URL || undefined,
+    keeperSignerToken: process.env.KEEPER_SIGNER_TOKEN || undefined,
+    keeperAddress: process.env.KEEPER_ADDRESS || undefined,
+    keeperId: process.env.KEEPER_ID || undefined,
     keeperChainlinkFeed:
       process.env.KEEPER_CHAINLINK_FEED || "0x694AA1769357215DE4FAC081bf1f309aDC325306",
 

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -2,6 +2,14 @@ import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { ethers } from "ethers";
 import { bumpedFees } from "../../utils/gas.util.js";
+import { KmsEcdsaSigner } from "./kms-ecdsa-signer.js";
+
+/**
+ * An ethers Signer that also exposes a synchronous `.address` (like ethers.Wallet). Both the
+ * plaintext `ethers.Wallet` and the KMS-TEE `KmsEcdsaSigner` (CC-34) satisfy it, so the wallet
+ * fields can hold either without the call sites (which read `.address` sync) caring which.
+ */
+type OnchainSigner = ethers.Signer & { readonly address: string };
 
 /**
  * CROSS-REPO INTERFACE CONTRACT — the account owner-auth gate.
@@ -53,12 +61,12 @@ export interface PackedUserOp {
 export class BlockchainService {
   private readonly logger = new Logger(BlockchainService.name);
   private provider: ethers.Provider;
-  private wallet: ethers.Wallet;
+  private wallet: OnchainSigner;
   /** Dedicated keeper signer (KEEPER_PRIVATE_KEY) — kept SEPARATE from the relay
    *  operator key and the admin/registration key so the keeper's updatePrice()
    *  nonce queue can't contend with relay submissions on the same EOA. Falls back
    *  to `wallet` (ETH_PRIVATE_KEY) only when KEEPER_PRIVATE_KEY is unset. */
-  private keeperWallet?: ethers.Wallet;
+  private keeperWallet?: OnchainSigner;
 
   /**
    * Nonce-race protection for the shared operator EOA (`this.wallet`): the attest keeper (inc-2)
@@ -141,9 +149,44 @@ export class BlockchainService {
       }
     }
 
-    // Dedicated keeper signer (optional). Unset → keeper reuses `wallet`.
+    // Dedicated keeper signer (optional). Precedence: KMS-TEE custody (KEEPER_SIGNER_URL, CC-34)
+    // > plaintext KEEPER_PRIVATE_KEY. Unset both → keeper reuses `wallet`.
+    const keeperSignerUrl = this.configService.get<string>("keeperSignerUrl");
     const keeperKey = this.configService.get<string>("keeperPrivateKey");
-    if (keeperKey && /^0x[0-9a-fA-F]{64}$/.test(keeperKey)) {
+    if (keeperSignerUrl) {
+      // KMS-TEE keeper: the secp256k1 key is sealed in the co-located KMS, never on disk. The
+      // keeper EOA (funded with ETH) comes from provisioning (KMS_KEEPER_ADDRESS → KEEPER_ADDRESS).
+      const keeperAddress = this.configService.get<string>("keeperAddress");
+      if (!keeperAddress) {
+        this.logger.error(
+          "KEEPER_SIGNER_URL is set but KEEPER_ADDRESS is missing — KMS keeper signer DISABLED"
+        );
+      } else {
+        try {
+          const kms = new KmsEcdsaSigner(
+            {
+              url: keeperSignerUrl,
+              address: keeperAddress,
+              token: this.configService.get<string>("keeperSignerToken"),
+              keeperId: this.configService.get<string>("keeperId"),
+            },
+            this.provider
+          );
+          // Same-EOA guard (as below): only treat as dedicated when it differs from the operator,
+          // so a shared address still serializes on the operator nonce FIFO.
+          if (this.wallet && kms.address.toLowerCase() === this.wallet.address.toLowerCase()) {
+            this.logger.warn(
+              "KEEPER_ADDRESS is the SAME EOA as the operator wallet — keeper writes serialize on the shared nonce FIFO"
+            );
+          } else {
+            this.keeperWallet = kms;
+            this.logger.log(`Keeper signer (KMS-TEE): ${kms.address}`);
+          }
+        } catch (error: any) {
+          this.logger.error(`Invalid KMS keeper signer config: ${error.message}`);
+        }
+      }
+    } else if (keeperKey && /^0x[0-9a-fA-F]{64}$/.test(keeperKey)) {
       try {
         const kw = new ethers.Wallet(keeperKey, this.provider);
         // If KEEPER_PRIVATE_KEY resolves to the SAME EOA as ETH_PRIVATE_KEY (two Wallet objects, one
@@ -166,7 +209,7 @@ export class BlockchainService {
   }
 
   /** Signer the keeper uses for updatePrice() — dedicated key if set, else the admin wallet. */
-  private get keeperSigner(): ethers.Wallet | undefined {
+  private get keeperSigner(): OnchainSigner | undefined {
     return this.keeperWallet ?? this.wallet;
   }
 

--- a/src/modules/blockchain/kms-ecdsa-signer.spec.ts
+++ b/src/modules/blockchain/kms-ecdsa-signer.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, jest } from "@jest/globals";
+import { ethers } from "ethers";
+import { KmsEcdsaSigner } from "./kms-ecdsa-signer.js";
+
+/**
+ * The KMS TEE holds the real key; here a local ethers.Wallet stands in for it. The mock KMS
+ * signs the exact 32-byte digest KmsEcdsaSigner sends (KMS "does not hash"), so if our digest
+ * computation + {r,s,v} assembly is correct, the output is BYTE-IDENTICAL to what the Wallet
+ * would have produced directly. That equality is the golden `ecrecover(digest,sig)==address`
+ * invariant KMS golden-tests against on hardware (CC-34).
+ */
+const KEY = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+const wallet = new ethers.Wallet(KEY);
+const URL = "http://127.0.0.1:3100";
+const TOKEN = "keeper-token-abc";
+
+/** A mock KMS /kms/sign that signs the incoming digest with `signWith` and reports `reportAddr`. */
+function mockKms(opts?: { signWith?: ethers.SigningKey; reportAddr?: string; captured?: any }) {
+  const signWith = opts?.signWith ?? wallet.signingKey;
+  const reportAddr = opts?.reportAddr ?? wallet.address;
+  return jest.fn(async (url: any, init: any) => {
+    const body = JSON.parse(init.body);
+    if (opts?.captured) {
+      opts.captured.url = url;
+      opts.captured.headers = init.headers;
+      opts.captured.body = body;
+    }
+    const sig = signWith.sign(body.digest);
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ signature: sig.serialized, address: reportAddr }),
+    } as any;
+  }) as unknown as typeof fetch;
+}
+
+function signer(fetchImpl: typeof fetch, over?: Partial<{ token: string; address: string }>) {
+  return new KmsEcdsaSigner({
+    url: URL,
+    address: over?.address ?? wallet.address,
+    token: over?.token ?? TOKEN,
+    fetchImpl,
+  });
+}
+
+describe("KmsEcdsaSigner", () => {
+  it("getAddress returns the configured keeper EOA (checksummed)", async () => {
+    expect(await signer(mockKms()).getAddress()).toBe(wallet.address);
+  });
+
+  it("signMessage is byte-identical to ethers.Wallet", async () => {
+    const s = signer(mockKms());
+    const msg = "co-sign this liveness attest";
+    expect(await s.signMessage(msg)).toBe(await wallet.signMessage(msg));
+    // and recovers to the keeper EOA
+    expect(ethers.verifyMessage(msg, await s.signMessage(msg))).toBe(wallet.address);
+  });
+
+  it("signTransaction is byte-identical to ethers.Wallet (EIP-1559)", async () => {
+    const tx: ethers.TransactionRequest = {
+      to: "0x539B9681aFd5BFbCaa655Fe4c6BdcFe1fa7864bC",
+      value: 0n,
+      data: "0x1234",
+      nonce: 7,
+      gasLimit: 120000n,
+      maxFeePerGas: 30_000_000_000n,
+      maxPriorityFeePerGas: 1_000_000_000n,
+      chainId: 11155111,
+      type: 2,
+    };
+    const fromKms = await signer(mockKms()).signTransaction(tx);
+    expect(fromKms).toBe(await wallet.signTransaction(tx));
+    // the serialized tx recovers to the keeper EOA
+    expect(ethers.Transaction.from(fromKms).from).toBe(wallet.address);
+  });
+
+  it("sends the digest (not the message) + X-Signer-Token, and asks KMS not to hash", async () => {
+    const captured: any = {};
+    const s = signer(mockKms({ captured }));
+    const msg = "hello";
+    await s.signMessage(msg);
+    expect(captured.body.digest).toBe(ethers.hashMessage(msg)); // 32B digest, KMS won't re-hash
+    expect(captured.headers["X-Signer-Token"]).toBe(TOKEN);
+    expect(captured.url).toBe(`${URL}/kms/sign`);
+  });
+
+  it("omits X-Signer-Token when no token configured", async () => {
+    const captured: any = {};
+    const s = new KmsEcdsaSigner({
+      url: URL,
+      address: wallet.address,
+      fetchImpl: mockKms({ captured }),
+    });
+    await s.signMessage("x");
+    expect(captured.headers["X-Signer-Token"]).toBeUndefined();
+  });
+
+  it("rejects when KMS reports a different address (wrong board key)", async () => {
+    const other = ethers.Wallet.createRandom().address;
+    await expect(signer(mockKms({ reportAddr: other })).signMessage("x")).rejects.toThrow(
+      /address mismatch/i
+    );
+  });
+
+  it("rejects when the signature does not recover to the keeper EOA", async () => {
+    // KMS signs with a DIFFERENT key but (buggily) still claims our address → must be caught.
+    const rogue = ethers.Wallet.createRandom().signingKey;
+    await expect(
+      signer(mockKms({ signWith: rogue, reportAddr: wallet.address })).signMessage("x")
+    ).rejects.toThrow(/does not recover/i);
+  });
+
+  it("rejects a non-2xx KMS response (fail-closed)", async () => {
+    const badFetch = jest.fn(async () => ({
+      ok: false,
+      status: 403,
+      json: async () => ({}),
+    })) as any;
+    await expect(signer(badFetch).signMessage("x")).rejects.toThrow(/HTTP 403/);
+  });
+
+  it("rejects a malformed keeper address at construction", () => {
+    expect(() => signer(mockKms(), { address: "not-an-address" })).toThrow();
+  });
+});

--- a/src/modules/blockchain/kms-ecdsa-signer.ts
+++ b/src/modules/blockchain/kms-ecdsa-signer.ts
@@ -1,0 +1,151 @@
+import { ethers } from "ethers";
+
+/**
+ * KMS-TEE ECDSA signer (CC-34). An ethers Signer whose secp256k1 private key is sealed in
+ * the co-located KMS OP-TEE and never touches disk — the ECDSA analogue of the BLS
+ * `RUST_SIGNER_URL` seam (bls.service.ts). Every signature is produced by the KMS by
+ * signing a raw 32-byte digest; this class only computes the digest (tx sighash / EIP-191 /
+ * EIP-712) and assembles the returned {r,s,v} back onto the payload.
+ *
+ * Wire contract (frozen with KMS, CC-34 comment 87e42971):
+ *   POST {url}/kms/sign   Header: X-Signer-Token: <token>   (fail-closed: KMS rejects without it)
+ *     req  { keeper_id?, digest: "0x"<32B> }        // KMS does NOT hash — it signs the digest
+ *     resp { signature: "0x"<65B r‖s‖v, v=27/28, low-S>, address: "0x"<20B keeper EOA> }
+ *
+ * The key is a board singleton (KMS_KEEPER_KEY_ID / KMS_KEEPER_ADDRESS on the KMS side); this
+ * signer is addressed only by its EOA, which the operator funds with ETH. When unconfigured,
+ * BlockchainService falls back to a plaintext `.env` Wallet — this class is only constructed
+ * when KEEPER_SIGNER_URL is set.
+ */
+export interface KmsEcdsaSignerOptions {
+  /** KEEPER_SIGNER_URL — the KMS loopback base, e.g. http://127.0.0.1:3100. */
+  url: string;
+  /** The keeper EOA (KMS_KEEPER_ADDRESS) this TEE key derives to — funded with ETH. */
+  address: string;
+  /** KEEPER_SIGNER_TOKEN → X-Signer-Token. KMS is fail-closed: signing is rejected without it. */
+  token?: string;
+  /** Optional keeper_id if the KMS holds more than one keeper key (default: board singleton). */
+  keeperId?: string;
+  /** Injectable fetch (tests). Defaults to global fetch (Node ≥ 18). */
+  fetchImpl?: typeof fetch;
+  /** Per-call timeout guarding against a hung KMS socket. */
+  timeoutMs?: number;
+}
+
+export class KmsEcdsaSigner extends ethers.AbstractSigner {
+  /** Sync EOA, mirroring ethers.Wallet.address so BlockchainService can use it as a drop-in. */
+  readonly address: string;
+  private readonly url: string;
+  private readonly token?: string;
+  private readonly keeperId?: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+
+  constructor(opts: KmsEcdsaSignerOptions, provider: ethers.Provider | null = null) {
+    super(provider);
+    // Validate + checksum up front so a bad KEEPER_ADDRESS fails fast, not on first tx.
+    this.address = ethers.getAddress(opts.address);
+    this.url = opts.url.replace(/\/+$/, "");
+    this.token = opts.token;
+    this.keeperId = opts.keeperId;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.timeoutMs = opts.timeoutMs ?? 5000;
+  }
+
+  async getAddress(): Promise<string> {
+    return this.address;
+  }
+
+  connect(provider: ethers.Provider | null): KmsEcdsaSigner {
+    return new KmsEcdsaSigner(
+      {
+        url: this.url,
+        address: this.address,
+        token: this.token,
+        keeperId: this.keeperId,
+        fetchImpl: this.fetchImpl,
+        timeoutMs: this.timeoutMs,
+      },
+      provider
+    );
+  }
+
+  /**
+   * Sign a raw 32-byte digest in the KMS TEE. Defence in depth: we reject unless the returned
+   * signature actually recovers to our configured keeper EOA — so a wrong-key / wrong-board KMS
+   * response can never be assembled onto a broadcast tx. This is the same `ecrecover(digest,sig)
+   * == address` invariant KMS golden-tests against (CC-34).
+   */
+  private async _signDigest(digest: string): Promise<ethers.Signature> {
+    if (!/^0x[0-9a-fA-F]{64}$/.test(digest)) {
+      throw new Error(`KmsEcdsaSigner: digest must be 32-byte hex, got ${digest}`);
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    let json: { signature?: string; address?: string };
+    try {
+      const res = await this.fetchImpl(`${this.url}/kms/sign`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          ...(this.token ? { "X-Signer-Token": this.token } : {}),
+        },
+        body: JSON.stringify({
+          digest,
+          ...(this.keeperId ? { keeper_id: this.keeperId } : {}),
+        }),
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        throw new Error(`KMS /kms/sign returned HTTP ${res.status}`);
+      }
+      json = (await res.json()) as { signature?: string; address?: string };
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!json?.signature) {
+      throw new Error("KMS /kms/sign: response missing `signature`");
+    }
+    // KMS echoes the signing EOA — a mismatch means the board holds a different keeper key.
+    if (json.address && ethers.getAddress(json.address) !== this.address) {
+      throw new Error(
+        `KMS keeper address mismatch: signer=${this.address}, KMS=${ethers.getAddress(json.address)}`
+      );
+    }
+    // Signature.from parses the 65-byte r‖s‖v (v=27/28) and enforces canonical low-S.
+    const sig = ethers.Signature.from(json.signature);
+    const recovered = ethers.recoverAddress(digest, sig);
+    if (recovered !== this.address) {
+      throw new Error(
+        `KMS signature does not recover to keeper EOA: expected ${this.address}, recovered ${recovered}`
+      );
+    }
+    return sig;
+  }
+
+  async signTransaction(tx: ethers.TransactionRequest): Promise<string> {
+    // sendTransaction() populates the tx first, so `from`/`to` are resolved addresses here.
+    // Transaction.from() rejects a `from` field — strip it after asserting it is ours.
+    const { from, ...rest } = tx;
+    if (from != null && ethers.getAddress(String(from)) !== this.address) {
+      throw new Error(`KmsEcdsaSigner: tx.from ${from} does not match keeper EOA ${this.address}`);
+    }
+    const unsigned = ethers.Transaction.from(rest as ethers.TransactionLike<string>);
+    unsigned.signature = await this._signDigest(unsigned.unsignedHash);
+    return unsigned.serialized;
+  }
+
+  async signMessage(message: string | Uint8Array): Promise<string> {
+    // EIP-191 personal_sign digest, then TEE-sign it.
+    return (await this._signDigest(ethers.hashMessage(message))).serialized;
+  }
+
+  async signTypedData(
+    domain: ethers.TypedDataDomain,
+    types: Record<string, ethers.TypedDataField[]>,
+    value: Record<string, unknown>
+  ): Promise<string> {
+    return (await this._signDigest(ethers.TypedDataEncoder.hash(domain, types, value))).serialized;
+  }
+}


### PR DESCRIPTION
DVT side of CC-34. KMS side (secp256k1 keeper signing on loopback `:3100`) is already merged to AirAccount main (PR #168). This adds the DVT signer that consumes the frozen byte contract.

## What

`KmsEcdsaSigner extends ethers.AbstractSigner` — the ECDSA analogue of the BLS `RUST_SIGNER_URL` seam. The secp256k1 key is sealed in the co-located KMS OP-TEE and never touches disk; DVT computes the digest (tx sighash / EIP-191 / EIP-712), POSTs it **raw** to `/kms/sign` (KMS does not hash) with `X-Signer-Token`, and assembles the returned 65-byte `r‖s‖v` (v=27/28, low-S) back onto the payload.

- **BlockchainService**: `KEEPER_SIGNER_URL` seam. Precedence KMS-TEE > plaintext `KEEPER_PRIVATE_KEY`; unset → `.env` fallback (standalone nodes unchanged). Wallet fields widened to `Signer & { address }` — no `Wallet`-specific API is used on them, so it's a drop-in; the same-EOA nonce-FIFO guard is preserved.
- **config**: `KEEPER_SIGNER_URL` / `KEEPER_SIGNER_TOKEN` / `KEEPER_ADDRESS` / `KEEPER_ID`.
- **eslint**: `AbortController` as a Node 18+ global (fetch timeout).

## Defense in depth

`_signDigest` rejects unless `recoverAddress(digest,sig) == keeper EOA` — a wrong-key / wrong-board KMS response can never be assembled onto a broadcast tx. This is the exact `ecrecover(digest,sig)==address` invariant KMS golden-tests on hardware. Plus: KMS-reported address must match, `Signature.from` enforces canonical low-S, digest must be 32B, non-2xx fails closed.

## Verification

- `kms-ecdsa-signer.spec.ts`: `signMessage` + `signTransaction` are **BYTE-IDENTICAL to ethers.Wallet** (a local Wallet stands in for the TEE; the mock signs the exact digest DVT sends, so equality proves the digest + {r,s,v} assembly is correct). Plus fail-closed cases: address mismatch, bad recovery, non-2xx, missing token, malformed address. **9/9 pass.**
- Full suite **390 green**, type-check + lint clean.

EIP-155/1559 `v` encoding is handled by `ethers.Transaction.serialized` from the attached `Signature` (not hand-computed) — the byte-identical test confirms it.

## Scope / follow-ups

- Keeper signer only (the KMS keeper k1 singleton). Operator-wallet-via-KMS is a follow-up (docs/KEEPER-KMS-SIGNING.md Phase 4).
- Self-service provisioning command + masked dashboard display = next PR.
- Byte golden + hardware E2E land with CC-24 on the board.
- 🔴 Mainnet keeper-funding hard-gate (`/dev/tee*` device-auth) is KMS/systemd-side, tracked in CC-25 — no DVT change.

## Review

Self-reviewed (tx serialization field handling, recover-check, low-S, nonce/FIFO for the separate keeper EOA, same-EOA guard, fail-closed paths — all encoded as tests). A Codex adversarial pass is running in the background; reviewers welcome to Codex-review here as well.

https://claude.ai/code/session_01JrdmiUk4A258FmhDSKn9aj