### PR TITLE
docs(CC-89): guardian-collusion slashing stage-0 design

### DIFF
--- a/docs/AUDIT_SLASH_MODEL.md
+++ b/docs/AUDIT_SLASH_MODEL.md
@@ -3,6 +3,11 @@
 > Authoritative model for how the DVT node enforces rules. Corrected after a
 > design review (2026-07-09) that removed the credit① and over-issue③
 > stake-slash rules. See PR #205.
+>
+> This doc covers the quorum auditing **operators**. For the inverse — slashing
+> the **guardians** (co-signers) themselves when ≥m collude to pass a false slash
+> — see [`design/guardian-collusion-slash.md`](design/guardian-collusion-slash.md)
+> (CC-89, Protocol B).
 
 ## 1. Two enforcement mechanisms
 

--- a/docs/design/guardian-collusion-slash.md
+++ b/docs/design/guardian-collusion-slash.md
@@ -1,0 +1,147 @@
+# Guardian-Collusion Slashing (CC-89, Protocol B)
+
+> Stage-0 design doc. Companion to [`../AUDIT_SLASH_MODEL.md`](../AUDIT_SLASH_MODEL.md),
+> which covers the DVT node auditing **operators**. This doc covers the inverse:
+> slashing the **guardians** (the DVT co-signers themselves) when they collude.
+> Origin: CC-89 evaluation request from the RepCredit paper (DSR-Research-Flow).
+
+## 1. Why this exists — the threat the operator-audit model doesn't cover
+
+`AUDIT_SLASH_MODEL.md` is about a DVT quorum watching **operators** and slashing
+their **aPNTs**. It says nothing about the quorum itself being dishonest.
+
+The BLS slash path (`BLSAggregator.verifyAndExecute`) verifies that `m` real
+guardians co-signed a message and binds the slash to an `evidenceHash`, but the
+contract **never re-verifies the evidence content on-chain** — it commits to the
+hash and trusts the quorum. Therefore:
+
+> **≥m colluding guardians can pass a valid slash of an innocent operator.** The
+> aggregate signature is real, so nothing on-chain rejects it. The only possible
+> deterrent is economic: make the colluders lose their own stake.
+
+This is the threat the RepCredit paper's anti-collusion inequality models:
+
+```
+k · C_max  <  m · ρ · S_op · p_G
+                └──────┬──────┘
+      right side = a guardian's loss when its collusion is caught and slashed
+```
+
+- `m` = signatures needed to pass the attack. **For a slash this is
+  `slashThresholds[level]` (bootstrap WARNING=2 / MINOR=3 / MAJOR=3), NOT
+  `defaultThreshold=7`** (`defaultThreshold` is the reputation-consensus path
+  only). Using 7 overstates collusion resistance ~2–3×.
+- `S_op` = a guardian's ROLE_DVT GToken lock.
+- `ρ` = probability the collusion is detected **and** leads to a slash — the term
+  with no code correspondent until the detection layer (stage 2) exists.
+
+### Asset distinction — not "party" distinction
+
+The slashed operator (`operators[operator].aPNTsBalance`, requires
+ROLE_PAYMASTER_SUPER config) and the co-signing guardian (ROLE_DVT lock) are
+**different assets, not guaranteed-different parties**: the BLS slash path does
+**not** enforce ROLE_PAYMASTER_SUPER at slash time, and one address can hold both
+roles. What is guaranteed distinct is the asset — **aPNTs balance ≠ ROLE_DVT
+GToken lock**, even at a shared address. The gap is that the paper's `ρ · S_op`
+(a ROLE_DVT-stake loss) has no execution path targeting that asset.
+
+## 2. The auto-eject property (the free half of the mechanism)
+
+Every BLS verify reconstructs the aggregate key on-chain and checks **each
+signer** for live role + stake — `BLSAggregator._reconstructPkAgg`:
+
+```solidity
+if (!REGISTRY.hasRole(roleDvt, v)) revert SlotValidatorRoleRevoked(slot, v);
+(uint128 amount,,,, ) = staking.roleLocks(v, roleDvt);
+if (uint256(amount) < minStake) revert SlotValidatorStakeBelowMinimum(...);   // strict <
+```
+
+> **Consequence:** a guardian whose ROLE_DVT lock drops **below** `minStake` is
+> automatically ejected from all future signing — any proof that includes its
+> slot reverts. No separate "kick" logic is needed. The penalty shape for
+> collusion is therefore *slash the full lock → 0 < minStake → auto-eject*, which
+> both burns `S_op` and removes eligibility in one step.
+
+Note the boundary (SP review): the check is strict `<`. To **guarantee** ejection
+the slash must take the **full** lock (leaving 0), not `minStake` — leaving
+exactly `minStake` still passes the check. `executeGuardianSlash` slashes the
+full lock for this reason.
+
+## 3. Trigger authority — how the circular dependency is broken
+
+The obvious problem: `queueSlashWithConsensus` / `verifyAndExecute` require
+`msg.sender == DVT_VALIDATOR || owner()`, and the colluders **are** that quorum —
+they will never slash themselves. A same-quorum trigger cannot work.
+
+SP's `executeGuardianSlash` (BLSAggregator 4.2.0, **PR #370**) resolves this at
+the contract layer:
+
+| Property | How | Why it matters |
+| --- | --- | --- |
+| **Permissionless call, verifier-gated** | no caller-identity check; gated by `IFraudProofVerifier.verify(...)` | fraud *validity*, not caller identity, authorizes the slash → bypasses the colluding quorum |
+| **Address-based** (not slot) | slashes `roleLocks(guardian, ROLE_DVT)` by address | `validatorAtSlot` is reassignable (`revokeBLSPublicKey`); a slot captured at fraud time could resolve to an innocent validator later. Also blocks the revoke-key-to-escape trick |
+| **Full slash, no 30% cap** | slashes the entire lock | proven collusion must lose eligibility; the operator-path 30% cap protects *honest* operators from one bad epoch — a different threat model |
+| **fail-closed** | `fraudProofVerifier == address(0)` → revert | dormant until governance wires a verifier; safe to ship |
+
+So the trigger is **solved**. The remaining unbuilt half is purely the
+**detection**: what does `verify()` actually check.
+
+## 4. Stage-2 blueprint — `IFraudProofVerifier` (owned by this repo)
+
+```solidity
+interface IFraudProofVerifier {
+    function verify(uint256 fraudProofId, address[] calldata guiltyGuardians, bytes calldata fraudProof)
+        external view returns (bool);
+}
+```
+
+SP trusts only an owner-set verifier and never judges fraud itself. This repo
+builds the verifier + the off-chain cross-monitoring that feeds it.
+
+### The `view` constraint bounds ρ
+
+`verify` is `view` → the fraud proof must reduce to **on-chain-checkable facts**.
+That bounds which collusion is objectively provable:
+
+| Slash's underlying evidence | Trustless `view` fraud proof? | ρ status |
+| --- | --- | --- |
+| over-issue (`isOverIssued()` bool) | ✅ can prove "at block N `isOverIssued` was false → slash fraudulent" | can become a system property |
+| liveness / gossip heartbeat (today's active rule ②) | ❌ `evidenceHash` is opaque on-chain; `view` can't adjudicate | needs **CC-29 LivenessRegistry** to put liveness on-chain first |
+| purely off-chain evidence | ❌ | stays a governance assumption |
+
+> **ρ is only a system property for on-chain-objective violation classes.** For
+> off-chain-evidence slashes it remains a detection/governance assumption. This
+> is the same lesson as `AUDIT_SLASH_MODEL.md §2` (only objective on-chain
+> evidence may slash) applied to the accusers instead of the accused.
+
+### Design notes for the verifier
+
+- **`fraudProofId` must be verifier-bound to the fraud content** (e.g. a
+  deterministic derivation of the disputed proposalId), not a caller-arbitrary
+  value, so a valid proof cannot be "consumed" under an unrelated id.
+  (`consumedFraudProofs` in SP is a replay guard, not a binding.)
+- Guilty parties are bound to the **signer address at fraud time**, not the slot
+  (slot reuse — see §3).
+- Double-slash is already prevented by SP's 0-lock skip: a re-submitted proof
+  finds `amount == 0` and no-ops.
+
+## 5. Ownership & sequencing
+
+| Stage | Owner | Status |
+| --- | --- | --- |
+| 1 — `executeGuardianSlash` thin entry | SP | ✅ landed dormant (PR #370, BLSAggregator 4.2.0) |
+| 0 — this doc (auto-eject + threat model + trigger authority) | dvt | ✅ this file |
+| 2 — `IFraudProofVerifier` + off-chain detection (produces ρ) | dvt | ⏳ over-issue class first; liveness class gated on **CC-29** |
+
+**When to activate:** N large + operators independent (not co-located) + an
+on-chain-verifiable independent adjudication path. At the current 3-node,
+co-located, single-owner bootstrap, guardian-slash is dormant by design — the
+anti-collusion property is provided by **trusted owner**, and the paper's
+inequality is a **decentralized-phase target**, not a current deployed property.
+
+## References
+
+- CC-89 (coordination task) — evaluation thread and division of labour.
+- `SuperPaymaster` PR #370 — `executeGuardianSlash` + `IFraudProofVerifier`.
+- [`../AUDIT_SLASH_MODEL.md`](../AUDIT_SLASH_MODEL.md) — the operator-audit side.
+- CC-29 — LivenessRegistry (prerequisite for the liveness fraud-proof class).

--- a/docs/design/guardian-collusion-slash.md
+++ b/docs/design/guardian-collusion-slash.md
@@ -73,8 +73,8 @@ The obvious problem: `queueSlashWithConsensus` / `verifyAndExecute` require
 `msg.sender == DVT_VALIDATOR || owner()`, and the colluders **are** that quorum —
 they will never slash themselves. A same-quorum trigger cannot work.
 
-SP's `executeGuardianSlash` (BLSAggregator 4.2.0, **PR #370**) resolves this at
-the contract layer:
+SP's `executeGuardianSlash` (BLSAggregator 4.2.0, **PR #370 — OPEN, not yet
+merged**) is designed to resolve this at the contract layer:
 
 | Property | How | Why it matters |
 | --- | --- | --- |
@@ -105,11 +105,12 @@ That bounds which collusion is objectively provable:
 
 | Slash's underlying evidence | Trustless `view` fraud proof? | ρ status |
 | --- | --- | --- |
-| over-issue (`isOverIssued()` bool) | ✅ can prove "at block N `isOverIssued` was false → slash fraudulent" | can become a system property |
+| over-issue (`isOverIssued()` bool) | ⚠️ **only within a challenge window** — a `view` verifier reads *current* state, not the `epoch`-block state the slash was pinned to (see "historical-state gap" in §4b) | system property **only** while the disputed block's state is on-chain-provable (bounded window) |
 | liveness / gossip heartbeat (today's active rule ②) | ❌ `evidenceHash` is opaque on-chain; `view` can't adjudicate | needs **CC-29 LivenessRegistry** to put liveness on-chain first |
 | purely off-chain evidence | ❌ | stays a governance assumption |
 
-> **ρ is only a system property for on-chain-objective violation classes.** For
+> **ρ is only a system property for on-chain-objective violation classes, and even
+> then only within a bounded challenge window** (§4b historical-state gap). For
 > off-chain-evidence slashes it remains a detection/governance assumption. This
 > is the same lesson as `AUDIT_SLASH_MODEL.md §2` (only objective on-chain
 > evidence may slash) applied to the accusers instead of the accused.
@@ -119,11 +120,15 @@ That bounds which collusion is objectively provable:
 - **`fraudProofId` must be verifier-bound to the fraud content** (e.g. a
   deterministic derivation of the disputed proposalId), not a caller-arbitrary
   value, so a valid proof cannot be "consumed" under an unrelated id.
-  (`consumedFraudProofs` in SP is a replay guard, not a binding.)
+  (SP's `guardianSlashed[fraudProofId][guardian]` is a replay guard, not a
+  content binding.)
 - Guilty parties are bound to the **signer address at fraud time**, not the slot
   (slot reuse — see §3).
-- Double-slash is already prevented by SP's 0-lock skip: a re-submitted proof
-  finds `amount == 0` and no-ops.
+- Replay/double-slash guard is **per-`(fraudProofId, guardian)`**
+  (`guardianSlashed`), not per-id: a re-submitted proof re-slashing an
+  already-slashed guardian no-ops, and an already-exited (0-lock) co-signer is
+  **not** consumed — so listing an exited guardian can never burn the proof for
+  the still-staked colluders (the exited-guardian griefing fix, PR #370).
 
 ## 4b. Stage-2 fraud-proof spec (draft — CC-89 stage-2 kickoff)
 
@@ -139,8 +144,8 @@ proves it actually ran (view-readable).
 
 | # | Claim | Difficulty |
 | --- | --- | --- |
-| (i) | the cited violation was **false at `epoch`** (the slash was unjustified) | **tractable** for on-chain-objective classes: recompute the evidence from state pinned at the `epoch` block (e.g. `isOverIssued()` was false) |
-| (ii) | a specific set of **guardian addresses co-signed** this exact proposal | **blocked** — see below |
+| (i) | the cited violation was **false at `epoch`** (the slash was unjustified) | **not as easy as it looks** — a `view` verifier reads *current* state, not the `epoch` block. `isOverIssued()` now ≠ at `epoch`. Needs a historical-state mechanism (see "historical-state gap"). |
+| (ii) | a specific set of **guardian addresses co-signed** this exact proposal | resolved by A' (SP commitment) — see "attribution gap" |
 
 ### The attribution gap (ii) — the real stage-2 blocker
 
@@ -153,25 +158,72 @@ mapping ≠ the fraud-time mapping. **Result: after the fact, on-chain state can
 tell you which addresses co-signed a past slash.** You can prove the slash was
 wrong (i) but not who to punish (ii).
 
-Two ways to close (ii):
+**Resolved: A' (commitment compromise)** — decided with SP on CC-89 (Codex-reviewed).
+Three options were weighed:
 
-| Option | Mechanism | Cost / risk |
+| Option | Mechanism | Verdict |
 | --- | --- | --- |
-| **A — SP persists attribution** | `verifyAndExecute` stores, per `proposalId`, the resolved **signer address set** (addresses, not slots). Verifier reads it. | needs an **SP change** (storage + a getter); robust. |
-| **B — proof carries re-verifiable sig** | fraud proof carries `{message, claimedSigners[], sigG2}`; verifier reconstructs the claimed signers' aggregate pubkey from their **current** BLS keys and re-checks the pairing → proves they signed. | no SP storage change, but **breaks if a colluder rotates/revokes its BLS key post-attack** (key no longer on-chain to reconstruct). Needs a key snapshot or accepts the gap. |
+| A — SP stores the full **signer address set** per proposal | robust | rejected: N-address `SSTORE` per slash, heavy |
+| B — proof carries `{message, claimedSigners[], sigG2}`, verifier re-checks the pairing against **current** BLS keys | dvt-only | rejected: **breaks if a colluder revokes/rotates its BLS key post-attack** (a normal guardian right + a natural escape) |
+| **A' — SP stores a 1-word fraud-time commitment** | chosen | ~1/N the gas of A; the commitment is a fraud-time snapshot, so post-attack key revoke can't break it |
 
-> **Decision needed with SP.** Option A is the clean, robust path but makes
-> stage 2 a **joint SP+dvt** change, not dvt-only. Option B keeps it dvt-side but
-> has a post-attack key-revocation hole. This must be settled before any verifier
-> code — it changes who builds what.
+**A' mechanics.** In `verifyAndExecute`, after `_checkSignatures` succeeds and
+before any `revokeBLSPublicKey`, SP persists one word per proposal (reusing the
+`_reconstructPkAgg` slot loop — no second traversal), on **all** success paths
+(incl. reputation/combined):
+
+```solidity
+mapping(uint256 proposalId => bytes32) proposalSignersCommitment;
+commitment = keccak256(abi.encode(
+  "BLS_SIGNERS_COMMITMENT_V1", block.chainid, address(this),
+  proposalId, expectedMessageHash, signerMask, sortedSigners));  // uint160 strict-asc, no dup/zero, ≤ MAX_VALIDATORS
+```
+
+The `verify(fraudProofId, guiltyGuardians, fraudProof)` verifier then:
+1. decodes the disputed `proposalId` + `claimedSigners` from `fraudProof`;
+2. reads `proposalSignersCommitment[proposalId]`, checks `keccak(same-structure) == commitment`;
+3. **enforces `guiltyGuardians ⊆ claimedSigners`** — the commitment only proves
+   the *set*, not that the accused are in it; without this subset check a valid
+   commitment could slash **innocent** addresses (the actual slash targets the
+   externally-supplied `guiltyGuardians`). This check is mandatory, verifier-side;
+4. recomputes the disputed evidence (subject to the historical-state gap below).
+
+**Data availability (dvt).** The commitment is irreversible — it cannot reproduce
+the address set. So the detection layer's watcher **must record `claimedSigners`
+at fraud-observation time**, and watchers must be **redundant / multi-point**: if
+every watcher misses the fraud-time signer set, attribution is permanently lost.
+
+### The historical-state gap (i) — over-issue is not free either
+
+Claim (i) — "the cited violation was false at `epoch`" — is **not** trivially a
+`view` read. `IFraudProofVerifier.verify` is called on-chain from
+`executeGuardianSlash`, where an ordinary Solidity `view` reads **current**
+state. `isOverIssued()` *now* is not `isOverIssued()` at `epoch`. If the token's
+state changes between the false slash and the fraud-proof submission, a naive
+`isOverIssued()` read either fails to slash or adjudicates against the wrong
+block. Closing it needs one of:
+
+- a **bounded challenge window** using `BLOCKHASH` (only the last ~256 blocks are
+  reachable on-chain) + an EIP-1186 storage proof against the `epoch` block's
+  state root → trustless but time-bounded;
+- extending A''s commitment to also anchor the **objective evidence value** at
+  fraud time (only helps if that value is itself objective, not the guardians'
+  claim);
+- a trusted historical-state checkpoint/oracle → weakens ρ to a governance
+  assumption.
+
+**Consequence for the paper:** over-issue ρ is a system property **only within a
+bounded challenge window**, not indefinitely. This must be stated. (It also means
+the challenge-period design SP deferred for the stake-exit escape is needed for
+evidence-recompute too, not just for exit.)
 
 ### fraudProofId binding
 
 `fraudProofId` must be a **deterministic derivation of the disputed
 `proposalId`** (e.g. `keccak256("GUARDIAN_FRAUD", proposalId)`), computed by the
 verifier — never a caller-free value — so a valid proof can't be consumed under
-an unrelated id and the same fraud can't be double-filed. SP's
-`consumedFraudProofs[fraudProofId]` is then a correct replay guard.
+an unrelated id and the same fraud can't be double-filed. SP's per-`(proof,
+guardian)` `guardianSlashed` map is then a correct replay guard.
 
 ### Prerequisites (why stage-2 implementation can't start yet)
 
@@ -179,20 +231,29 @@ an unrelated id and the same fraud can't be double-filed. SP's
    over-issue is a *view* (not a slash), liveness is *auto-jail* (not a
    stake-slash), the slash pipeline is dormant (`AUDIT_SLASH_MODEL.md §4`). No
    armed slash ⇒ nothing to fraud-prove.
-2. **Attribution (ii)** resolved — Option A (SP) or B (dvt), above.
-3. **Liveness class only:** CC-29 `LivenessRegistry` deployed (liveness must be
+2. **A historical-state / challenge-window mechanism** for claim (i) — a `view`
+   verifier can't read `epoch`-block state (above). Bounds when a fraud proof can
+   be filed.
+3. **The claimedSigners watcher** (dvt, redundant) — needed to reproduce the
+   set the A' commitment only anchors.
+4. **Liveness class only:** CC-29 `LivenessRegistry` deployed (liveness must be
    an on-chain fact before a `view` proof can dispute an offline-slash).
+5. Attribution direction (A') is **decided**; SP changing `verifyAndExecute` (a
+   load-bearing consensus path) still requires spec alignment before code.
 
-The **spec is dependency-free and complete enough to build against**; the
-**implementation** waits on 1 + 2 (+ 3 for liveness).
+The **spec is complete enough to build against**; the **implementation** waits on
+1–3 (+ 4 for liveness). Orthogonal: the **stake-exit escape** (a guardian
+withdrawing its ROLE_DVT lock to 0 before the proof → `executeGuardianSlash`
+skips) is a challenger-mechanism concern (challenge period / withdrawal freeze),
+tracked separately.
 
 ## 5. Ownership & sequencing
 
 | Stage | Owner | Status |
 | --- | --- | --- |
-| 1 — `executeGuardianSlash` thin entry | SP | ✅ landed dormant (PR #370, BLSAggregator 4.2.0) |
-| 0 — this doc (auto-eject + threat model + trigger authority) | dvt | ✅ this file |
-| 2 — `IFraudProofVerifier` + off-chain detection (produces ρ) | dvt (+ SP for attribution, §4b) | ⏳ spec drafted (§4b); impl blocked on: an armed slash rule + attribution decision (A/B) + (liveness) CC-29 |
+| 1 — `executeGuardianSlash` thin entry | SP | 🔶 **PR #370 OPEN** (dormant/fail-closed, address-based, per-`(proof,guardian)` idempotent). NOT merged — review in progress. Do not treat as deployed. |
+| 0 — this doc (auto-eject + threat model + trigger authority) | dvt | 🔶 PR #221 OPEN (review in progress) |
+| 2 — `IFraudProofVerifier` + off-chain detection (produces ρ) | dvt (+ SP `proposalSignersCommitment`, §4b) | ⏳ spec drafted (§4b, attribution = A'); impl blocked on: an armed slash rule + a historical-state/challenge-window mechanism + (liveness) CC-29 |
 
 **When to activate:** N large + operators independent (not co-located) + an
 on-chain-verifiable independent adjudication path. At the current 3-node,

--- a/docs/design/guardian-collusion-slash.md
+++ b/docs/design/guardian-collusion-slash.md
@@ -73,8 +73,8 @@ The obvious problem: `queueSlashWithConsensus` / `verifyAndExecute` require
 `msg.sender == DVT_VALIDATOR || owner()`, and the colluders **are** that quorum —
 they will never slash themselves. A same-quorum trigger cannot work.
 
-SP's `executeGuardianSlash` (BLSAggregator 4.2.0, **PR #370 — OPEN, not yet
-merged**) is designed to resolve this at the contract layer:
+SP's `executeGuardianSlash` (BLSAggregator 4.2.0, **PR #370 — merged, but
+dormant** until a verifier is wired) resolves this at the contract layer:
 
 | Property | How | Why it matters |
 | --- | --- | --- |
@@ -251,8 +251,8 @@ tracked separately.
 
 | Stage | Owner | Status |
 | --- | --- | --- |
-| 1 — `executeGuardianSlash` thin entry | SP | 🔶 **PR #370 OPEN** (dormant/fail-closed, address-based, per-`(proof,guardian)` idempotent). NOT merged — review in progress. Do not treat as deployed. |
-| 0 — this doc (auto-eject + threat model + trigger authority) | dvt | 🔶 PR #221 OPEN (review in progress) |
+| 1 — `executeGuardianSlash` thin entry | SP | ✅ **merged** (PR #370, BLSAggregator 4.2.0) — but **dormant/fail-closed** (`fraudProofVerifier == 0` → revert), address-based, per-`(proof,guardian)` idempotent. Code is in-tree but inert until a verifier is wired. |
+| 0 — this doc (auto-eject + threat model + trigger authority) | dvt | PR #221 |
 | 2 — `IFraudProofVerifier` + off-chain detection (produces ρ) | dvt (+ SP `proposalSignersCommitment`, §4b) | ⏳ spec drafted (§4b, attribution = A'); impl blocked on: an armed slash rule + a historical-state/challenge-window mechanism + (liveness) CC-29 |
 
 **When to activate:** N large + operators independent (not co-located) + an

--- a/docs/design/guardian-collusion-slash.md
+++ b/docs/design/guardian-collusion-slash.md
@@ -125,13 +125,74 @@ That bounds which collusion is objectively provable:
 - Double-slash is already prevented by SP's 0-lock skip: a re-submitted proof
   finds `amount == 0` and no-ops.
 
+## 4b. Stage-2 fraud-proof spec (draft — CC-89 stage-2 kickoff)
+
+A fraud proof disputes **one executed slash** and asks the verifier to confirm
+two independent things. The second one is the hard, newly-surfaced blocker.
+
+**What is disputed:** an executed slash proposal
+`(proposalId, operator, slashLevel, epoch, evidenceHash)` — the tuple
+`verifyAndExecute` signed over. `BLSAggregator.executedProposals[proposalId]`
+proves it actually ran (view-readable).
+
+**The verifier must confirm BOTH:**
+
+| # | Claim | Difficulty |
+| --- | --- | --- |
+| (i) | the cited violation was **false at `epoch`** (the slash was unjustified) | **tractable** for on-chain-objective classes: recompute the evidence from state pinned at the `epoch` block (e.g. `isOverIssued()` was false) |
+| (ii) | a specific set of **guardian addresses co-signed** this exact proposal | **blocked** — see below |
+
+### The attribution gap (ii) — the real stage-2 blocker
+
+`BLSAggregator` persists **only `executedProposals[proposalId]` (a bool)**. It
+does **not** store the signer set, the `signerMask`, or the signature; the
+`SlashExecuted` / `SlashConsensusReached` events carry some of it but **a `view`
+verifier cannot read logs**. And `signerMask → validatorAtSlot` is **not**
+back-resolvable: slots are reassignable (`revokeBLSPublicKey`), so today's
+mapping ≠ the fraud-time mapping. **Result: after the fact, on-chain state cannot
+tell you which addresses co-signed a past slash.** You can prove the slash was
+wrong (i) but not who to punish (ii).
+
+Two ways to close (ii):
+
+| Option | Mechanism | Cost / risk |
+| --- | --- | --- |
+| **A — SP persists attribution** | `verifyAndExecute` stores, per `proposalId`, the resolved **signer address set** (addresses, not slots). Verifier reads it. | needs an **SP change** (storage + a getter); robust. |
+| **B — proof carries re-verifiable sig** | fraud proof carries `{message, claimedSigners[], sigG2}`; verifier reconstructs the claimed signers' aggregate pubkey from their **current** BLS keys and re-checks the pairing → proves they signed. | no SP storage change, but **breaks if a colluder rotates/revokes its BLS key post-attack** (key no longer on-chain to reconstruct). Needs a key snapshot or accepts the gap. |
+
+> **Decision needed with SP.** Option A is the clean, robust path but makes
+> stage 2 a **joint SP+dvt** change, not dvt-only. Option B keeps it dvt-side but
+> has a post-attack key-revocation hole. This must be settled before any verifier
+> code — it changes who builds what.
+
+### fraudProofId binding
+
+`fraudProofId` must be a **deterministic derivation of the disputed
+`proposalId`** (e.g. `keccak256("GUARDIAN_FRAUD", proposalId)`), computed by the
+verifier — never a caller-free value — so a valid proof can't be consumed under
+an unrelated id and the same fraud can't be double-filed. SP's
+`consumedFraudProofs[fraudProofId]` is then a correct replay guard.
+
+### Prerequisites (why stage-2 implementation can't start yet)
+
+1. **An armed, on-chain-objective slash rule** to defend. Today none exists:
+   over-issue is a *view* (not a slash), liveness is *auto-jail* (not a
+   stake-slash), the slash pipeline is dormant (`AUDIT_SLASH_MODEL.md §4`). No
+   armed slash ⇒ nothing to fraud-prove.
+2. **Attribution (ii)** resolved — Option A (SP) or B (dvt), above.
+3. **Liveness class only:** CC-29 `LivenessRegistry` deployed (liveness must be
+   an on-chain fact before a `view` proof can dispute an offline-slash).
+
+The **spec is dependency-free and complete enough to build against**; the
+**implementation** waits on 1 + 2 (+ 3 for liveness).
+
 ## 5. Ownership & sequencing
 
 | Stage | Owner | Status |
 | --- | --- | --- |
 | 1 — `executeGuardianSlash` thin entry | SP | ✅ landed dormant (PR #370, BLSAggregator 4.2.0) |
 | 0 — this doc (auto-eject + threat model + trigger authority) | dvt | ✅ this file |
-| 2 — `IFraudProofVerifier` + off-chain detection (produces ρ) | dvt | ⏳ over-issue class first; liveness class gated on **CC-29** |
+| 2 — `IFraudProofVerifier` + off-chain detection (produces ρ) | dvt (+ SP for attribution, §4b) | ⏳ spec drafted (§4b); impl blocked on: an armed slash rule + attribution decision (A/B) + (liveness) CC-29 |
 
 **When to activate:** N large + operators independent (not co-located) + an
 on-chain-verifiable independent adjudication path. At the current 3-node,


### PR DESCRIPTION
## What

Stage 0 of **CC-89 Protocol B** (dvt side) — a design doc, no code change. Companion to `docs/AUDIT_SLASH_MODEL.md` (which covers the quorum auditing *operators*); this covers the inverse: slashing the **guardians** (co-signers) when ≥m collude.

New: `docs/design/guardian-collusion-slash.md`. Cross-link added in `AUDIT_SLASH_MODEL.md`.

## Why

CC-89 (RepCredit paper) flagged that BLS slashing burns the operator's aPNTs but never the colluding guardians' ROLE_DVT stake. SP landed the execution entry (`executeGuardianSlash`, PR #370, dormant). This doc is dvt's stage-0 deliverable: threat model + the mechanism SP's entry plugs into + the stage-2 blueprint we own.

## Contents

- **Threat model**: ≥m colluding guardians pass a *valid* slash of an innocent operator — `verifyAndExecute` verifies m sigs + binds `evidenceHash` but never re-verifies evidence content. Asset distinction: aPNTs ≠ ROLE_DVT lock (not a guaranteed-party distinction).
- **Auto-eject property**: stake `<` minStake → `_reconstructPkAgg` reverts → ejected from signing (paper hadn't documented this).
- **Trigger authority**: SP `executeGuardianSlash` (PR #370) — permissionless + verifier-gated breaks the same-quorum circular dependency; address-based (slot-reuse safe); full slash → auto-eject.
- **Stage-2 blueprint**: `IFraudProofVerifier`; the `view` constraint bounds ρ to on-chain-objective violation classes (over-issue first; liveness gated on CC-29).

## Correction captured for the paper

m for a slash = `slashThresholds[level]` (bootstrap 2/3/3), **not** `defaultThreshold=7` (would overstate collusion resistance ~2–3×).

Refs: CC-89, SuperPaymaster PR #370, CC-29.