### PR TITLE
feat(CC-89): over-issue guardian-collusion fraud-proof verifier + watcher core

### DIFF
--- a/contracts/src/interfaces/IFraudProofVerifier.sol
+++ b/contracts/src/interfaces/IFraudProofVerifier.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.19;
+
+/**
+ * @title IFraudProofVerifier
+ * @notice The seam BLSAggregator.executeGuardianSlash (SuperPaymaster PR #370) plugs into.
+ *         SP trusts only an owner-set verifier and never judges fraud itself: it slashes the
+ *         addresses in `guiltyGuardians` iff `verify(...)` returns true. Correctness of "are
+ *         these guardians truly guilty" is entirely the verifier's job (CC-89 A').
+ *
+ * @dev    `view` — the fraud proof must reduce to on-chain-checkable facts (see
+ *         docs/design/guardian-collusion-slash.md §4b). MUST fail-closed: any malformed input,
+ *         missing/mismatched signer-set commitment, non-subset accusation, or unproven fraud
+ *         returns `false` (never revert on a rejected proof — a revert would let the caller
+ *         distinguish rejection reasons and grief the permissionless entry).
+ */
+interface IFraudProofVerifier {
+    /// @param fraudProofId    Replay-guard key (SP-side, per (proof,guardian)); the verifier binds it
+    ///                        to the disputed content so a valid proof can't be filed under an unrelated id.
+    /// @param guiltyGuardians Addresses the caller wants slashed — the verifier MUST prove
+    ///                        `guiltyGuardians ⊆ claimedSigners` or a valid commitment could slash innocents.
+    /// @param fraudProof      Opaque proof bytes, decoded and interpreted solely by the verifier.
+    /// @return ok             true iff the slash of `guiltyGuardians` is proven fraudulent-collusion.
+    function verify(uint256 fraudProofId, address[] calldata guiltyGuardians, bytes calldata fraudProof)
+        external
+        view
+        returns (bool ok);
+}

--- a/contracts/src/verifiers/OverIssueFraudProofVerifier.sol
+++ b/contracts/src/verifiers/OverIssueFraudProofVerifier.sol
@@ -132,25 +132,14 @@ contract OverIssueFraudProofVerifier is IFraudProofVerifier {
         if (fraudProofId != deriveFraudProofId(proposalId)) return false;
 
         // 2. claimedSigners canonical: strictly ascending uint160, non-zero, bounded.
-        uint256 n = claimedSigners.length;
-        if (n == 0 || n > MAX_SIGNERS) return false;
-        for (uint256 i = 0; i < n; i++) {
-            if (claimedSigners[i] == address(0)) return false;
-            if (i > 0 && uint160(claimedSigners[i - 1]) >= uint160(claimedSigners[i])) return false;
-        }
+        if (!_canonicalSigners(claimedSigners)) return false;
 
-        // 3. Commitment check with disputedToken bound in via evidenceHash → messageHash.
-        //    Reconstruct SP's slash message from the fields (attacker can't swap disputedToken
-        //    without breaking evidenceHash → messageHash → commitment).
-        bytes32 messageHash = slashMessageHash(proposalId, operator, slashLevel, epoch, disputedToken);
-        bytes32 anchor = IBLSAggregatorCommitment(AGGREGATOR).proposalSignersCommitment(proposalId);
-        if (anchor == bytes32(0)) return false; // not a recorded proposal
-        bytes32 recomputed = keccak256(
-            abi.encode(
-                SIGNERS_COMMITMENT_TAG, block.chainid, AGGREGATOR, proposalId, messageHash, signerMask, claimedSigners
-            )
-        );
-        if (recomputed != anchor) return false;
+        // 3. Commitment check with disputedToken bound in via evidenceHash → messageHash (an
+        //    attacker can't swap disputedToken without breaking evidenceHash → messageHash → commitment).
+        //    Extracted into a helper to keep this frame's local count low (coverage compiles without viaIR).
+        if (!_commitmentMatches(proposalId, operator, slashLevel, epoch, disputedToken, signerMask, claimedSigners)) {
+            return false;
+        }
 
         // 4. Subset: guiltyGuardians ⊆ claimedSigners (both strictly ascending → single merge pass).
         if (!_isSubset(guiltyGuardians, claimedSigners)) return false;
@@ -160,6 +149,38 @@ contract OverIssueFraudProofVerifier is IFraudProofVerifier {
         if (IOverIssuable(disputedToken).isOverIssued()) return false;
 
         return true;
+    }
+
+    /// @dev claimedSigners canonical form: strictly ascending uint160, non-zero, bounded.
+    function _canonicalSigners(address[] memory claimedSigners) internal pure returns (bool) {
+        uint256 n = claimedSigners.length;
+        if (n == 0 || n > MAX_SIGNERS) return false;
+        for (uint256 i = 0; i < n; i++) {
+            if (claimedSigners[i] == address(0)) return false;
+            if (i > 0 && uint160(claimedSigners[i - 1]) >= uint160(claimedSigners[i])) return false;
+        }
+        return true;
+    }
+
+    /// @dev Reconstruct SP's slash message (binding disputedToken) and match the A' commitment.
+    function _commitmentMatches(
+        uint256 proposalId,
+        address operator,
+        uint8 slashLevel,
+        uint256 epoch,
+        address disputedToken,
+        uint256 signerMask,
+        address[] memory claimedSigners
+    ) internal view returns (bool) {
+        bytes32 anchor = IBLSAggregatorCommitment(AGGREGATOR).proposalSignersCommitment(proposalId);
+        if (anchor == bytes32(0)) return false; // not a recorded proposal
+        bytes32 messageHash = slashMessageHash(proposalId, operator, slashLevel, epoch, disputedToken);
+        bytes32 recomputed = keccak256(
+            abi.encode(
+                SIGNERS_COMMITMENT_TAG, block.chainid, AGGREGATOR, proposalId, messageHash, signerMask, claimedSigners
+            )
+        );
+        return recomputed == anchor;
     }
 
     /// @dev `sub ⊆ set` where BOTH are strictly ascending by uint160. Requires ≥1 accused.

--- a/contracts/src/verifiers/OverIssueFraudProofVerifier.sol
+++ b/contracts/src/verifiers/OverIssueFraudProofVerifier.sol
@@ -16,36 +16,41 @@ interface IOverIssuable {
 /**
  * @title OverIssueFraudProofVerifier
  * @notice CC-89 stage-2, over-issue class. Proves a guardian-collusion slash was fraudulent so
- *         `BLSAggregator.executeGuardianSlash` can slash the colluding guardians' ROLE_DVT stake.
+ *         `BLSAggregator.executeGuardianSlash` (SP PR #370) can slash the colluding guardians'
+ *         ROLE_DVT stake. SP trusts only this verifier's boolean and never judges fraud itself.
  *
- * A fraud proof is accepted iff ALL hold (fail-closed → `false` otherwise, never revert):
+ * A fraud proof is accepted iff ALL hold (fail-closed → returns `false`, NEVER reverts):
  *   1. `fraudProofId` is the canonical derivation of the disputed `proposalId` (content-bound).
  *   2. `claimedSigners` is canonical: strictly ascending by uint160, non-zero, bounded.
- *   3. `claimedSigners` matches SP's fraud-time A' commitment for `proposalId` (byte-identical recompute).
+ *   3. The FULL disputed slash message is reconstructed from the proof's slash fields and matches
+ *      SP's fraud-time A' commitment for `proposalId`. Crucially the `disputedToken` is bound INTO
+ *      the recomputed `evidenceHash → messageHash → commitment` chain, so an attacker cannot take a
+ *      real proposal's signer set and point it at an unrelated not-over-issued token to slash the
+ *      honest guardians who signed it (the CC-89 Codex-review Critical).
  *   4. `guiltyGuardians ⊆ claimedSigners` — the commitment proves the SET, not that the accused are
- *      in it; without this, a valid commitment could slash an innocent address.
- *   5. the over-issue the slash cited is FALSE — i.e. the token is not over-issued → the slash was unjust.
+ *      in it; without this a valid commitment could slash an innocent address.
+ *   5. the over-issue the slash cited is FALSE — the token is not over-issued → the slash was unjust.
+ *
+ * @dev EVIDENCE STRUCTURE (cross-repo alignment). The disputed slash's `evidenceHash` (opaque to SP,
+ *      supplied by the slash filer) MUST be `keccak256(abi.encode(OVERISSUE_EVIDENCE_TAG, token,
+ *      operator, epoch))`. The E2E slash filer must file with exactly this — else the message
+ *      reconstruction won't match and every proof is rejected.
  *
  * @dev STAGE / SCOPE. Step 5 reads the disputed token's CURRENT `isOverIssued()`. This is the
- *      **testnet-E2E variant** and is sound ONLY while the token's over-issue state is held constant
- *      between the disputed slash and this proof. The **production** variant must recompute against
- *      the disputed epoch-block state (BLOCKHASH + EIP-1186 storage proof, bounded challenge window)
- *      — the historical-state gap in docs/design/guardian-collusion-slash.md §4b. NOT for mainnet as-is.
- *
- * Skeleton status: logic complete for E2E scope; pending Foundry coverage + Codex review + the
- * three CC-89 alignment points (E2E state-hold, watcher `claimedSigners` byte-alignment, fraudProof format).
+ *      **testnet-E2E variant**, sound ONLY while the token's over-issue state is held constant
+ *      between the disputed slash and this proof. PRODUCTION must recompute against the disputed
+ *      epoch-block state (BLOCKHASH + storage proof, bounded challenge window) — the historical-state
+ *      gap in docs/design/guardian-collusion-slash.md §4b. NOT mainnet-ready as-is.
  */
 contract OverIssueFraudProofVerifier is IFraudProofVerifier {
-    /// @notice Domain tag for the deterministic fraudProofId ↔ proposalId binding (step 1).
     string internal constant FRAUD_ID_TAG = "GUARDIAN_FRAUD_V1";
-    /// @notice Domain tag SP anchors the signer-set commitment under (must match PR #371 exactly).
-    string internal constant SIGNERS_COMMITMENT_TAG = "BLS_SIGNERS_COMMITMENT_V1";
-    /// @notice Upper bound on the signer set == BLSAggregator.MAX_VALIDATORS.
-    uint256 internal constant MAX_SIGNERS = 13;
+    string internal constant SIGNERS_COMMITMENT_TAG = "BLS_SIGNERS_COMMITMENT_V1"; // must match SP PR #371
+    string internal constant OVERISSUE_EVIDENCE_TAG = "DVT_OVERISSUE_EVIDENCE_V1";
+    uint256 internal constant MAX_SIGNERS = 13; // == BLSAggregator.MAX_VALIDATORS
 
-    /// @notice The BLSAggregator whose `proposalSignersCommitment` we read AND whose address is
-    ///         bound into the commitment (`address(this)` inside SP's `_computeSignersCommitment`).
-    ///         The recompute only matches when this equals the aggregator that stored the commitment.
+    /// @notice The BLSAggregator whose commitment we read AND whose address SP bound into the
+    ///         commitment (`address(this)` in `_computeSignersCommitment`). The recompute only
+    ///         matches when this equals the aggregator that stored the commitment.
     address public immutable AGGREGATOR;
 
     constructor(address aggregator) {
@@ -58,27 +63,70 @@ contract OverIssueFraudProofVerifier is IFraudProofVerifier {
         return uint256(keccak256(abi.encode(FRAUD_ID_TAG, proposalId)));
     }
 
-    /// @inheritdoc IFraudProofVerifier
-    /// @dev fraudProof = abi.encode(
-    ///        uint256 proposalId, bytes32 messageHash, uint256 signerMask,
-    ///        address[] claimedSigners, address disputedToken)
+    /// @notice The over-issue evidenceHash the slash filer MUST use (binds token+operator+epoch).
+    function evidenceHash(address disputedToken, address operator, uint256 epoch) public pure returns (bytes32) {
+        return keccak256(abi.encode(OVERISSUE_EVIDENCE_TAG, disputedToken, operator, epoch));
+    }
+
+    /// @notice Reconstruct SP's slash-only `expectedMessageHash` (byte-identical to
+    ///         BLSAggregator.verifyAndExecute's slash-path encoding: repUsers/newScores empty).
+    function slashMessageHash(uint256 proposalId, address operator, uint8 slashLevel, uint256 epoch, address disputedToken)
+        public
+        view
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encode(
+                proposalId,
+                operator,
+                slashLevel,
+                new address[](0),
+                new uint256[](0),
+                epoch,
+                block.chainid,
+                evidenceHash(disputedToken, operator, epoch)
+            )
+        );
+    }
+
+    /**
+     * @inheritdoc IFraudProofVerifier
+     * @dev fraudProof = abi.encode(
+     *        uint256 proposalId, address operator, uint8 slashLevel, uint256 epoch,
+     *        address disputedToken, uint256 signerMask, address[] claimedSigners)
+     *      Wraps the real check in a self-staticcall so a malformed proof or a malicious
+     *      `disputedToken` that reverts can only make verify return false — never revert.
+     */
     function verify(uint256 fraudProofId, address[] calldata guiltyGuardians, bytes calldata fraudProof)
         external
         view
         override
         returns (bool)
     {
-        // Malformed proof bytes ⇒ reject (abi.decode reverts are contained by the caller's try/pattern;
-        // executeGuardianSlash treats a revert as a failed proof — but we avoid reverting on shape here).
-        if (fraudProof.length < 160) return false; // 5 head words minimum
+        try this.check(fraudProofId, guiltyGuardians, fraudProof) returns (bool ok) {
+            return ok;
+        } catch {
+            return false; // fail-closed: decode revert, missing commitment call, or token revert
+        }
+    }
+
+    /// @dev The real verification. External only so `verify` can try/catch it; self-call-gated.
+    function check(uint256 fraudProofId, address[] calldata guiltyGuardians, bytes calldata fraudProof)
+        external
+        view
+        returns (bool)
+    {
+        require(msg.sender == address(this), "self only");
 
         (
             uint256 proposalId,
-            bytes32 messageHash,
+            address operator,
+            uint8 slashLevel,
+            uint256 epoch,
+            address disputedToken,
             uint256 signerMask,
-            address[] memory claimedSigners,
-            address disputedToken
-        ) = abi.decode(fraudProof, (uint256, bytes32, uint256, address[], address));
+            address[] memory claimedSigners
+        ) = abi.decode(fraudProof, (uint256, address, uint8, uint256, address, uint256, address[]));
 
         // 1. Content binding: fraudProofId MUST be the canonical derivation of proposalId.
         if (fraudProofId != deriveFraudProofId(proposalId)) return false;
@@ -91,9 +139,12 @@ contract OverIssueFraudProofVerifier is IFraudProofVerifier {
             if (i > 0 && uint160(claimedSigners[i - 1]) >= uint160(claimedSigners[i])) return false;
         }
 
-        // 3. Commitment check: the claimed set must equal SP's fraud-time snapshot for this proposal.
+        // 3. Commitment check with disputedToken bound in via evidenceHash → messageHash.
+        //    Reconstruct SP's slash message from the fields (attacker can't swap disputedToken
+        //    without breaking evidenceHash → messageHash → commitment).
+        bytes32 messageHash = slashMessageHash(proposalId, operator, slashLevel, epoch, disputedToken);
         bytes32 anchor = IBLSAggregatorCommitment(AGGREGATOR).proposalSignersCommitment(proposalId);
-        if (anchor == bytes32(0)) return false; // no such recorded proposal
+        if (anchor == bytes32(0)) return false; // not a recorded proposal
         bytes32 recomputed = keccak256(
             abi.encode(
                 SIGNERS_COMMITMENT_TAG, block.chainid, AGGREGATOR, proposalId, messageHash, signerMask, claimedSigners
@@ -104,8 +155,8 @@ contract OverIssueFraudProofVerifier is IFraudProofVerifier {
         // 4. Subset: guiltyGuardians ⊆ claimedSigners (both strictly ascending → single merge pass).
         if (!_isSubset(guiltyGuardians, claimedSigners)) return false;
 
-        // 5. Over-issue evidence. E2E variant: current-state read (see contract-level @dev). A `false`
-        //    value means the token was not over-issued ⇒ the slash citing over-issue was fraudulent.
+        // 5. Over-issue evidence (E2E current-state variant; see contract @dev). A revert here bubbles
+        //    to verify's catch → false (fail-closed). `false` ⇒ not over-issued ⇒ slash was fraudulent.
         if (IOverIssuable(disputedToken).isOverIssued()) return false;
 
         return true;

--- a/contracts/src/verifiers/OverIssueFraudProofVerifier.sol
+++ b/contracts/src/verifiers/OverIssueFraudProofVerifier.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.19;
+
+import {IFraudProofVerifier} from "../interfaces/IFraudProofVerifier.sol";
+
+/// @dev The BLSAggregator's A' commitment getter (SuperPaymaster PR #371).
+interface IBLSAggregatorCommitment {
+    function proposalSignersCommitment(uint256 proposalId) external view returns (bytes32);
+}
+
+/// @dev A community xPNTs token's objective over-issue flag (CC-28).
+interface IOverIssuable {
+    function isOverIssued() external view returns (bool);
+}
+
+/**
+ * @title OverIssueFraudProofVerifier
+ * @notice CC-89 stage-2, over-issue class. Proves a guardian-collusion slash was fraudulent so
+ *         `BLSAggregator.executeGuardianSlash` can slash the colluding guardians' ROLE_DVT stake.
+ *
+ * A fraud proof is accepted iff ALL hold (fail-closed → `false` otherwise, never revert):
+ *   1. `fraudProofId` is the canonical derivation of the disputed `proposalId` (content-bound).
+ *   2. `claimedSigners` is canonical: strictly ascending by uint160, non-zero, bounded.
+ *   3. `claimedSigners` matches SP's fraud-time A' commitment for `proposalId` (byte-identical recompute).
+ *   4. `guiltyGuardians ⊆ claimedSigners` — the commitment proves the SET, not that the accused are
+ *      in it; without this, a valid commitment could slash an innocent address.
+ *   5. the over-issue the slash cited is FALSE — i.e. the token is not over-issued → the slash was unjust.
+ *
+ * @dev STAGE / SCOPE. Step 5 reads the disputed token's CURRENT `isOverIssued()`. This is the
+ *      **testnet-E2E variant** and is sound ONLY while the token's over-issue state is held constant
+ *      between the disputed slash and this proof. The **production** variant must recompute against
+ *      the disputed epoch-block state (BLOCKHASH + EIP-1186 storage proof, bounded challenge window)
+ *      — the historical-state gap in docs/design/guardian-collusion-slash.md §4b. NOT for mainnet as-is.
+ *
+ * Skeleton status: logic complete for E2E scope; pending Foundry coverage + Codex review + the
+ * three CC-89 alignment points (E2E state-hold, watcher `claimedSigners` byte-alignment, fraudProof format).
+ */
+contract OverIssueFraudProofVerifier is IFraudProofVerifier {
+    /// @notice Domain tag for the deterministic fraudProofId ↔ proposalId binding (step 1).
+    string internal constant FRAUD_ID_TAG = "GUARDIAN_FRAUD_V1";
+    /// @notice Domain tag SP anchors the signer-set commitment under (must match PR #371 exactly).
+    string internal constant SIGNERS_COMMITMENT_TAG = "BLS_SIGNERS_COMMITMENT_V1";
+    /// @notice Upper bound on the signer set == BLSAggregator.MAX_VALIDATORS.
+    uint256 internal constant MAX_SIGNERS = 13;
+
+    /// @notice The BLSAggregator whose `proposalSignersCommitment` we read AND whose address is
+    ///         bound into the commitment (`address(this)` inside SP's `_computeSignersCommitment`).
+    ///         The recompute only matches when this equals the aggregator that stored the commitment.
+    address public immutable AGGREGATOR;
+
+    constructor(address aggregator) {
+        require(aggregator != address(0), "aggregator=0");
+        AGGREGATOR = aggregator;
+    }
+
+    /// @notice Canonical fraudProofId for a disputed proposal (callers derive the same value).
+    function deriveFraudProofId(uint256 proposalId) public pure returns (uint256) {
+        return uint256(keccak256(abi.encode(FRAUD_ID_TAG, proposalId)));
+    }
+
+    /// @inheritdoc IFraudProofVerifier
+    /// @dev fraudProof = abi.encode(
+    ///        uint256 proposalId, bytes32 messageHash, uint256 signerMask,
+    ///        address[] claimedSigners, address disputedToken)
+    function verify(uint256 fraudProofId, address[] calldata guiltyGuardians, bytes calldata fraudProof)
+        external
+        view
+        override
+        returns (bool)
+    {
+        // Malformed proof bytes ⇒ reject (abi.decode reverts are contained by the caller's try/pattern;
+        // executeGuardianSlash treats a revert as a failed proof — but we avoid reverting on shape here).
+        if (fraudProof.length < 160) return false; // 5 head words minimum
+
+        (
+            uint256 proposalId,
+            bytes32 messageHash,
+            uint256 signerMask,
+            address[] memory claimedSigners,
+            address disputedToken
+        ) = abi.decode(fraudProof, (uint256, bytes32, uint256, address[], address));
+
+        // 1. Content binding: fraudProofId MUST be the canonical derivation of proposalId.
+        if (fraudProofId != deriveFraudProofId(proposalId)) return false;
+
+        // 2. claimedSigners canonical: strictly ascending uint160, non-zero, bounded.
+        uint256 n = claimedSigners.length;
+        if (n == 0 || n > MAX_SIGNERS) return false;
+        for (uint256 i = 0; i < n; i++) {
+            if (claimedSigners[i] == address(0)) return false;
+            if (i > 0 && uint160(claimedSigners[i - 1]) >= uint160(claimedSigners[i])) return false;
+        }
+
+        // 3. Commitment check: the claimed set must equal SP's fraud-time snapshot for this proposal.
+        bytes32 anchor = IBLSAggregatorCommitment(AGGREGATOR).proposalSignersCommitment(proposalId);
+        if (anchor == bytes32(0)) return false; // no such recorded proposal
+        bytes32 recomputed = keccak256(
+            abi.encode(
+                SIGNERS_COMMITMENT_TAG, block.chainid, AGGREGATOR, proposalId, messageHash, signerMask, claimedSigners
+            )
+        );
+        if (recomputed != anchor) return false;
+
+        // 4. Subset: guiltyGuardians ⊆ claimedSigners (both strictly ascending → single merge pass).
+        if (!_isSubset(guiltyGuardians, claimedSigners)) return false;
+
+        // 5. Over-issue evidence. E2E variant: current-state read (see contract-level @dev). A `false`
+        //    value means the token was not over-issued ⇒ the slash citing over-issue was fraudulent.
+        if (IOverIssuable(disputedToken).isOverIssued()) return false;
+
+        return true;
+    }
+
+    /// @dev `sub ⊆ set` where BOTH are strictly ascending by uint160. Requires ≥1 accused.
+    function _isSubset(address[] calldata sub, address[] memory set) internal pure returns (bool) {
+        uint256 m = sub.length;
+        if (m == 0) return false;
+        uint256 j = 0;
+        uint256 len = set.length;
+        for (uint256 i = 0; i < m; i++) {
+            if (sub[i] == address(0)) return false;
+            if (i > 0 && uint160(sub[i - 1]) >= uint160(sub[i])) return false; // sub not canonical
+            while (j < len && uint160(set[j]) < uint160(sub[i])) {
+                unchecked {
+                    j++;
+                }
+            }
+            if (j >= len || set[j] != sub[i]) return false; // sub[i] not present in set
+        }
+        return true;
+    }
+}

--- a/contracts/test/OverIssueFraudProofVerifier.t.sol
+++ b/contracts/test/OverIssueFraudProofVerifier.t.sol
@@ -205,6 +205,27 @@ contract OverIssueFraudProofVerifierTest is Test {
         assertFalse(verifier.verify(_fpid(), _g(S2), _proof(_claimed(), address(bad))));
     }
 
+    // ---- golden vector: Solidity commitment == the TS watcher's (byte-alignment) ----
+
+    function test_Golden_CommitmentByteAlignment_MatchesTS() public {
+        // Same fixed vector asserted in src/modules/audit/guardian-fraud-proof.spec.ts.
+        // If Solidity abi.encode and ethers abi.encode ever diverge for these types, both break.
+        vm.chainId(1);
+        address AGG = address(0x0A99);
+        address goldToken = address(0xBEEF);
+        bytes32 mh = verifier.slashMessageHash(42, OPERATOR, 2, 1000, goldToken);
+        assertEq(mh, bytes32(0x593a53c8408d4f89674782c8cf0d3d2b3def99ac442ee6431f64e05965c50a46), "messageHash");
+
+        address[] memory signers = new address[](3);
+        signers[0] = S1;
+        signers[1] = S2;
+        signers[2] = S3;
+        bytes32 commitment = keccak256(
+            abi.encode("BLS_SIGNERS_COMMITMENT_V1", block.chainid, AGG, uint256(42), mh, uint256(0x7), signers)
+        );
+        assertEq(commitment, bytes32(0x8c38195124813c84cddbf33daca3efbb3f4718ba43167e6b30550229693f6588), "commitment");
+    }
+
     function test_Check_NotSelfCallable() public {
         // Pre-compute args so vm.expectRevert applies to the check() call, not the view helpers.
         uint256 id = _fpid();

--- a/contracts/test/OverIssueFraudProofVerifier.t.sol
+++ b/contracts/test/OverIssueFraudProofVerifier.t.sol
@@ -38,19 +38,26 @@ contract MockToken {
     }
 }
 
+contract RevertingToken {
+    function isOverIssued() external pure returns (bool) {
+        revert("boom");
+    }
+}
+
 contract OverIssueFraudProofVerifierTest is Test {
     OverIssueFraudProofVerifier internal verifier;
     MockAggregator internal agg;
     MockToken internal token;
 
-    // Ascending-by-uint160 signer set (numeric order == uint160 order for these).
     address internal constant S1 = address(0x1111);
     address internal constant S2 = address(0x2222);
     address internal constant S3 = address(0x3333);
     address internal constant OUTSIDER = address(0x9999);
 
+    address internal constant OPERATOR = address(0xABCD);
+    uint8 internal constant SLASH_LEVEL = 2; // MAJOR
+    uint256 internal constant EPOCH = 1000;
     uint256 internal constant PROPOSAL_ID = 42;
-    bytes32 internal constant MESSAGE_HASH = keccak256("msg");
     uint256 internal constant SIGNER_MASK = 0x7; // bits 1,2,3
 
     function setUp() public {
@@ -68,66 +75,86 @@ contract OverIssueFraudProofVerifierTest is Test {
         a[2] = S3;
     }
 
-    function _recordCommitment(address[] memory signers) internal {
-        agg.record(PROPOSAL_ID, MESSAGE_HASH, SIGNER_MASK, signers);
+    /// records the commitment for a slash over `disputedToken`, using the verifier's own messageHash
+    /// reconstruction (so test + contract are guaranteed consistent).
+    function _record(address[] memory signers, address disputedToken) internal {
+        bytes32 mh = verifier.slashMessageHash(PROPOSAL_ID, OPERATOR, SLASH_LEVEL, EPOCH, disputedToken);
+        agg.record(PROPOSAL_ID, mh, SIGNER_MASK, signers);
     }
 
-    function _fraudProof(address[] memory claimedSigners) internal view returns (bytes memory) {
-        return abi.encode(PROPOSAL_ID, MESSAGE_HASH, SIGNER_MASK, claimedSigners, address(token));
+    function _proof(address[] memory claimedSigners, address disputedToken) internal pure returns (bytes memory) {
+        return abi.encode(PROPOSAL_ID, OPERATOR, SLASH_LEVEL, EPOCH, disputedToken, SIGNER_MASK, claimedSigners);
     }
 
     function _fpid() internal view returns (uint256) {
         return verifier.deriveFraudProofId(PROPOSAL_ID);
     }
 
-    function _guilty(address one) internal pure returns (address[] memory g) {
+    function _g(address a) internal pure returns (address[] memory g) {
         g = new address[](1);
-        g[0] = one;
+        g[0] = a;
     }
 
     // ---- happy path -------------------------------------------------------
 
     function test_HappyPath_ProvenFraud_ReturnsTrue() public {
-        _recordCommitment(_claimed());
+        _record(_claimed(), address(token));
         token.setOver(false); // NOT over-issued ⇒ the over-issue slash was fraudulent
-        assertTrue(verifier.verify(_fpid(), _guilty(S2), _fraudProof(_claimed())));
+        assertTrue(verifier.verify(_fpid(), _g(S2), _proof(_claimed(), address(token))));
+    }
+
+    function test_HappyPath_MultiGuardianGuilty() public {
+        _record(_claimed(), address(token));
+        token.setOver(false);
+        address[] memory guilty = new address[](2);
+        guilty[0] = S1;
+        guilty[1] = S3; // ascending subset
+        assertTrue(verifier.verify(_fpid(), guilty, _proof(_claimed(), address(token))));
+    }
+
+    // ---- CRITICAL regression: disputedToken must be bound to the slash --------
+
+    function test_Reject_TokenSwap_CannotSlashHonestSignersOfARealSlash() public {
+        // A real slash cited tokenA (say tokenA IS over-issued → the slash was JUST, signers honest).
+        _record(_claimed(), address(token));
+        // Attacker keeps the same proposalId/signers/commitment but points at a fresh not-over-issued token.
+        MockToken tokenB = new MockToken();
+        tokenB.setOver(false);
+        assertFalse(verifier.verify(_fpid(), _g(S2), _proof(_claimed(), address(tokenB))));
     }
 
     // ---- fail-closed negatives -------------------------------------------
 
     function test_Reject_GuiltyNotSubset_CannotSlashInnocent() public {
-        _recordCommitment(_claimed());
+        _record(_claimed(), address(token));
         token.setOver(false);
-        // OUTSIDER co-signed nothing; a valid commitment must not let it be slashed.
-        assertFalse(verifier.verify(_fpid(), _guilty(OUTSIDER), _fraudProof(_claimed())));
+        assertFalse(verifier.verify(_fpid(), _g(OUTSIDER), _proof(_claimed(), address(token))));
     }
 
     function test_Reject_CommitmentMissing() public {
-        // no agg.record(...)
         token.setOver(false);
-        assertFalse(verifier.verify(_fpid(), _guilty(S2), _fraudProof(_claimed())));
+        assertFalse(verifier.verify(_fpid(), _g(S2), _proof(_claimed(), address(token))));
     }
 
     function test_Reject_TamperedClaimedSigners_CommitmentMismatch() public {
-        _recordCommitment(_claimed());
+        _record(_claimed(), address(token));
         token.setOver(false);
-        // Present a different (but canonical) set than the one committed.
         address[] memory tampered = new address[](2);
         tampered[0] = S1;
         tampered[1] = S3;
-        assertFalse(verifier.verify(_fpid(), _guilty(S1), _fraudProof(tampered)));
+        assertFalse(verifier.verify(_fpid(), _g(S1), _proof(tampered, address(token))));
     }
 
     function test_Reject_StillOverIssued_SlashWasJustified() public {
-        _recordCommitment(_claimed());
-        token.setOver(true); // still over-issued ⇒ slash justified ⇒ not fraud
-        assertFalse(verifier.verify(_fpid(), _guilty(S2), _fraudProof(_claimed())));
+        _record(_claimed(), address(token));
+        token.setOver(true);
+        assertFalse(verifier.verify(_fpid(), _g(S2), _proof(_claimed(), address(token))));
     }
 
     function test_Reject_WrongFraudProofId() public {
-        _recordCommitment(_claimed());
+        _record(_claimed(), address(token));
         token.setOver(false);
-        assertFalse(verifier.verify(_fpid() + 1, _guilty(S2), _fraudProof(_claimed())));
+        assertFalse(verifier.verify(_fpid() + 1, _g(S2), _proof(_claimed(), address(token))));
     }
 
     function test_Reject_ClaimedSignersNotCanonical_Unsorted() public {
@@ -135,21 +162,55 @@ contract OverIssueFraudProofVerifierTest is Test {
         unsorted[0] = S3;
         unsorted[1] = S1;
         unsorted[2] = S2;
-        _recordCommitment(unsorted); // commitment over the unsorted set...
+        _record(unsorted, address(token));
         token.setOver(false);
-        // verifier rejects non-canonical claimedSigners regardless of commitment match.
-        assertFalse(verifier.verify(_fpid(), _guilty(S1), _fraudProof(unsorted)));
+        assertFalse(verifier.verify(_fpid(), _g(S1), _proof(unsorted, address(token))));
     }
 
     function test_Reject_ClaimedSignersHasZero() public {
         address[] memory withZero = new address[](2);
         withZero[0] = address(0);
         withZero[1] = S1;
-        _recordCommitment(withZero);
+        _record(withZero, address(token));
         token.setOver(false);
-        assertFalse(verifier.verify(_fpid(), _guilty(S1), _fraudProof(withZero)));
+        assertFalse(verifier.verify(_fpid(), _g(S1), _proof(withZero, address(token))));
     }
 
-    // TODO(stage-2): multi-guardian guilty subset; empty guilty; guilty not ascending;
-    // fuzz over signer sets; historical-state (production) variant once challenge-window lands.
+    function test_Reject_EmptyGuilty() public {
+        _record(_claimed(), address(token));
+        token.setOver(false);
+        assertFalse(verifier.verify(_fpid(), new address[](0), _proof(_claimed(), address(token))));
+    }
+
+    function test_Reject_GuiltyNotAscending() public {
+        _record(_claimed(), address(token));
+        token.setOver(false);
+        address[] memory guilty = new address[](2);
+        guilty[0] = S3;
+        guilty[1] = S1; // descending → rejected
+        assertFalse(verifier.verify(_fpid(), guilty, _proof(_claimed(), address(token))));
+    }
+
+    // ---- never-revert (fail-closed) --------------------------------------
+
+    function test_MalformedProof_ReturnsFalse_NoRevert() public view {
+        bytes memory garbage = hex"deadbeef";
+        assertFalse(verifier.verify(_fpid(), _g(S2), garbage));
+    }
+
+    function test_MaliciousTokenRevert_ReturnsFalse_NoRevert() public {
+        RevertingToken bad = new RevertingToken();
+        _record(_claimed(), address(bad));
+        // token reverts on isOverIssued() → verify catches → false (not a revert, no slash).
+        assertFalse(verifier.verify(_fpid(), _g(S2), _proof(_claimed(), address(bad))));
+    }
+
+    function test_Check_NotSelfCallable() public {
+        // Pre-compute args so vm.expectRevert applies to the check() call, not the view helpers.
+        uint256 id = _fpid();
+        address[] memory g = _g(S2);
+        bytes memory p = _proof(_claimed(), address(token));
+        vm.expectRevert(bytes("self only"));
+        verifier.check(id, g, p);
+    }
 }

--- a/contracts/test/OverIssueFraudProofVerifier.t.sol
+++ b/contracts/test/OverIssueFraudProofVerifier.t.sol
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.19;
+
+import {Test} from "forge-std/Test.sol";
+import {OverIssueFraudProofVerifier} from "../src/verifiers/OverIssueFraudProofVerifier.sol";
+
+/// @dev Mirrors SuperPaymaster BLSAggregator's A' commitment (PR #371). `signers` MUST be pre-sorted
+///      ascending by uint160 — identical encoding to `_computeSignersCommitment`, keyed on address(this).
+contract MockAggregator {
+    mapping(uint256 => bytes32) public proposalSignersCommitment;
+
+    function record(uint256 proposalId, bytes32 messageHash, uint256 signerMask, address[] memory sortedSigners)
+        external
+    {
+        proposalSignersCommitment[proposalId] = keccak256(
+            abi.encode(
+                "BLS_SIGNERS_COMMITMENT_V1",
+                block.chainid,
+                address(this),
+                proposalId,
+                messageHash,
+                signerMask,
+                sortedSigners
+            )
+        );
+    }
+}
+
+contract MockToken {
+    bool public over;
+
+    function setOver(bool v) external {
+        over = v;
+    }
+
+    function isOverIssued() external view returns (bool) {
+        return over;
+    }
+}
+
+contract OverIssueFraudProofVerifierTest is Test {
+    OverIssueFraudProofVerifier internal verifier;
+    MockAggregator internal agg;
+    MockToken internal token;
+
+    // Ascending-by-uint160 signer set (numeric order == uint160 order for these).
+    address internal constant S1 = address(0x1111);
+    address internal constant S2 = address(0x2222);
+    address internal constant S3 = address(0x3333);
+    address internal constant OUTSIDER = address(0x9999);
+
+    uint256 internal constant PROPOSAL_ID = 42;
+    bytes32 internal constant MESSAGE_HASH = keccak256("msg");
+    uint256 internal constant SIGNER_MASK = 0x7; // bits 1,2,3
+
+    function setUp() public {
+        agg = new MockAggregator();
+        token = new MockToken();
+        verifier = new OverIssueFraudProofVerifier(address(agg));
+    }
+
+    // ---- helpers ----------------------------------------------------------
+
+    function _claimed() internal pure returns (address[] memory a) {
+        a = new address[](3);
+        a[0] = S1;
+        a[1] = S2;
+        a[2] = S3;
+    }
+
+    function _recordCommitment(address[] memory signers) internal {
+        agg.record(PROPOSAL_ID, MESSAGE_HASH, SIGNER_MASK, signers);
+    }
+
+    function _fraudProof(address[] memory claimedSigners) internal view returns (bytes memory) {
+        return abi.encode(PROPOSAL_ID, MESSAGE_HASH, SIGNER_MASK, claimedSigners, address(token));
+    }
+
+    function _fpid() internal view returns (uint256) {
+        return verifier.deriveFraudProofId(PROPOSAL_ID);
+    }
+
+    function _guilty(address one) internal pure returns (address[] memory g) {
+        g = new address[](1);
+        g[0] = one;
+    }
+
+    // ---- happy path -------------------------------------------------------
+
+    function test_HappyPath_ProvenFraud_ReturnsTrue() public {
+        _recordCommitment(_claimed());
+        token.setOver(false); // NOT over-issued ⇒ the over-issue slash was fraudulent
+        assertTrue(verifier.verify(_fpid(), _guilty(S2), _fraudProof(_claimed())));
+    }
+
+    // ---- fail-closed negatives -------------------------------------------
+
+    function test_Reject_GuiltyNotSubset_CannotSlashInnocent() public {
+        _recordCommitment(_claimed());
+        token.setOver(false);
+        // OUTSIDER co-signed nothing; a valid commitment must not let it be slashed.
+        assertFalse(verifier.verify(_fpid(), _guilty(OUTSIDER), _fraudProof(_claimed())));
+    }
+
+    function test_Reject_CommitmentMissing() public {
+        // no agg.record(...)
+        token.setOver(false);
+        assertFalse(verifier.verify(_fpid(), _guilty(S2), _fraudProof(_claimed())));
+    }
+
+    function test_Reject_TamperedClaimedSigners_CommitmentMismatch() public {
+        _recordCommitment(_claimed());
+        token.setOver(false);
+        // Present a different (but canonical) set than the one committed.
+        address[] memory tampered = new address[](2);
+        tampered[0] = S1;
+        tampered[1] = S3;
+        assertFalse(verifier.verify(_fpid(), _guilty(S1), _fraudProof(tampered)));
+    }
+
+    function test_Reject_StillOverIssued_SlashWasJustified() public {
+        _recordCommitment(_claimed());
+        token.setOver(true); // still over-issued ⇒ slash justified ⇒ not fraud
+        assertFalse(verifier.verify(_fpid(), _guilty(S2), _fraudProof(_claimed())));
+    }
+
+    function test_Reject_WrongFraudProofId() public {
+        _recordCommitment(_claimed());
+        token.setOver(false);
+        assertFalse(verifier.verify(_fpid() + 1, _guilty(S2), _fraudProof(_claimed())));
+    }
+
+    function test_Reject_ClaimedSignersNotCanonical_Unsorted() public {
+        address[] memory unsorted = new address[](3);
+        unsorted[0] = S3;
+        unsorted[1] = S1;
+        unsorted[2] = S2;
+        _recordCommitment(unsorted); // commitment over the unsorted set...
+        token.setOver(false);
+        // verifier rejects non-canonical claimedSigners regardless of commitment match.
+        assertFalse(verifier.verify(_fpid(), _guilty(S1), _fraudProof(unsorted)));
+    }
+
+    function test_Reject_ClaimedSignersHasZero() public {
+        address[] memory withZero = new address[](2);
+        withZero[0] = address(0);
+        withZero[1] = S1;
+        _recordCommitment(withZero);
+        token.setOver(false);
+        assertFalse(verifier.verify(_fpid(), _guilty(S1), _fraudProof(withZero)));
+    }
+
+    // TODO(stage-2): multi-guardian guilty subset; empty guilty; guilty not ascending;
+    // fuzz over signer sets; historical-state (production) variant once challenge-window lands.
+}

--- a/docs/design/guardian-collusion-slash.md
+++ b/docs/design/guardian-collusion-slash.md
@@ -225,6 +225,32 @@ verifier — never a caller-free value — so a valid proof can't be consumed un
 an unrelated id and the same fraud can't be double-filed. SP's per-`(proof,
 guardian)` `guardianSlashed` map is then a correct replay guard.
 
+### Over-issue evidence & slash convention (the filer MUST match)
+
+To bind the disputed `token` into the commitment (closing the token-swap forgery
+a naive verifier allows — CC-89 Codex review), the verifier does **not** trust a
+caller-supplied message hash. It reconstructs SP's slash-only `expectedMessageHash`
+from the slash fields, where the over-issue `evidenceHash` has a **fixed preimage**:
+
+```
+evidenceHash = keccak256(abi.encode("DVT_OVERISSUE_EVIDENCE_V1", token, operator, epoch))
+messageHash  = keccak256(abi.encode(proposalId, operator, slashLevel,
+                                    address[](0), uint256[](0),   // repUsers, newScores — see below
+                                    epoch, block.chainid, evidenceHash))
+commitment   = keccak256(abi.encode("BLS_SIGNERS_COMMITMENT_V1", chainid, aggregator,
+                                    proposalId, messageHash, signerMask, claimedSigners))
+```
+
+**Whoever files an over-issue slash (the E2E filer / the future audit rule) MUST**:
+1. set `evidenceHash = keccak256(abi.encode("DVT_OVERISSUE_EVIDENCE_V1", token, operator, epoch))`;
+2. file it as a **pure** slash — `repUsers` **and** `newScores` both empty. SP's
+   slash-only branch fires on `repUsers.length == 0` alone, but the verifier only
+   recognises the canonical empty/empty form; a non-empty `newScores` yields a
+   different `messageHash` and the proof will (fail-closed) not verify.
+
+Any deviation just means that slash cannot be fraud-proven (no wrongful slash) —
+but it is a **cross-repo alignment point**, not something the verifier can self-enforce.
+
 ### Prerequisites (why stage-2 implementation can't start yet)
 
 1. **An armed, on-chain-objective slash rule** to defend. Today none exists:

--- a/src/modules/audit/guardian-fraud-proof.spec.ts
+++ b/src/modules/audit/guardian-fraud-proof.spec.ts
@@ -1,0 +1,73 @@
+import { ethers } from "ethers";
+import {
+  decodeSignerMask,
+  deriveFraudProofId,
+  overIssueEvidenceHash,
+  encodeOverIssueFraudProof,
+  FRAUD_ID_TAG,
+  OVERISSUE_EVIDENCE_TAG,
+  OverIssueFraudProofInputs,
+} from "./guardian-fraud-proof.js";
+
+const coder = ethers.AbiCoder.defaultAbiCoder();
+
+const S1 = ethers.getAddress("0x0000000000000000000000000000000000001111");
+const S2 = ethers.getAddress("0x0000000000000000000000000000000000002222");
+const S3 = ethers.getAddress("0x0000000000000000000000000000000000003333");
+const OPERATOR = ethers.getAddress("0x000000000000000000000000000000000000abcd");
+const TOKEN = ethers.getAddress("0x000000000000000000000000000000000000beef");
+
+describe("guardian-fraud-proof encoding (CC-89 stage-2)", () => {
+  it("decodeSignerMask reads the first word of abi.encode(mask, sigG2)", () => {
+    const proof = coder.encode(["uint256", "bytes"], [0x7n, "0xdeadbeef"]);
+    expect(decodeSignerMask(proof)).toBe(0x7n);
+  });
+
+  it("deriveFraudProofId is deterministic, id-bound, and matches the verifier's keccak", () => {
+    const id = deriveFraudProofId(42n);
+    // Same value the Solidity verifier computes: keccak256(abi.encode("GUARDIAN_FRAUD_V1", proposalId)).
+    const expected = BigInt(ethers.keccak256(coder.encode(["string", "uint256"], [FRAUD_ID_TAG, 42n])));
+    expect(id).toBe(expected);
+    expect(deriveFraudProofId(42n)).toBe(id); // deterministic
+    expect(deriveFraudProofId(43n)).not.toBe(id); // proposal-bound
+    expect(id).toBeLessThan(1n << 256n); // valid uint256
+  });
+
+  it("overIssueEvidenceHash binds token/operator/epoch (fixed preimage)", () => {
+    const h = overIssueEvidenceHash(TOKEN, OPERATOR, 1000n);
+    const expected = ethers.keccak256(
+      coder.encode(
+        ["string", "address", "address", "uint256"],
+        [OVERISSUE_EVIDENCE_TAG, TOKEN, OPERATOR, 1000n]
+      )
+    );
+    expect(h).toBe(expected);
+    // token swap ⇒ different hash (this is what closes the Codex Critical on-chain).
+    const other = ethers.getAddress("0x000000000000000000000000000000000000c0de");
+    expect(overIssueEvidenceHash(other, OPERATOR, 1000n)).not.toBe(h);
+  });
+
+  it("encodeOverIssueFraudProof round-trips through the verifier's decode shape", () => {
+    const inputs: OverIssueFraudProofInputs = {
+      proposalId: 42n,
+      operator: OPERATOR,
+      slashLevel: 2,
+      epoch: 1000n,
+      disputedToken: TOKEN,
+      signerMask: 0x7n,
+      claimedSigners: [S1, S2, S3],
+    };
+    const bytes = encodeOverIssueFraudProof(inputs);
+    const [proposalId, operator, slashLevel, epoch, disputedToken, signerMask, claimedSigners] = coder.decode(
+      ["uint256", "address", "uint8", "uint256", "address", "uint256", "address[]"],
+      bytes
+    );
+    expect(BigInt(proposalId)).toBe(42n);
+    expect(operator).toBe(OPERATOR);
+    expect(Number(slashLevel)).toBe(2);
+    expect(BigInt(epoch)).toBe(1000n);
+    expect(disputedToken).toBe(TOKEN);
+    expect(BigInt(signerMask)).toBe(0x7n);
+    expect([...claimedSigners]).toEqual([S1, S2, S3]);
+  });
+});

--- a/src/modules/audit/guardian-fraud-proof.spec.ts
+++ b/src/modules/audit/guardian-fraud-proof.spec.ts
@@ -1,9 +1,12 @@
 import { ethers } from "ethers";
 import {
-  decodeSignerMask,
+  decodeSignerMaskFromBlsProof,
   deriveFraudProofId,
   overIssueEvidenceHash,
+  overIssueSlashMessageHash,
+  computeSignersCommitment,
   encodeOverIssueFraudProof,
+  orderSignersFromSlotMap,
   FRAUD_ID_TAG,
   OVERISSUE_EVIDENCE_TAG,
   OverIssueFraudProofInputs,
@@ -18,19 +21,20 @@ const OPERATOR = ethers.getAddress("0x000000000000000000000000000000000000abcd")
 const TOKEN = ethers.getAddress("0x000000000000000000000000000000000000beef");
 
 describe("guardian-fraud-proof encoding (CC-89 stage-2)", () => {
-  it("decodeSignerMask reads the first word of abi.encode(mask, sigG2)", () => {
+  it("decodeSignerMaskFromBlsProof reads the first word of abi.encode(mask, sigG2)", () => {
     const proof = coder.encode(["uint256", "bytes"], [0x7n, "0xdeadbeef"]);
-    expect(decodeSignerMask(proof)).toBe(0x7n);
+    expect(decodeSignerMaskFromBlsProof(proof)).toBe(0x7n);
   });
 
   it("deriveFraudProofId is deterministic, id-bound, and matches the verifier's keccak", () => {
     const id = deriveFraudProofId(42n);
-    // Same value the Solidity verifier computes: keccak256(abi.encode("GUARDIAN_FRAUD_V1", proposalId)).
-    const expected = BigInt(ethers.keccak256(coder.encode(["string", "uint256"], [FRAUD_ID_TAG, 42n])));
+    const expected = BigInt(
+      ethers.keccak256(coder.encode(["string", "uint256"], [FRAUD_ID_TAG, 42n]))
+    );
     expect(id).toBe(expected);
-    expect(deriveFraudProofId(42n)).toBe(id); // deterministic
-    expect(deriveFraudProofId(43n)).not.toBe(id); // proposal-bound
-    expect(id).toBeLessThan(1n << 256n); // valid uint256
+    expect(deriveFraudProofId(42n)).toBe(id);
+    expect(deriveFraudProofId(43n)).not.toBe(id);
+    expect(id).toBeLessThan(1n << 256n);
   });
 
   it("overIssueEvidenceHash binds token/operator/epoch (fixed preimage)", () => {
@@ -42,7 +46,6 @@ describe("guardian-fraud-proof encoding (CC-89 stage-2)", () => {
       )
     );
     expect(h).toBe(expected);
-    // token swap ⇒ different hash (this is what closes the Codex Critical on-chain).
     const other = ethers.getAddress("0x000000000000000000000000000000000000c0de");
     expect(overIssueEvidenceHash(other, OPERATOR, 1000n)).not.toBe(h);
   });
@@ -58,10 +61,11 @@ describe("guardian-fraud-proof encoding (CC-89 stage-2)", () => {
       claimedSigners: [S1, S2, S3],
     };
     const bytes = encodeOverIssueFraudProof(inputs);
-    const [proposalId, operator, slashLevel, epoch, disputedToken, signerMask, claimedSigners] = coder.decode(
-      ["uint256", "address", "uint8", "uint256", "address", "uint256", "address[]"],
-      bytes
-    );
+    const [proposalId, operator, slashLevel, epoch, disputedToken, signerMask, claimedSigners] =
+      coder.decode(
+        ["uint256", "address", "uint8", "uint256", "address", "uint256", "address[]"],
+        bytes
+      );
     expect(BigInt(proposalId)).toBe(42n);
     expect(operator).toBe(OPERATOR);
     expect(Number(slashLevel)).toBe(2);
@@ -69,5 +73,44 @@ describe("guardian-fraud-proof encoding (CC-89 stage-2)", () => {
     expect(disputedToken).toBe(TOKEN);
     expect(BigInt(signerMask)).toBe(0x7n);
     expect([...claimedSigners]).toEqual([S1, S2, S3]);
+  });
+
+  describe("orderSignersFromSlotMap (byte-critical derivation)", () => {
+    // slot→address map returning an already-scrambled order to prove the ascending sort.
+    const slotMap: Record<number, string> = { 1: S3, 2: S1, 3: S2 };
+    const resolver = (slot: number) => Promise.resolve(slotMap[slot] ?? ethers.ZeroAddress);
+
+    it("maps set bits to 1-indexed slots and sorts ascending by uint160", async () => {
+      // mask 0x7 = bits 0,1,2 → slots 1,2,3 → [S3,S1,S2] → sorted [S1,S2,S3]
+      expect(await orderSignersFromSlotMap(0x7n, resolver)).toEqual([S1, S2, S3]);
+    });
+
+    it("selects only the set slots (bit i ⇔ slot i+1)", async () => {
+      // mask 0x5 = bits 0,2 → slots 1,3 → [S3,S2] → sorted [S2,S3]
+      expect(await orderSignersFromSlotMap(0x5n, resolver)).toEqual([S2, S3]);
+    });
+
+    it("rejects a signerMask with bits above MAX_VALIDATORS (slot 13)", async () => {
+      await expect(orderSignersFromSlotMap(1n << 13n, resolver)).rejects.toThrow(
+        /bits above slot 13/
+      );
+    });
+
+    it("rejects a zero-address slot (partial/wrong set)", async () => {
+      // mask 0xF = slots 1..4, but slot 4 is unset in the map → zero → throw
+      await expect(orderSignersFromSlotMap(0xfn, resolver)).rejects.toThrow(/is zero/);
+    });
+  });
+
+  it("computeSignersCommitment matches a golden vector (TS↔Solidity byte-alignment)", () => {
+    // Same fixed vector asserted in the Foundry test (OverIssueFraudProofVerifier.t.sol golden test):
+    // chainId=1, aggregator=0x…0A99, proposalId=42, operator=…abcd, slashLevel=2, epoch=1000,
+    // token=…beef, signerMask=0x7, claimedSigners=[S1,S2,S3]. If ethers and Solidity abi.encode
+    // ever diverge for these types, this hex changes and both suites break.
+    const AGG = ethers.getAddress("0x0000000000000000000000000000000000000a99");
+    const mh = overIssueSlashMessageHash(1n, 42n, OPERATOR, 2, 1000n, TOKEN);
+    const commitment = computeSignersCommitment(AGG, 1n, 42n, mh, 0x7n, [S1, S2, S3]);
+    expect(mh).toBe("0x593a53c8408d4f89674782c8cf0d3d2b3def99ac442ee6431f64e05965c50a46");
+    expect(commitment).toBe("0x8c38195124813c84cddbf33daca3efbb3f4718ba43167e6b30550229693f6588");
   });
 });

--- a/src/modules/audit/guardian-fraud-proof.ts
+++ b/src/modules/audit/guardian-fraud-proof.ts
@@ -1,0 +1,119 @@
+import { ethers } from "ethers";
+
+/**
+ * CC-89 stage-2 (over-issue class) — the off-chain half that feeds
+ * `OverIssueFraudProofVerifier`. Two concerns live here:
+ *
+ *  1. `resolveClaimedSigners` — the byte-critical derivation the watcher runs: from a
+ *     `verifyAndExecute` tx's `signerMask`, resolve the co-signer ADDRESSES using the
+ *     aggregator's `validatorAtSlot` **pinned to the verifyAndExecute EXECUTION block**
+ *     (NOT the over-issue epoch block — SP correction, CC-89 7b4f237e #2), sorted strictly
+ *     ascending by uint160. This MUST match SP's `_computeSignersCommitment` `sorted`
+ *     derivation byte-for-byte, else the on-chain commitment check rejects every proof.
+ *
+ *  2. `encodeOverIssueFraudProof` / `deriveFraudProofId` — the assembler: builds the exact
+ *     `fraudProof` bytes + `fraudProofId` the verifier decodes. The over-issue slash's
+ *     `evidenceHash` has a FIXED preimage the E2E filer must also use (docs §4b).
+ *
+ * The commitment is irreversible, so the watcher MUST record `claimedSigners` at
+ * fraud-observation time and MUST be run redundantly on multiple nodes — if every watcher
+ * misses a slash's signer set, attribution is permanently lost.
+ */
+
+/** Domain tags — MUST match OverIssueFraudProofVerifier.sol exactly. */
+export const FRAUD_ID_TAG = "GUARDIAN_FRAUD_V1";
+export const OVERISSUE_EVIDENCE_TAG = "DVT_OVERISSUE_EVIDENCE_V1";
+/** BLSAggregator.MAX_VALIDATORS. */
+export const MAX_VALIDATORS = 13;
+
+/** Decode the `signerMask` from a verifyAndExecute `proof` (= abi.encode(uint256 signerMask, bytes sigG2)). */
+export function decodeSignerMask(proof: string): bigint {
+  // Only the first 32-byte word is the mask; SP decodes proof[:32] likewise.
+  const [signerMask] = ethers.AbiCoder.defaultAbiCoder().decode(["uint256"], ethers.dataSlice(proof, 0, 32));
+  return BigInt(signerMask);
+}
+
+/**
+ * Resolve co-signer addresses for a `signerMask`, reading `validatorAtSlot` pinned to
+ * `executionBlock` (the block the verifyAndExecute tx was mined in), sorted ascending by
+ * uint160 — byte-identical to SP `_computeSignersCommitment`.
+ *
+ * THROWS if any selected slot resolves to the zero address at that block (a hole means the
+ * mask/block pair is wrong — never silently record a partial/incorrect set).
+ */
+export async function resolveClaimedSigners(
+  provider: ethers.Provider,
+  aggregator: string,
+  signerMask: bigint,
+  executionBlock: number
+): Promise<string[]> {
+  const agg = new ethers.Contract(
+    aggregator,
+    ["function validatorAtSlot(uint8 slot) view returns (address)"],
+    provider
+  );
+  const signers: string[] = [];
+  for (let slot = 1; slot <= MAX_VALIDATORS; slot++) {
+    if (((signerMask >> BigInt(slot - 1)) & 1n) === 0n) continue;
+    const addr: string = await agg.validatorAtSlot(slot, { blockTag: executionBlock });
+    if (addr === ethers.ZeroAddress) {
+      throw new Error(
+        `resolveClaimedSigners: slot ${slot} is zero at block ${executionBlock} — wrong mask/block?`
+      );
+    }
+    signers.push(ethers.getAddress(addr));
+  }
+  // Strictly ascending by uint160(address). getAddress → checksummed; compare on the numeric value.
+  signers.sort((a, b) => {
+    const x = BigInt(a);
+    const y = BigInt(b);
+    return x < y ? -1 : x > y ? 1 : 0;
+  });
+  // Reject a duplicate (a healthy slot map never repeats an address across selected slots).
+  for (let i = 1; i < signers.length; i++) {
+    if (BigInt(signers[i - 1]) >= BigInt(signers[i])) {
+      throw new Error(`resolveClaimedSigners: duplicate/unordered signer ${signers[i]}`);
+    }
+  }
+  return signers;
+}
+
+/** Canonical fraudProofId — MUST match verifier.deriveFraudProofId. */
+export function deriveFraudProofId(proposalId: bigint): bigint {
+  return BigInt(
+    ethers.keccak256(ethers.AbiCoder.defaultAbiCoder().encode(["string", "uint256"], [FRAUD_ID_TAG, proposalId]))
+  );
+}
+
+/** The over-issue evidenceHash the slash filer MUST use — binds token+operator+epoch. */
+export function overIssueEvidenceHash(disputedToken: string, operator: string, epoch: bigint): string {
+  return ethers.keccak256(
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      ["string", "address", "address", "uint256"],
+      [OVERISSUE_EVIDENCE_TAG, disputedToken, operator, epoch]
+    )
+  );
+}
+
+export interface OverIssueFraudProofInputs {
+  proposalId: bigint;
+  operator: string;
+  slashLevel: number;
+  epoch: bigint;
+  disputedToken: string;
+  signerMask: bigint;
+  /** MUST be the strictly-ascending set from resolveClaimedSigners. */
+  claimedSigners: string[];
+}
+
+/**
+ * Assemble the `fraudProof` bytes the verifier decodes:
+ *   abi.encode(uint256 proposalId, address operator, uint8 slashLevel, uint256 epoch,
+ *              address disputedToken, uint256 signerMask, address[] claimedSigners)
+ */
+export function encodeOverIssueFraudProof(i: OverIssueFraudProofInputs): string {
+  return ethers.AbiCoder.defaultAbiCoder().encode(
+    ["uint256", "address", "uint8", "uint256", "address", "uint256", "address[]"],
+    [i.proposalId, i.operator, i.slashLevel, i.epoch, i.disputedToken, i.signerMask, i.claimedSigners]
+  );
+}

--- a/src/modules/audit/guardian-fraud-proof.ts
+++ b/src/modules/audit/guardian-fraud-proof.ts
@@ -23,13 +23,21 @@ import { ethers } from "ethers";
 /** Domain tags — MUST match OverIssueFraudProofVerifier.sol exactly. */
 export const FRAUD_ID_TAG = "GUARDIAN_FRAUD_V1";
 export const OVERISSUE_EVIDENCE_TAG = "DVT_OVERISSUE_EVIDENCE_V1";
+export const SIGNERS_COMMITMENT_TAG = "BLS_SIGNERS_COMMITMENT_V1";
 /** BLSAggregator.MAX_VALIDATORS. */
 export const MAX_VALIDATORS = 13;
 
-/** Decode the `signerMask` from a verifyAndExecute `proof` (= abi.encode(uint256 signerMask, bytes sigG2)). */
-export function decodeSignerMask(proof: string): bigint {
-  // Only the first 32-byte word is the mask; SP decodes proof[:32] likewise.
-  const [signerMask] = ethers.AbiCoder.defaultAbiCoder().decode(["uint256"], ethers.dataSlice(proof, 0, 32));
+/**
+ * Decode the `signerMask` from a raw verifyAndExecute BLS `proof`
+ * (= `abi.encode(uint256 signerMask, bytes sigG2)`). NOTE: this is the SP-side BLS proof,
+ * NOT the verifier's `fraudProof` (which starts with `proposalId`, mask being its 6th field).
+ * Only the first 32-byte word is the mask; SP decodes `proof[:32]` likewise.
+ */
+export function decodeSignerMaskFromBlsProof(proof: string): bigint {
+  const [signerMask] = ethers.AbiCoder.defaultAbiCoder().decode(
+    ["uint256"],
+    ethers.dataSlice(proof, 0, 32)
+  );
   return BigInt(signerMask);
 }
 
@@ -52,27 +60,46 @@ export async function resolveClaimedSigners(
     ["function validatorAtSlot(uint8 slot) view returns (address)"],
     provider
   );
+  return orderSignersFromSlotMap(signerMask, slot =>
+    agg.validatorAtSlot(slot, { blockTag: executionBlock })
+  );
+}
+
+/**
+ * The pure, testable core of the derivation: given a `signerMask` and an async slot→address
+ * resolver (pinned to the execution block), produce the strictly-ascending-by-uint160 signer set
+ * that reproduces SP's `_computeSignersCommitment` `sorted` array. Rejects high mask bits, zero
+ * slots, and duplicates (never a partial/wrong set).
+ */
+export async function orderSignersFromSlotMap(
+  signerMask: bigint,
+  resolveSlot: (slot: number) => Promise<string>
+): Promise<string[]> {
+  // Reject mask bits beyond MAX_VALIDATORS — SP's _reconstructPkAgg rejects them outright, so a
+  // high bit means the mask is wrong; never silently drop it (the fraudProof embeds the raw mask).
+  if (signerMask >> BigInt(MAX_VALIDATORS) !== 0n) {
+    throw new Error(
+      `orderSignersFromSlotMap: signerMask ${signerMask.toString(16)} has bits above slot ${MAX_VALIDATORS}`
+    );
+  }
   const signers: string[] = [];
   for (let slot = 1; slot <= MAX_VALIDATORS; slot++) {
     if (((signerMask >> BigInt(slot - 1)) & 1n) === 0n) continue;
-    const addr: string = await agg.validatorAtSlot(slot, { blockTag: executionBlock });
+    const addr = await resolveSlot(slot);
     if (addr === ethers.ZeroAddress) {
-      throw new Error(
-        `resolveClaimedSigners: slot ${slot} is zero at block ${executionBlock} — wrong mask/block?`
-      );
+      throw new Error(`orderSignersFromSlotMap: slot ${slot} is zero — wrong mask/block?`);
     }
     signers.push(ethers.getAddress(addr));
   }
-  // Strictly ascending by uint160(address). getAddress → checksummed; compare on the numeric value.
+  // Strictly ascending by uint160(address) — matches SP's uint160 sort (checksum doesn't affect it).
   signers.sort((a, b) => {
     const x = BigInt(a);
     const y = BigInt(b);
     return x < y ? -1 : x > y ? 1 : 0;
   });
-  // Reject a duplicate (a healthy slot map never repeats an address across selected slots).
   for (let i = 1; i < signers.length; i++) {
     if (BigInt(signers[i - 1]) >= BigInt(signers[i])) {
-      throw new Error(`resolveClaimedSigners: duplicate/unordered signer ${signers[i]}`);
+      throw new Error(`orderSignersFromSlotMap: duplicate/unordered signer ${signers[i]}`);
     }
   }
   return signers;
@@ -81,12 +108,18 @@ export async function resolveClaimedSigners(
 /** Canonical fraudProofId — MUST match verifier.deriveFraudProofId. */
 export function deriveFraudProofId(proposalId: bigint): bigint {
   return BigInt(
-    ethers.keccak256(ethers.AbiCoder.defaultAbiCoder().encode(["string", "uint256"], [FRAUD_ID_TAG, proposalId]))
+    ethers.keccak256(
+      ethers.AbiCoder.defaultAbiCoder().encode(["string", "uint256"], [FRAUD_ID_TAG, proposalId])
+    )
   );
 }
 
 /** The over-issue evidenceHash the slash filer MUST use — binds token+operator+epoch. */
-export function overIssueEvidenceHash(disputedToken: string, operator: string, epoch: bigint): string {
+export function overIssueEvidenceHash(
+  disputedToken: string,
+  operator: string,
+  epoch: bigint
+): string {
   return ethers.keccak256(
     ethers.AbiCoder.defaultAbiCoder().encode(
       ["string", "address", "address", "uint256"],
@@ -114,6 +147,73 @@ export interface OverIssueFraudProofInputs {
 export function encodeOverIssueFraudProof(i: OverIssueFraudProofInputs): string {
   return ethers.AbiCoder.defaultAbiCoder().encode(
     ["uint256", "address", "uint8", "uint256", "address", "uint256", "address[]"],
-    [i.proposalId, i.operator, i.slashLevel, i.epoch, i.disputedToken, i.signerMask, i.claimedSigners]
+    [
+      i.proposalId,
+      i.operator,
+      i.slashLevel,
+      i.epoch,
+      i.disputedToken,
+      i.signerMask,
+      i.claimedSigners,
+    ]
+  );
+}
+
+/**
+ * Reconstruct SP's slash-only `expectedMessageHash` (byte-identical to
+ * BLSAggregator.verifyAndExecute's slash path AND to verifier.slashMessageHash): over-issue
+ * slashes are pure slashes, so `repUsers` and `newScores` are BOTH empty.
+ */
+export function overIssueSlashMessageHash(
+  chainId: bigint,
+  proposalId: bigint,
+  operator: string,
+  slashLevel: number,
+  epoch: bigint,
+  disputedToken: string
+): string {
+  return ethers.keccak256(
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      ["uint256", "address", "uint8", "address[]", "uint256[]", "uint256", "uint256", "bytes32"],
+      [
+        proposalId,
+        operator,
+        slashLevel,
+        [],
+        [],
+        epoch,
+        chainId,
+        overIssueEvidenceHash(disputedToken, operator, epoch),
+      ]
+    )
+  );
+}
+
+/**
+ * Recompute SP's A' `proposalSignersCommitment` (byte-identical to `_computeSignersCommitment`).
+ * The watcher can self-check that its assembled proof WILL pass on-chain before submitting.
+ * `messageHash` must be built with the SAME chainId as `overIssueSlashMessageHash` used.
+ */
+export function computeSignersCommitment(
+  aggregator: string,
+  chainId: bigint,
+  proposalId: bigint,
+  messageHash: string,
+  signerMask: bigint,
+  claimedSigners: string[]
+): string {
+  return ethers.keccak256(
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      ["string", "uint256", "address", "uint256", "bytes32", "uint256", "address[]"],
+      [
+        SIGNERS_COMMITMENT_TAG,
+        chainId,
+        aggregator,
+        proposalId,
+        messageHash,
+        signerMask,
+        claimedSigners,
+      ]
+    )
   );
 }


### PR DESCRIPTION
## What

DVT stage-2 (over-issue class) of CC-89 guardian-collusion slashing — the half that lets SP's `BLSAggregator.executeGuardianSlash` (PR #370, merged) actually slash a colluding guardian. SP delivered the A' commitment (PR #371, merged); this is the DVT verifier + the byte-critical watcher core.

**Scope = testnet-E2E mechanism.** NOT mainnet-armed (see the historical-state note below).

## Contents

**On-chain (`contracts/`)**
- `IFraudProofVerifier.sol` — the seam `executeGuardianSlash` calls.
- `OverIssueFraudProofVerifier.sol` — `verify()`: fraudProofId content-binding → canonical `claimedSigners` → **reconstruct SP's slash message (evidenceHash→messageHash) and match the A' commitment** → `guiltyGuardians ⊆ claimedSigners` → over-issue evidence. Fail-closed (never reverts; `try/catch` self-call). Handles the pr-daemon `commitment != 0` constraint.
- 16 Foundry tests (happy, multi-guardian, token-swap regression, subset-rejects-innocent, commitment missing/mismatch, still-over-issued, non-canonical, never-revert, self-gate, **golden byte-alignment**).

**Off-chain (`src/modules/audit/`)**
- `guardian-fraud-proof.ts` — `resolveClaimedSigners` (co-signers from `signerMask` via `validatorAtSlot` **pinned to the verifyAndExecute execution block**, uint160-sorted, matching SP `_computeSignersCommitment`) + the fraudProof assembler + `computeSignersCommitment` (watcher self-check).
- 9 jest tests incl. the **golden vector cross-checked against the Foundry test** — same inputs → same commitment hex on both sides, proving ethers ↔ Solidity `abi.encode` alignment.

## Review (per convention, done before this PR)
- **Verifier: 2 Codex rounds.** Round 1 caught a **Critical** (skeleton trusted a caller-supplied messageHash → an attacker could slash the honest signers of any real slash by pointing at a fresh not-over-issued token). Fixed by reconstructing the message from the slash fields, binding `disputedToken`. Round 2: no residual Critical/High.
- **Watcher core: 1 Codex round.** No Critical/High (byte-aligned, no false-positive-slash). Low/Medium findings (high-bit guard, naming, golden cross-check) all applied.

## Cross-repo alignment (for the Phase-2 E2E filer)
The over-issue `evidenceHash` has a fixed preimage the slash filer MUST use: `keccak256(abi.encode("DVT_OVERISSUE_EVIDENCE_V1", token, operator, epoch))`, filed as a pure slash (empty repUsers **and** newScores). Documented in `docs/design/guardian-collusion-slash.md §4b` and flagged to @repo:sp on CC-89.

## Not in this PR (follow-up)
- Watcher **service** plumbing: event subscription on verifyAndExecute + durable multi-node record of proposalId→claimedSigners + NestJS wiring.
- Phase-2 joint testnet E2E with SP.
- Production historical-state variant (BLOCKHASH + storage proof, bounded challenge window) — the current over-issue read is the E2E current-state variant.

Refs: CC-89, SP PR #370 + #371, issue #222.