### PR TITLE
feat(CC-24): dvt.service key-less unit + env template (2nd node-setup helper)

### DIFF
--- a/deploy/kms-tee/README.md
+++ b/deploy/kms-tee/README.md
@@ -1,0 +1,52 @@
+# KMS-TEE key-less co-located DVT (A-board "power-on → unattended KMS+DVT1")
+
+DVT-side deliverable for CC-24. The board is KMS-controlled; the KMS
+`node-setup` runs this recipe (method ②: it calls DVT's scripts, never edits DVT
+code). This directory is the DVT half — the two "helpers" KMS is waiting on:
+
+| Helper                      | File                                                                                 | Role                                                                  |
+| --------------------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| key-less node_state writer  | [`scripts/write-keyless-node-state.mjs`](../../scripts/write-keyless-node-state.mjs) | KMS `gen-key` 48B G1 pubkey → `{nodeId, publicKey}`, no privateKey    |
+| key-less systemd unit + env | [`dvt.service`](./dvt.service) + [`dvt.env.example`](./dvt.env.example)              | no tmpfs passphrase; `After=kms-api.service`; sources the KMS handoff |
+
+## Why key-less (the whole point)
+
+The board today runs an **isolated encrypted keystore** whose passphrase lives
+in `/run/dvt/pass` (tmpfs) — wiped on every power cut, so DVT can't self-start
+unattended. KMS-TEE custody removes the passphrase entirely: the BLS key is
+sealed in the KMS OP-TEE, DVT boots key-less and signs via `RUST_SIGNER_URL`
+(KMS `:3100`). Power-on → KMS unseals its own TEE key → DVT starts key-less →
+signs.
+
+## The recipe (what KMS node-setup runs on the board)
+
+```bash
+# KMS self-init has written /etc/airaccount/dvt-handoff.env:
+#   RUST_SIGNER_URL / RUST_SIGNER_REQUIRED / RUST_SIGNER_TOKEN  +  KMS_BLS_PUBKEY
+. /etc/airaccount/dvt-handoff.env
+
+# 1. DVT v1.9.0/v1.7.1 → v1.11.0, bare-node build (pure JS, board-proven)
+cd /opt/dvt-build && git fetch --tags && git checkout v1.11.0 && ./scripts/build-bare-node.sh
+
+# 2. key-less node_state from KMS's pubkey (DVT derives the nodeId — don't re-implement it)
+node scripts/write-keyless-node-state.mjs "$KMS_BLS_PUBKEY"      # → /opt/dvt-build/node_state.json
+
+# 3. config: DVT-owned dvt.env (non-secret) + KMS-owned handoff (signer wiring, already on disk)
+cp deploy/kms-tee/dvt.env.example /opt/dvt-build/dvt.env         # edit only if PORT/validator differ
+
+# 4. key-less unit: no /run/dvt/pass, ordered after KMS, enabled for boot
+cp deploy/kms-tee/dvt.service /etc/systemd/system/dvt.service
+systemctl daemon-reload && systemctl enable --now dvt.service
+```
+
+## Acceptance (local first, on-chain separate)
+
+Cold-boot → `kms-api` up → `dvt` key-less up (waits quietly if KMS not ready
+yet) → both `/health` green → `/sign` byte-aligned (CC-22 converged). On-chain
+`registerBLSPublicKey` is **separately gated** on the operator key/gas — not
+required for power-on self-run.
+
+## Reversible
+
+Unset the handoff (or `RUST_SIGNER_URL`) → DVT falls back to local-keystore
+mode. Switch can't brick.

--- a/deploy/kms-tee/dvt.env.example
+++ b/deploy/kms-tee/dvt.env.example
@@ -1,0 +1,20 @@
+# DVT-owned, non-secret config for the KMS-TEE key-less co-located node (CC-24).
+# Copy to /opt/dvt-build/dvt.env. The signer wiring is NOT here — it comes from the KMS
+# handoff (/etc/airaccount/dvt-handoff.env: RUST_SIGNER_URL / RUST_SIGNER_REQUIRED /
+# RUST_SIGNER_TOKEN), loaded by dvt.service. Keep secrets out of this file.
+
+PORT=8080
+
+# v1.9.0+ authoritative Sepolia validator (deploy/sdk-dvt-config.testnet.json = single source).
+# ⚠️ replaces the stale 0xF780Cc3F the board currently has. Flip for mainnet once deployed.
+VALIDATOR_CONTRACT_ADDRESS=0x539B9681aFd5BFbCaa655Fe4c6BdcFe1fa7864bC
+ENTRY_POINT_ADDRESS=0x0000000071727De22E5E9d8BAf0edAc6f37da032
+
+# Key-less node_state written by scripts/write-keyless-node-state.mjs (no privateKey).
+NODE_STATE_FILE=/opt/dvt-build/node_state.json
+
+# Signer wiring comes from /etc/airaccount/dvt-handoff.env (KMS-written), e.g.:
+#   RUST_SIGNER_URL=http://127.0.0.1:3100
+#   RUST_SIGNER_REQUIRED=true
+#   RUST_SIGNER_TOKEN=<KMS_BLS_SIGNER_TOKEN>
+# Do NOT duplicate them here — the handoff file is the source, so a token rotation is one edit.

--- a/deploy/kms-tee/dvt.service
+++ b/deploy/kms-tee/dvt.service
@@ -1,0 +1,52 @@
+# AAStar DVT (aNode) — KMS-TEE KEY-LESS, co-located with KMS on one board (CC-24).
+#
+# The key-less counterpart of the board's isolated-keystore dvt.service. Two deltas make
+# "power-on → unattended KMS+DVT1" work:
+#   1. NO /run/dvt/pass (tmpfs passphrase) — the BLS private key is sealed in the KMS OP-TEE,
+#      so there is nothing to re-type after a power cut. Signing goes via RUST_SIGNER_URL.
+#   2. Ordered After=kms-api.service — KMS starts first. (Even if DVT wins the race it boots
+#      key-less without probing KMS, and /health is pure liveness, so it just waits quietly
+#      until KMS :3100 is up — verified in node.service.ts. Wants= keeps them coupled.)
+#
+# Signer wiring (RUST_SIGNER_URL / RUST_SIGNER_REQUIRED / RUST_SIGNER_TOKEN) is provided by the
+# KMS handoff file the KMS self-init writes; DVT owns only the non-secret dvt.env. Apply on the
+# board (KMS node-setup does this, method ②):
+#   cp deploy/kms-tee/dvt.service /etc/systemd/system/dvt.service
+#   systemctl daemon-reload && systemctl enable --now dvt.service
+[Unit]
+Description=AAStar DVT (aNode) — KMS-TEE key-less (co-located)
+Documentation=https://github.com/AAStarCommunity/YetAnotherAA-Validator
+After=network-online.target kms-api.service
+Wants=network-online.target kms-api.service
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/dvt-build
+# DVT-owned non-secret config (PORT / VALIDATOR / ENTRY_POINT / NODE_STATE_FILE).
+EnvironmentFile=/opt/dvt-build/dvt.env
+# KMS-owned handoff (RUST_SIGNER_URL / RUST_SIGNER_REQUIRED / RUST_SIGNER_TOKEN), written by the
+# KMS self-init. Leading '-' = optional: absent → node falls back to local-keystore mode.
+EnvironmentFile=-/etc/airaccount/dvt-handoff.env
+ExecStart=/opt/node20/bin/node /opt/dvt-build/dist/main.js
+
+# Unattended self-heal: recover from crash/OOM and auto-start on boot. (on-failure would not
+# restart a clean exit; a key-holding signer should always come back.) StartLimit caps a storm.
+Restart=always
+RestartSec=5
+StartLimitIntervalSec=60
+StartLimitBurst=5
+StandardOutput=append:/opt/dvt-build/dvt.log
+StandardError=append:/opt/dvt-build/dvt.log
+
+# --- hardening (unchanged from the board's unit) ---
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+ReadWritePaths=/opt/dvt-build
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The **second** of the two DVT deliverables the KMS node-setup is waiting on for the A-board "power-on → unattended KMS+DVT1" switch (CC-24). The first — `write-keyless-node-state.mjs` — merged in #208.

`deploy/kms-tee/`:
- **`dvt.service`** — key-less counterpart of the board's isolated-keystore unit. Two deltas that make unattended power-on work: (1) **NO `/run/dvt/pass`** tmpfs passphrase (BLS key sealed in KMS TEE → nothing to re-type after a power cut; signs via `RUST_SIGNER_URL`); (2) `After=`/`Wants=kms-api.service` (KMS first; DVT boots key-less without probing KMS and waits quietly if it wins the race — verified in `node.service.ts`). `Restart=always` + `StartLimit` for self-heal. Sources the KMS handoff env with a leading `-` (optional) so it degrades to local-keystore mode when absent — **reversible, can't brick**.
- **`dvt.env.example`** — DVT-owned non-secret config (PORT / validator `0x539B96` replacing the stale `0xF780` / entrypoint / node_state). Signer wiring (`RUST_SIGNER_*`) comes from the KMS-written `/etc/airaccount/dvt-handoff.env` (their PR #169), not duplicated here — clean KMS/DVT file boundary, token rotation = one edit.
- **`README.md`** — the exact recipe KMS node-setup runs (method ②: calls DVT scripts, never edits DVT code) + acceptance + reversibility.

With both helpers delivered, KMS can wire the node-setup DVT-deploy step and the A-board switch is unblocked.

Config-only (systemd unit + env template + README) — no runtime code. Based on the board's actual `/opt/dvt-build` unit (read live over SSH), hardening unchanged.

https://claude.ai/code/session_01JrdmiUk4A258FmhDSKn9aj