### PR TITLE
feat(CC-89): guardian-slash watcher service — durable claimedSigners capture

### DIFF
--- a/docs/design/cc89-stage2-shipping-plan.md
+++ b/docs/design/cc89-stage2-shipping-plan.md
@@ -1,0 +1,172 @@
+# CC-89 Stage-2 Shipping Plan — over-issue guardian-collusion slash (DVT half)
+
+> **Scope**: testnet-E2E only (no mainnet activation). Ship every remaining DVT
+> dev task agreed on CC-89, each as its own reviewed PR, then run the DVT-side
+> E2E, then hand off to a joint testnet run with SuperPaymaster (SP). This doc
+> is the machine-readable checklist the `/goal` command drives; it is also the
+> human plan of record.
+>
+> Coordination hub: Seeder **CC-89** (project `Coordination`, `repo:dvt` /
+> `repo:sp` labels). Upstream contract already merged on SP:
+> `executeGuardianSlash` (PR #370), A' commitment `proposalSignersCommitment`
+> (PR #371). SP E2E harness lives on SP branch `feat/guardian-slash-e2e-harness`
+> (`contracts/test/modules/GuardianSlashE2E.t.sol`).
+
+## 0. What is already DONE (do not rebuild)
+
+| #   | Deliverable                                                                           | Where                                     | Status            |
+| --- | ------------------------------------------------------------------------------------- | ----------------------------------------- | ----------------- |
+| D0  | Stage-0 design doc (threat model, auto-eject, trigger authority)                      | `docs/design/guardian-collusion-slash.md` | ✅ PR #221 merged |
+| D1  | `OverIssueFraudProofVerifier.sol` + `IFraudProofVerifier.sol` + 16 Foundry tests      | `contracts/`                              | ✅ PR #223 merged |
+| D2  | Watcher CORE (`guardian-fraud-proof.ts`: derivation + encode + golden byte-alignment) | `src/modules/audit/`                      | ✅ PR #223 merged |
+
+## 1. Feature decomposition — each ships as ONE PR
+
+### F1 — Guardian-slash watcher SERVICE ✅ built, awaiting review→PR→merge
+
+Branch: `feat/cc89-guardian-watcher` (already checked out, changes present,
+UNCOMMITTED). Files: `guardian-signer-store.ts`,
+`guardian-slash-watcher.core.ts`, `guardian-slash-watcher.service.ts` (+ 3
+specs) + `guardian-fraud-proof.ts` extensions (`decodeVerifyAndExecuteCalldata`,
+`rawSlashMessageHash`, `repSlashMessageHash`) + `audit.module.ts` /
+`configuration.ts` wiring.
+
+What it does: polls `BLSAggregator.SlashExecuted`, decodes the
+`verifyAndExecute` calldata, resolves the co-signer address set via
+`validatorAtSlot` pinned to the **execution block**, self-checks the recomputed
+A' commitment against on-chain, and durably records
+`proposalId → {claimedSigners, …}` (the irreversible-commitment
+data-availability layer). In-process per node; opt-in
+`AUDIT_GUARDIAN_WATCH_ENABLED` (default off); fail-closed; restart-safe cursor.
+
+**Acceptance (F1):**
+
+- [ ] `npm run type-check` + `npm run lint:check` + `npm run format:check`
+      clean.
+- [ ] `jest src/modules/audit` green (new specs + no regression).
+- [ ] `npm run build` clean.
+- [ ] Codex review: no unresolved Critical/High.
+- [ ] Opt-in default-off + fail-closed disable paths present (aggregator no-code
+      / bad addr / bad interval).
+- [ ] Watcher NEVER persists a partial/guessed signer set (throws → skip +
+      alert); a commitment self-check miss is RECORDED with
+      `commitmentVerified:false` + loud alert (not silently dropped).
+- [ ] pr-daemon/`clestons` APPROVE + required checks green (既有 non-required
+      reds documented).
+- [ ] Merged; `jest src/modules/audit` green on master.
+
+### F2 — Fraud-proof ASSEMBLER ⬜ to build
+
+New: `src/modules/audit/guardian-fraud-proof-assembler.ts` (+ spec). Optionally
+a thin CLI `scripts/cc89-file-fraud-proof.mjs` for the E2E.
+
+What it does: given a disputed `proposalId` (its watcher record) + the
+`disputedToken` + the accused `guiltyGuardians`, it (a) validates
+`guiltyGuardians ⊆ claimedSigners`, (b) builds the `fraudProof` bytes +
+`fraudProofId` (reusing merged `encodeOverIssueFraudProof` /
+`deriveFraudProofId`), (c) self-checks the record's commitment reproduces
+on-chain AND that the disputed token's over-issue evidence recompute would pass,
+and (d) exposes a submit path to
+`BLSAggregator.executeGuardianSlash(fraudProofId, guiltyGuardians, fraudProof)`.
+Refuses to assemble/submit if any self-check fails (never files a proof that
+will revert/return false).
+
+**Acceptance (F2):**
+
+- [ ] Cross-check test: assembler output fed to `OverIssueFraudProofVerifier`
+      (Foundry, or a TS↔golden vector) returns `true` for a genuine over-issue
+      fraud and `false` for token-swap / non-subset / still-over-issued.
+- [ ] `guiltyGuardians ⊆ claimedSigners` enforced before assembly; assembler
+      throws otherwise.
+- [ ] Submit path is dry-run-able (build + local staticCall preflight) and does
+      NOT broadcast unless explicitly armed.
+- [ ] type-check / lint / format / jest / build clean; Codex no Critical/High.
+- [ ] pr-daemon APPROVE + checks green; merged; tests green on master.
+
+### F3 — E2E acceptance checklist + DVT-side E2E driver ⬜ to build
+
+Update issue **#222** with the joint acceptance checklist; add
+`docs/design/cc89-e2e-runbook.md`
+
+- a driver `scripts/cc89-e2e.mjs` (dry-run against a local/Sepolia BLSAggregator
+  with A' commitment) that walks: over-issue slash (verifyAndExecute stores
+  commitment) → watcher captures `claimedSigners` → assembler builds
+  `fraudProof` → `executeGuardianSlash` → `OverIssueFraudProofVerifier.verify` →
+  guardian ROLE_DVT lock → 0 → auto-eject.
+
+**Acceptance (F3):**
+
+- [ ] Runbook documents the full chain + the cross-repo evidence convention
+      (`evidenceHash = keccak256("DVT_OVERISSUE_EVIDENCE_V1", token, operator, epoch)`,
+      slash filed pure = empty repUsers AND newScores).
+- [ ] Driver dry-runs the DVT half end-to-end against SP's
+      `GuardianSlashE2E.t.sol` shape (real verifier swapped for `MockVerifier`),
+      asserting the watcher's recompute == on-chain commitment.
+- [ ] Issue #222 acceptance checklist posted; CC-89 updated; both repos' items
+      enumerated.
+- [ ] Documented handoff for the **tomorrow** joint testnet run with SP.
+
+## 2. Per-feature loop protocol (what `/goal` runs for EACH feature)
+
+```
+for feature F in [F1, F2, F3]:
+  1. SYNC:   git checkout master && git pull --ff-only
+             if F already merged (grep git log for its PR / marker) → skip F.
+  2. BRANCH: reuse F's feature branch if it exists with the built changes; else create it off master.
+  3. BUILD:  implement F (F1 is already built). Keep ESM .js imports; match repo conventions.
+  4. GATE:   npm run type-check && npm run lint:check && npm run format:check
+             && NODE_OPTIONS=--experimental-vm-modules npx jest <F specs> && npm run build
+             (+ cd contracts && forge test  if F touches contracts/)
+             → any red: fix, re-run. Do NOT proceed on red.
+  5. REVIEW: Codex Tier-1 (codex:codex-rescue) on the diff. Strict/adversarial: correctness,
+             races, fail-closed, fund-safety. Fix every Critical/High; re-review; loop until clean
+             (or a finding is EXPLICITLY deferred with rationale). Report rounds to the user.
+  6. COMMIT: git add -A && commit  "feat(CC-89): <F summary> (Codex Tier-1 reviewed)"
+             (money-adjacent → follow the security-fix message convention in history).
+  7. PR:     git push -u origin <branch>; gh pr create --base master --reviewer clestons
+             --title/--body (link CC-89 + issue #222 + acceptance box). The reviewer add triggers
+             the background pr-daemon bot.
+  8. WAIT:   poll  gh pr view <n> --json reviewDecision,statusCheckRollup,reviews  (via /loop 5m).
+             - REQUEST_CHANGES  → fix findings (goutou PR-review / Codex), push new commit
+                                  (NEVER force-push, NEVER amend pushed commits), re-request; loop.
+             - APPROVED + required checks green → step 9.
+             (既有 non-required reds — Security Audit / Code Quality / forge coverage viaIR —
+              are the repo's pre-existing UNSTABLE state, not this PR's regression: document, don't block.)
+  9. MERGE:  gh pr merge <n> --squash --delete-branch.
+ 10. VERIFY: git checkout master && git pull; run F's suite on master → must be green.
+ 11. REPORT: goutou → CC-89 comment "[repo:dvt] F<n> 交付 ✅ (PR #<n> merged)"; update this doc's
+             status boxes + the guardian-collusion-slash-gap memory.
+```
+
+**Never** bypass branch protection / enforce_admins / self-approve (see memory
+`never-bypass-branch-protection`). Cross-repo changes go via PR, never direct
+edits (`pr-not-direct-edit-other-repos`).
+
+## 3. After all features merged — E2E phase
+
+1. Run the F3 driver (`scripts/cc89-e2e.mjs` dry-run) — DVT half end-to-end,
+   assert watcher recompute == on-chain commitment and verifier returns true for
+   the crafted fraud.
+2. Confirm the issue #222 acceptance checklist DVT items are all ticked.
+3. Post CC-89 "DVT stage-2 dev complete + E2E dry-run green; ready for joint
+   testnet" with the handoff (SP action: deploy A'-BLSAggregator to Sepolia +
+   run `GuardianSlashE2E` with the real verifier swapped in; DVT action: run
+   watcher + assembler against it).
+
+## 4. Tomorrow — joint testnet E2E with SP (not in this run)
+
+SP deploys the A' `BLSAggregator` to Sepolia and rewires; crafts an over-issue
+slash; DVT's watcher captures `claimedSigners`; DVT assembler files the fraud
+proof; `executeGuardianSlash` slashes the colluding guardians' ROLE_DVT lock to
+0 → auto-eject. This closes ρ's detection half (paper: "implemented +
+testnet-verified"). Coordinate timing on CC-89.
+
+## 5. Definition of done (whole `/goal` run)
+
+- [ ] F1, F2, F3 each: Codex-clean, bot-approved, merged to master, suite green
+      on master.
+- [ ] DVT-side E2E dry-run green.
+- [ ] Issue #222 acceptance checklist (DVT items) complete; CC-89 updated;
+      memory updated.
+- [ ] Handoff posted for the tomorrow joint run. (The joint run itself is out of
+      scope here.)

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -208,6 +208,23 @@ export default () => {
     auditCooldownMs: parseInt(process.env.AUDIT_COOLDOWN_MS || "3600000", 10),
     auditWatchlist: parseAllowlist(process.env.AUDIT_WATCHLIST || ""),
     auditProofDir: process.env.AUDIT_PROOF_DIR || "./audit-proofs",
+    // CC-89 stage-2 guardian-slash WATCHER (opt-in, default off). Captures each SlashExecuted's
+    // signer ADDRESS set (validatorAtSlot @ execution block) so a later over-issue fraud proof can
+    // reproduce SP's irreversible A' commitment. Pure observer — never signs/files/slashes. Runs in
+    // every node; the fleet's redundancy is what guarantees a slash's set is never wholly missed.
+    // AUDIT_GUARDIAN_WATCH_FROM_BLOCK: the BLSAggregator (A' commitment) deploy block — scan lower
+    //   bound (0 = genesis, slow). AUDIT_GUARDIAN_WATCH_DIR: per-node record store (contains no keys).
+    //   Reuses AUDIT_BLS_AGGREGATOR_ADDRESS, AUDIT_FINALITY_CONFIRMATIONS, AUDIT_ROLE_LOG_CHUNK.
+    auditGuardianWatchEnabled: process.env.AUDIT_GUARDIAN_WATCH_ENABLED === "true",
+    auditGuardianWatchDir: process.env.AUDIT_GUARDIAN_WATCH_DIR || "./guardian-signer-records",
+    auditGuardianWatchIntervalMs: parseInt(
+      process.env.AUDIT_GUARDIAN_WATCH_INTERVAL_MS || "60000",
+      10
+    ),
+    auditGuardianWatchFromBlock: (() => {
+      const parsed = parseInt(process.env.AUDIT_GUARDIAN_WATCH_FROM_BLOCK || "0", 10);
+      return Math.max(0, Number.isFinite(parsed) ? parsed : 0);
+    })(),
     auditChainId: parseInt(process.env.AUDIT_CHAIN_ID || "11155111", 10),
     auditRegistryAddress: process.env.AUDIT_REGISTRY_ADDRESS || undefined,
     auditSuperPaymasterAddress: process.env.AUDIT_SUPER_PAYMASTER_ADDRESS || undefined,

--- a/src/modules/audit/audit.module.ts
+++ b/src/modules/audit/audit.module.ts
@@ -13,6 +13,7 @@ import { BlockchainService } from "../blockchain/blockchain.service.js";
 import { IQuorumCoSigner, PendingSlotCoSigner, QUORUM_COSIGNER } from "./slash-consensus.js";
 import { GossipQuorumCoSigner } from "./gossip-quorum-cosigner.js";
 import { LivenessKeeperService } from "./liveness-keeper.service.js";
+import { GuardianSlashWatcherService } from "./guardian-slash-watcher.service.js";
 
 /**
  * DVT Phase 2 (目标2) — autonomous operator audit module. Reuses the shared BlockchainService
@@ -32,6 +33,9 @@ import { LivenessKeeperService } from "./liveness-keeper.service.js";
     // inc-2 C1 — liveness attest keeper (opt-in AUDIT_ATTEST_ENABLED). Self-disables at bootstrap
     // when unconfigured; OpsAlertService is @Global so it injects without an explicit import.
     LivenessKeeperService,
+    // CC-89 stage-2 — guardian-slash watcher (opt-in AUDIT_GUARDIAN_WATCH_ENABLED). Self-disables at
+    // bootstrap when unconfigured. Owns its own read-only provider; OpsAlertService is @Global.
+    GuardianSlashWatcherService,
     {
       provide: QUORUM_COSIGNER,
       useFactory: (

--- a/src/modules/audit/guardian-fraud-proof.spec.ts
+++ b/src/modules/audit/guardian-fraud-proof.spec.ts
@@ -4,9 +4,12 @@ import {
   deriveFraudProofId,
   overIssueEvidenceHash,
   overIssueSlashMessageHash,
+  rawSlashMessageHash,
   computeSignersCommitment,
   encodeOverIssueFraudProof,
+  decodeVerifyAndExecuteCalldata,
   orderSignersFromSlotMap,
+  VERIFY_AND_EXECUTE_ABI,
   FRAUD_ID_TAG,
   OVERISSUE_EVIDENCE_TAG,
   OverIssueFraudProofInputs,
@@ -73,6 +76,50 @@ describe("guardian-fraud-proof encoding (CC-89 stage-2)", () => {
     expect(disputedToken).toBe(TOKEN);
     expect(BigInt(signerMask)).toBe(0x7n);
     expect([...claimedSigners]).toEqual([S1, S2, S3]);
+  });
+
+  it("overIssueSlashMessageHash == rawSlashMessageHash with the fixed-preimage evidenceHash", () => {
+    const raw = rawSlashMessageHash(
+      1n,
+      42n,
+      OPERATOR,
+      2,
+      1000n,
+      overIssueEvidenceHash(TOKEN, OPERATOR, 1000n)
+    );
+    expect(overIssueSlashMessageHash(1n, 42n, OPERATOR, 2, 1000n, TOKEN)).toBe(raw);
+  });
+
+  describe("decodeVerifyAndExecuteCalldata (watcher calldata decode)", () => {
+    const iface = new ethers.Interface([VERIFY_AND_EXECUTE_ABI]);
+    const blsProof = coder.encode(["uint256", "bytes"], [0x7n, "0xdead"]);
+
+    it("decodes a slash-only verifyAndExecute call into its signed fields + signerMask", () => {
+      const evidenceHash = ethers.keccak256("0x1234");
+      const data = iface.encodeFunctionData("verifyAndExecute", [
+        42n,
+        OPERATOR,
+        2,
+        [], // repUsers
+        [], // newScores
+        1000n,
+        evidenceHash,
+        blsProof,
+      ]);
+      const args = decodeVerifyAndExecuteCalldata(data);
+      expect(args.proposalId).toBe(42n);
+      expect(args.operator).toBe(OPERATOR);
+      expect(args.slashLevel).toBe(2);
+      expect(args.repUsers).toEqual([]);
+      expect(args.newScores).toEqual([]);
+      expect(args.epoch).toBe(1000n);
+      expect(args.evidenceHash).toBe(evidenceHash);
+      expect(args.signerMask).toBe(0x7n); // from proof[:32]
+    });
+
+    it("throws on a non-verifyAndExecute selector (guards against wrong/wrapped calls)", () => {
+      expect(() => decodeVerifyAndExecuteCalldata("0xdeadbeef")).toThrow();
+    });
   });
 
   describe("orderSignersFromSlotMap (byte-critical derivation)", () => {

--- a/src/modules/audit/guardian-fraud-proof.ts
+++ b/src/modules/audit/guardian-fraud-proof.ts
@@ -160,9 +160,55 @@ export function encodeOverIssueFraudProof(i: OverIssueFraudProofInputs): string 
 }
 
 /**
- * Reconstruct SP's slash-only `expectedMessageHash` (byte-identical to
- * BLSAggregator.verifyAndExecute's slash path AND to verifier.slashMessageHash): over-issue
- * slashes are pure slashes, so `repUsers` and `newScores` are BOTH empty.
+ * Reconstruct SP's slash-only `expectedMessageHash` from a RAW evidenceHash (byte-identical to
+ * BLSAggregator.verifyAndExecute's slash-only branch: `repUsers`/`newScores` empty, commits
+ * `evidenceHash` + chainId). The watcher uses this with the evidenceHash it read from the
+ * verifyAndExecute calldata — it does NOT need to know which token the slash cited.
+ */
+export function rawSlashMessageHash(
+  chainId: bigint,
+  proposalId: bigint,
+  operator: string,
+  slashLevel: number,
+  epoch: bigint,
+  evidenceHash: string
+): string {
+  return ethers.keccak256(
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      ["uint256", "address", "uint8", "address[]", "uint256[]", "uint256", "uint256", "bytes32"],
+      [proposalId, operator, slashLevel, [], [], epoch, chainId, evidenceHash]
+    )
+  );
+}
+
+/**
+ * Reconstruct SP's reputation/combined-path `expectedMessageHash` (7-field encoding, no
+ * evidenceHash — BLSAggregator.verifyAndExecute's `repUsers.length > 0` branch). The watcher
+ * needs this to self-check the commitment for combined proposals (operator slashed AND rep
+ * updated); over-issue fraud proofs themselves only target the slash-only branch.
+ */
+export function repSlashMessageHash(
+  chainId: bigint,
+  proposalId: bigint,
+  operator: string,
+  slashLevel: number,
+  repUsers: string[],
+  newScores: bigint[],
+  epoch: bigint
+): string {
+  return ethers.keccak256(
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      ["uint256", "address", "uint8", "address[]", "uint256[]", "uint256", "uint256"],
+      [proposalId, operator, slashLevel, repUsers, newScores, epoch, chainId]
+    )
+  );
+}
+
+/**
+ * Reconstruct SP's slash-only `expectedMessageHash` for the OVER-ISSUE class (binds the
+ * disputed token via the fixed-preimage evidenceHash). Byte-identical to
+ * `verifier.slashMessageHash` — this is what the fraud-proof ASSEMBLER uses when it knows the
+ * token; the watcher uses `rawSlashMessageHash` with the on-chain evidenceHash instead.
  */
 export function overIssueSlashMessageHash(
   chainId: bigint,
@@ -172,21 +218,58 @@ export function overIssueSlashMessageHash(
   epoch: bigint,
   disputedToken: string
 ): string {
-  return ethers.keccak256(
-    ethers.AbiCoder.defaultAbiCoder().encode(
-      ["uint256", "address", "uint8", "address[]", "uint256[]", "uint256", "uint256", "bytes32"],
-      [
-        proposalId,
-        operator,
-        slashLevel,
-        [],
-        [],
-        epoch,
-        chainId,
-        overIssueEvidenceHash(disputedToken, operator, epoch),
-      ]
-    )
+  return rawSlashMessageHash(
+    chainId,
+    proposalId,
+    operator,
+    slashLevel,
+    epoch,
+    overIssueEvidenceHash(disputedToken, operator, epoch)
   );
+}
+
+/** The exact ABI of BLSAggregator.verifyAndExecute (SP `contracts/src/modules/monitoring/BLSAggregator.sol`). */
+export const VERIFY_AND_EXECUTE_ABI =
+  "function verifyAndExecute(uint256 proposalId, address operator, uint8 slashLevel, " +
+  "address[] repUsers, uint256[] newScores, uint256 epoch, bytes32 evidenceHash, bytes proof)";
+
+export interface VerifyAndExecuteArgs {
+  proposalId: bigint;
+  operator: string;
+  slashLevel: number;
+  repUsers: string[];
+  newScores: bigint[];
+  epoch: bigint;
+  evidenceHash: string;
+  /** signerMask decoded from proof[:32] (proof = abi.encode(uint256 signerMask, bytes sigG2)). */
+  signerMask: bigint;
+}
+
+/**
+ * Decode a top-level `verifyAndExecute` tx's calldata into the fields the watcher needs to
+ * reproduce SP's A' commitment. THROWS if `data` is not a verifyAndExecute call (wrong selector
+ * / undecodable) — the caller treats that as "not the direct call I expected" and skips (never
+ * records a guessed set). NOTE: this decodes the OUTER call; a proposal executed through an
+ * intermediary (e.g. DVT_VALIDATOR wrapping the call) won't decode here — a Phase-3 hardening
+ * concern (trace/internal-call resolution), out of scope for the direct-call E2E.
+ */
+export function decodeVerifyAndExecuteCalldata(data: string): VerifyAndExecuteArgs {
+  const iface = new ethers.Interface([VERIFY_AND_EXECUTE_ABI]);
+  const parsed = iface.parseTransaction({ data });
+  if (!parsed || parsed.name !== "verifyAndExecute") {
+    throw new Error("decodeVerifyAndExecuteCalldata: not a verifyAndExecute call");
+  }
+  const a = parsed.args;
+  return {
+    proposalId: BigInt(a[0]),
+    operator: ethers.getAddress(a[1]),
+    slashLevel: Number(a[2]),
+    repUsers: [...a[3]].map((x: string) => ethers.getAddress(x)),
+    newScores: [...a[4]].map((x: bigint) => BigInt(x)),
+    epoch: BigInt(a[5]),
+    evidenceHash: a[6],
+    signerMask: decodeSignerMaskFromBlsProof(a[7]),
+  };
 }
 
 /**

--- a/src/modules/audit/guardian-signer-store.spec.ts
+++ b/src/modules/audit/guardian-signer-store.spec.ts
@@ -1,0 +1,144 @@
+import { promises as fs } from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  LocalGuardianSignerStore,
+  GuardianSignerRecord,
+  GuardianCaptureFailure,
+} from "./guardian-signer-store.js";
+
+const makeRecord = (proposalId: string, verified = true): GuardianSignerRecord => ({
+  proposalId,
+  operator: "0x000000000000000000000000000000000000abcd",
+  slashLevel: 2,
+  epoch: "1000",
+  evidenceHash: "0x" + "11".repeat(32),
+  signerMask: "7",
+  claimedSigners: [
+    "0x0000000000000000000000000000000000001111",
+    "0x0000000000000000000000000000000000002222",
+  ],
+  executionBlock: 500,
+  txHash: "0x" + "ab".repeat(32),
+  chainId: "11155111",
+  commitment: "0x" + "22".repeat(32),
+  commitmentVerified: verified,
+  executionBlockTimestamp: 1_700_000_000,
+});
+
+const makeFailure = (block: number, logIndex: number): GuardianCaptureFailure => ({
+  block,
+  logIndex,
+  txHash: "0x" + "cd".repeat(32),
+  proposalId: "77",
+  reason: "tx not found",
+  attempts: 1,
+  parked: false,
+});
+
+describe("LocalGuardianSignerStore (CC-89 stage-2 data availability)", () => {
+  let dir: string;
+  let store: LocalGuardianSignerStore;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "guardian-store-"));
+    store = new LocalGuardianSignerStore(dir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("putVerified → hasTerminal → getVerified round-trips a canonical record", async () => {
+    const rec = makeRecord("42");
+    await store.putVerified(rec);
+    expect(await store.hasTerminal(42n)).toBe(true);
+    expect(await store.getVerified(42n)).toEqual(rec);
+  });
+
+  it("hasTerminal/getVerified are false/null for an unknown proposalId", async () => {
+    expect(await store.hasTerminal(999n)).toBe(false);
+    expect(await store.getVerified(999n)).toBeNull();
+  });
+
+  it("quarantined (unverified) records are hasTerminal but NOT readable as verified", async () => {
+    const rec = makeRecord("13", false);
+    await store.putUnverified(rec);
+    expect(await store.hasTerminal(13n)).toBe(true); // won't be re-scanned
+    expect(await store.getVerified(13n)).toBeNull(); // assembler must never read it as canonical
+  });
+
+  it("count reflects only canonical verified records (ignores quarantine + cursor)", async () => {
+    await store.putVerified(makeRecord("1"));
+    await store.putVerified(makeRecord("2"));
+    await store.putUnverified(makeRecord("3", false));
+    await store.writeCursor(123);
+    expect(await store.count()).toBe(2);
+  });
+
+  it("cursor round-trips and survives re-instantiation (restart-safe)", async () => {
+    expect(await store.readCursor()).toBeNull();
+    await store.writeCursor(8_888_888);
+    expect(await store.readCursor()).toBe(8_888_888);
+    const reopened = new LocalGuardianSignerStore(dir);
+    expect(await reopened.readCursor()).toBe(8_888_888);
+  });
+
+  it("putVerified is idempotent — re-putting overwrites, count stays 1", async () => {
+    await store.putVerified(makeRecord("7"));
+    await store.putVerified({ ...makeRecord("7"), executionBlock: 501 });
+    expect(await store.count()).toBe(1);
+    expect((await store.getVerified(7n))?.executionBlock).toBe(501);
+  });
+
+  describe("dead-letter (capture failures)", () => {
+    it("put/list/remove round-trips a failure keyed by block+logIndex", async () => {
+      await store.putFailure(makeFailure(500, 2));
+      await store.putFailure(makeFailure(501, 0));
+      let failures = await store.listFailures();
+      expect(failures).toHaveLength(2);
+
+      await store.removeFailure(500, 2);
+      failures = await store.listFailures();
+      expect(failures).toHaveLength(1);
+      expect(failures[0].block).toBe(501);
+    });
+
+    it("putFailure is idempotent on the same block+logIndex (last write wins)", async () => {
+      await store.putFailure(makeFailure(500, 2));
+      await store.putFailure({ ...makeFailure(500, 2), attempts: 5, parked: true });
+      const failures = await store.listFailures();
+      expect(failures).toHaveLength(1);
+      expect(failures[0].attempts).toBe(5);
+      expect(failures[0].parked).toBe(true);
+    });
+
+    it("hasFailure reflects an existing dead-letter keyed by block+logIndex", async () => {
+      expect(await store.hasFailure(500, 2)).toBe(false);
+      await store.putFailure(makeFailure(500, 2));
+      expect(await store.hasFailure(500, 2)).toBe(true);
+      expect(await store.hasFailure(500, 3)).toBe(false);
+    });
+
+    it("listFailures is empty when there is no failed dir", async () => {
+      expect(await store.listFailures()).toEqual([]);
+    });
+
+    it("recovers a CORRUPT dead-letter from its filename as a parked entry (not silently lost)", async () => {
+      await store.putFailure(makeFailure(500, 2));
+      // Corrupt the file on disk (truncated/garbage JSON).
+      await fs.writeFile(path.join(dir, "failed", "500-2.json"), "{not json", "utf8");
+      const failures = await store.listFailures();
+      expect(failures).toHaveLength(1);
+      expect(failures[0].block).toBe(500);
+      expect(failures[0].logIndex).toBe(2);
+      expect(failures[0].parked).toBe(true);
+      expect(failures[0].reason).toMatch(/corrupt/);
+    });
+
+    it("dead-letters do not count toward canonical records", async () => {
+      await store.putFailure(makeFailure(500, 2));
+      expect(await store.count()).toBe(0);
+    });
+  });
+});

--- a/src/modules/audit/guardian-signer-store.ts
+++ b/src/modules/audit/guardian-signer-store.ts
@@ -1,0 +1,245 @@
+import { promises as fs } from "fs";
+import * as path from "path";
+
+/**
+ * CC-89 stage-2 — the watcher's DATA-AVAILABILITY layer.
+ *
+ * SP's A' commitment (`proposalSignersCommitment[proposalId]`, PR #371) is an irreversible
+ * `bytes32` fingerprint of the fraud-time signer ADDRESS set — you cannot reverse it back to the
+ * addresses. So when a slash is later found fraudulent, the fraud-proof assembler needs the actual
+ * `claimedSigners` that reproduce that commitment. This store is where each DVT node durably keeps
+ * `proposalId → {claimedSigners, ...}` captured at execution time.
+ *
+ * Because the commitment is irreversible, a slash whose signer set NO node recorded is permanently
+ * un-attributable. The watcher must therefore run REDUNDANTLY across the fleet (each node writes its
+ * own store dir); this store is the per-node half of that redundancy, made restart-safe by a
+ * persisted scan cursor so a node that was down backfills from where it left off.
+ *
+ * THREE areas keep a wrong set from ever being trusted (Codex CC-89 review):
+ *   - VERIFIED (`<proposalId>.json`) — canonical. ONLY records whose recomputed commitment matched
+ *     on-chain. The fraud-proof assembler reads ONLY these.
+ *   - UNVERIFIED (`unverified/<proposalId>.json`) — quarantine. A record was built but its self-check
+ *     did NOT match on-chain (byte drift / wrong branch / a non-verifyAndExecute path). Kept as
+ *     durable evidence needing review; NEVER read by the assembler.
+ *   - FAILED (`failed/<block>-<logIndex>.json`) — dead-letter. The record could not be built at all
+ *     (tx fetch error, wrapped/undecodable call, hole slot). Retried each tick so a transient error
+ *     self-heals and a permanent one stays VISIBLE + RECOVERABLE instead of silently lost.
+ */
+
+/** One durably-recorded slash execution: everything needed to rebuild its fraudProof later. */
+export interface GuardianSignerRecord {
+  /** The disputed proposalId (BLSAggregator). Stringified bigint (JSON has no bigint). */
+  proposalId: string;
+  operator: string;
+  slashLevel: number;
+  /** Stringified bigint. */
+  epoch: string;
+  /** The RAW evidenceHash committed on-chain (opaque; binds the off-chain evidence). */
+  evidenceHash: string;
+  /** Stringified bigint. */
+  signerMask: string;
+  /** Co-signer addresses, strictly ascending by uint160 — reproduces SP's commitment `sorted`. */
+  claimedSigners: string[];
+  /** The block verifyAndExecute was mined in — the block `validatorAtSlot` was resolved at. */
+  executionBlock: number;
+  txHash: string;
+  chainId: string;
+  /** The on-chain commitment this record reproduces (self-check anchor). */
+  commitment: string;
+  /** Whether the locally-recomputed commitment matched the on-chain value at capture time. */
+  commitmentVerified: boolean;
+  /** The executionBlock's timestamp (chain time, not wall-clock). */
+  executionBlockTimestamp: number;
+}
+
+/** A log the watcher could not turn into a record — durable retry queue entry. */
+export interface GuardianCaptureFailure {
+  block: number;
+  logIndex: number;
+  txHash: string;
+  /** Best-effort (from the event topic); the retry re-derives the rest. */
+  proposalId: string;
+  reason: string;
+  attempts: number;
+  /** Once attempts hit the cap, the entry is PARKED — kept durable but no longer auto-retried. */
+  parked: boolean;
+}
+
+export interface IGuardianSignerStore {
+  /** Persist a VERIFIED record (canonical, self-check passed). */
+  putVerified(record: GuardianSignerRecord): Promise<string>;
+  /** Persist an UNVERIFIED record (quarantine — self-check failed; never read by the assembler). */
+  putUnverified(record: GuardianSignerRecord): Promise<string>;
+  /** True if this proposal already reached a terminal state (verified OR quarantined). */
+  hasTerminal(proposalId: bigint): Promise<boolean>;
+  /** Read a canonical (verified) record; null if absent/quarantined-only. */
+  getVerified(proposalId: bigint): Promise<GuardianSignerRecord | null>;
+  /** Count of canonical verified records. */
+  count(): Promise<number>;
+
+  /** Dead-letter a log that could not be captured (idempotent by block+logIndex; bumps attempts). */
+  putFailure(failure: GuardianCaptureFailure): Promise<void>;
+  /** True if a dead-letter already exists for this log (so a re-scan won't double-process it). */
+  hasFailure(block: number, logIndex: number): Promise<boolean>;
+  /** List dead-letters (both retryable and parked — caller filters on `parked`). */
+  listFailures(): Promise<GuardianCaptureFailure[]>;
+  /** Remove a dead-letter once it has been captured. */
+  removeFailure(block: number, logIndex: number): Promise<void>;
+
+  /** Persisted scan cursor: the last block fully scanned for SlashExecuted (restart-safe). */
+  readCursor(): Promise<number | null>;
+  writeCursor(block: number): Promise<void>;
+}
+
+/** Atomic write: temp file + rename, so a crash mid-write never leaves a truncated file. */
+async function atomicWrite(file: string, data: string): Promise<void> {
+  const tmp = `${file}.tmp`;
+  await fs.writeFile(tmp, data, "utf8");
+  await fs.rename(tmp, file);
+}
+
+/**
+ * Disk-backed store. Canonical verified records at `<dir>/<proposalId>.json`; quarantine under
+ * `<dir>/unverified/`; dead-letters under `<dir>/failed/`; cursor at `<dir>/.cursor`. Safe for the
+ * single-writer-per-node model (each node owns its own dir); NOT a shared multi-writer store.
+ */
+export class LocalGuardianSignerStore implements IGuardianSignerStore {
+  constructor(private readonly dir: string) {}
+
+  private verifiedFile(proposalId: bigint): string {
+    return path.join(this.dir, `${proposalId.toString()}.json`);
+  }
+  private unverifiedDir(): string {
+    return path.join(this.dir, "unverified");
+  }
+  private unverifiedFile(proposalId: bigint): string {
+    return path.join(this.unverifiedDir(), `${proposalId.toString()}.json`);
+  }
+  private failedDir(): string {
+    return path.join(this.dir, "failed");
+  }
+  private failedFile(block: number, logIndex: number): string {
+    return path.join(this.failedDir(), `${block}-${logIndex}.json`);
+  }
+  private cursorFile(): string {
+    return path.join(this.dir, ".cursor");
+  }
+
+  async putVerified(record: GuardianSignerRecord): Promise<string> {
+    await fs.mkdir(this.dir, { recursive: true });
+    const location = this.verifiedFile(BigInt(record.proposalId));
+    await atomicWrite(location, JSON.stringify(record, null, 2));
+    return location;
+  }
+
+  async putUnverified(record: GuardianSignerRecord): Promise<string> {
+    await fs.mkdir(this.unverifiedDir(), { recursive: true });
+    const location = this.unverifiedFile(BigInt(record.proposalId));
+    await atomicWrite(location, JSON.stringify(record, null, 2));
+    return location;
+  }
+
+  async hasTerminal(proposalId: bigint): Promise<boolean> {
+    for (const f of [this.verifiedFile(proposalId), this.unverifiedFile(proposalId)]) {
+      try {
+        await fs.access(f);
+        return true;
+      } catch {
+        // not present — check the next
+      }
+    }
+    return false;
+  }
+
+  async getVerified(proposalId: bigint): Promise<GuardianSignerRecord | null> {
+    try {
+      const raw = await fs.readFile(this.verifiedFile(proposalId), "utf8");
+      return JSON.parse(raw) as GuardianSignerRecord;
+    } catch {
+      return null;
+    }
+  }
+
+  async count(): Promise<number> {
+    try {
+      const files = await fs.readdir(this.dir);
+      return files.filter(f => f.endsWith(".json")).length;
+    } catch {
+      return 0;
+    }
+  }
+
+  async putFailure(failure: GuardianCaptureFailure): Promise<void> {
+    await fs.mkdir(this.failedDir(), { recursive: true });
+    await atomicWrite(
+      this.failedFile(failure.block, failure.logIndex),
+      JSON.stringify(failure, null, 2)
+    );
+  }
+
+  async hasFailure(block: number, logIndex: number): Promise<boolean> {
+    try {
+      await fs.access(this.failedFile(block, logIndex));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async listFailures(): Promise<GuardianCaptureFailure[]> {
+    let files: string[];
+    try {
+      files = await fs.readdir(this.failedDir());
+    } catch {
+      return [];
+    }
+    const out: GuardianCaptureFailure[] = [];
+    for (const f of files) {
+      if (!f.endsWith(".json")) continue;
+      try {
+        out.push(JSON.parse(await fs.readFile(path.join(this.failedDir(), f), "utf8")));
+      } catch {
+        // A corrupt/unreadable dead-letter would otherwise silently disable retries for that log
+        // (nothing re-scans a range past the cursor). Recover block+logIndex from the FILENAME
+        // (`<block>-<logIndex>.json`) and surface it as a PARKED corrupt entry so it stays visible
+        // for manual recovery instead of vanishing.
+        const m = /^(\d+)-(\d+)\.json$/.exec(f);
+        if (m) {
+          out.push({
+            block: parseInt(m[1], 10),
+            logIndex: parseInt(m[2], 10),
+            txHash: "",
+            proposalId: "",
+            reason: "corrupt dead-letter file (unreadable) — manual recovery needed",
+            attempts: Number.MAX_SAFE_INTEGER,
+            parked: true,
+          });
+        }
+      }
+    }
+    return out;
+  }
+
+  async removeFailure(block: number, logIndex: number): Promise<void> {
+    try {
+      await fs.rm(this.failedFile(block, logIndex));
+    } catch {
+      // already gone — fine
+    }
+  }
+
+  async readCursor(): Promise<number | null> {
+    try {
+      const raw = await fs.readFile(this.cursorFile(), "utf8");
+      const n = parseInt(raw.trim(), 10);
+      return Number.isFinite(n) && n >= 0 ? n : null;
+    } catch {
+      return null;
+    }
+  }
+
+  async writeCursor(block: number): Promise<void> {
+    await fs.mkdir(this.dir, { recursive: true });
+    await atomicWrite(this.cursorFile(), String(block));
+  }
+}

--- a/src/modules/audit/guardian-slash-watcher.core.spec.ts
+++ b/src/modules/audit/guardian-slash-watcher.core.spec.ts
@@ -1,0 +1,189 @@
+import { ethers } from "ethers";
+import { buildGuardianSignerRecord, WatcherRecordError } from "./guardian-slash-watcher.core.js";
+import {
+  VERIFY_AND_EXECUTE_ABI,
+  rawSlashMessageHash,
+  computeSignersCommitment,
+} from "./guardian-fraud-proof.js";
+
+const coder = ethers.AbiCoder.defaultAbiCoder();
+
+const S1 = ethers.getAddress("0x0000000000000000000000000000000000001111");
+const S2 = ethers.getAddress("0x0000000000000000000000000000000000002222");
+const S3 = ethers.getAddress("0x0000000000000000000000000000000000003333");
+const OPERATOR = ethers.getAddress("0x000000000000000000000000000000000000abcd");
+const AGG = ethers.getAddress("0x0000000000000000000000000000000000000a99");
+
+const CHAIN_ID = 11155111n;
+const PID = 42n;
+const LEVEL = 2;
+const EPOCH = 1000n;
+const MASK = 0x7n; // slots 1,2,3
+const EVIDENCE = ethers.keccak256(ethers.toUtf8Bytes("disputed-over-issue-evidence"));
+const EXEC_BLOCK = 500;
+const TX_HASH = "0x" + "ab".repeat(32);
+
+/**
+ * Minimal ethers v6 provider/runner: `call` dispatches the two aggregator view reads by selector;
+ * getTransaction/getBlock return the fixtures. Enough for buildGuardianSignerRecord + the
+ * Contract reads it drives (validatorAtSlot, proposalSignersCommitment).
+ */
+class MockProvider {
+  private readonly reads = new ethers.Interface([
+    "function validatorAtSlot(uint8 slot) view returns (address)",
+    "function proposalSignersCommitment(uint256 proposalId) view returns (bytes32)",
+  ]);
+  constructor(
+    private readonly validators: Record<number, string>,
+    private readonly commitments: Record<string, string>,
+    private readonly txData: string
+  ) {}
+
+  get provider(): this {
+    return this;
+  }
+
+  async resolveName(name: string): Promise<string> {
+    return name;
+  }
+
+  async call(tx: { data: string }): Promise<string> {
+    const sel = tx.data.slice(0, 10);
+    if (sel === this.reads.getFunction("validatorAtSlot")!.selector) {
+      const [slot] = this.reads.decodeFunctionData("validatorAtSlot", tx.data);
+      const addr = this.validators[Number(slot)] ?? ethers.ZeroAddress;
+      return this.reads.encodeFunctionResult("validatorAtSlot", [addr]);
+    }
+    if (sel === this.reads.getFunction("proposalSignersCommitment")!.selector) {
+      const [pid] = this.reads.decodeFunctionData("proposalSignersCommitment", tx.data);
+      const c = this.commitments[pid.toString()] ?? ethers.ZeroHash;
+      return this.reads.encodeFunctionResult("proposalSignersCommitment", [c]);
+    }
+    throw new Error(`unexpected call selector ${sel}`);
+  }
+
+  async getTransaction(_hash: string): Promise<{ data: string }> {
+    return { data: this.txData };
+  }
+
+  async getBlock(_n: number): Promise<{ timestamp: number }> {
+    return { timestamp: 1_700_000_000 };
+  }
+}
+
+function verifyAndExecuteCalldata(evidenceHash = EVIDENCE): string {
+  const iface = new ethers.Interface([VERIFY_AND_EXECUTE_ABI]);
+  const blsProof = coder.encode(["uint256", "bytes"], [MASK, "0xdead"]);
+  return iface.encodeFunctionData("verifyAndExecute", [
+    PID,
+    OPERATOR,
+    LEVEL,
+    [],
+    [],
+    EPOCH,
+    evidenceHash,
+    blsProof,
+  ]);
+}
+
+/** The commitment SP would store for this slash (what the watcher must reproduce). */
+function correctCommitment(): string {
+  const mh = rawSlashMessageHash(CHAIN_ID, PID, OPERATOR, LEVEL, EPOCH, EVIDENCE);
+  return computeSignersCommitment(AGG, CHAIN_ID, PID, mh, MASK, [S1, S2, S3]);
+}
+
+describe("buildGuardianSignerRecord (CC-89 stage-2 watcher core)", () => {
+  // Scrambled slot→address map to prove the ascending sort (slots 1,2,3 → S3,S1,S2 → sorted S1,S2,S3).
+  const validators: Record<number, string> = { 1: S3, 2: S1, 3: S2 };
+
+  it("captures the signer set and self-verifies against the on-chain commitment", async () => {
+    const provider = new MockProvider(
+      validators,
+      { [PID.toString()]: correctCommitment() },
+      verifyAndExecuteCalldata()
+    );
+    const rec = await buildGuardianSignerRecord(
+      provider as unknown as ethers.Provider,
+      AGG,
+      CHAIN_ID,
+      PID,
+      TX_HASH,
+      EXEC_BLOCK
+    );
+    expect(rec.claimedSigners).toEqual([S1, S2, S3]); // sorted ascending
+    expect(rec.commitmentVerified).toBe(true);
+    expect(rec.operator).toBe(OPERATOR);
+    expect(rec.epoch).toBe(EPOCH.toString());
+    expect(rec.evidenceHash).toBe(EVIDENCE);
+    expect(rec.signerMask).toBe(MASK.toString());
+    expect(rec.executionBlock).toBe(EXEC_BLOCK);
+    expect(rec.commitment).toBe(correctCommitment());
+  });
+
+  it("records but flags commitmentVerified=false when there is no on-chain commitment", async () => {
+    const provider = new MockProvider(validators, {}, verifyAndExecuteCalldata());
+    const rec = await buildGuardianSignerRecord(
+      provider as unknown as ethers.Provider,
+      AGG,
+      CHAIN_ID,
+      PID,
+      TX_HASH,
+      EXEC_BLOCK
+    );
+    expect(rec.commitmentVerified).toBe(false);
+    expect(rec.commitment).toBe(ethers.ZeroHash);
+  });
+
+  it("flags commitmentVerified=false when the on-chain commitment doesn't match (byte drift)", async () => {
+    const provider = new MockProvider(
+      validators,
+      { [PID.toString()]: "0x" + "cd".repeat(32) },
+      verifyAndExecuteCalldata()
+    );
+    const rec = await buildGuardianSignerRecord(
+      provider as unknown as ethers.Provider,
+      AGG,
+      CHAIN_ID,
+      PID,
+      TX_HASH,
+      EXEC_BLOCK
+    );
+    expect(rec.commitmentVerified).toBe(false);
+  });
+
+  it("throws when the event proposalId doesn't match the calldata (won't misattribute)", async () => {
+    const provider = new MockProvider(
+      validators,
+      { [PID.toString()]: correctCommitment() },
+      verifyAndExecuteCalldata()
+    );
+    await expect(
+      buildGuardianSignerRecord(
+        provider as unknown as ethers.Provider,
+        AGG,
+        CHAIN_ID,
+        99n, // event says 99, calldata says 42
+        TX_HASH,
+        EXEC_BLOCK
+      )
+    ).rejects.toThrow(WatcherRecordError);
+  });
+
+  it("throws when a selected slot is a hole (never records a partial set)", async () => {
+    const provider = new MockProvider(
+      { 1: S3, 2: S1 }, // slot 3 missing → mask 0x7 selects a zero slot
+      { [PID.toString()]: correctCommitment() },
+      verifyAndExecuteCalldata()
+    );
+    await expect(
+      buildGuardianSignerRecord(
+        provider as unknown as ethers.Provider,
+        AGG,
+        CHAIN_ID,
+        PID,
+        TX_HASH,
+        EXEC_BLOCK
+      )
+    ).rejects.toThrow();
+  });
+});

--- a/src/modules/audit/guardian-slash-watcher.core.ts
+++ b/src/modules/audit/guardian-slash-watcher.core.ts
@@ -1,0 +1,132 @@
+import { ethers } from "ethers";
+import {
+  decodeVerifyAndExecuteCalldata,
+  resolveClaimedSigners,
+  rawSlashMessageHash,
+  repSlashMessageHash,
+  computeSignersCommitment,
+} from "./guardian-fraud-proof.js";
+import { GuardianSignerRecord } from "./guardian-signer-store.js";
+
+/**
+ * The pure, testable core of the watcher: given a `SlashExecuted` occurrence (its proposalId, tx
+ * hash, and execution block) plus a provider, reconstruct the durable {@link GuardianSignerRecord}
+ * and self-verify it against SP's on-chain A' commitment.
+ *
+ * Kept standalone (no NestJS/DI) so it can be unit-tested with a mock provider — the same reason
+ * `orderSignersFromSlotMap` was extracted (CC-89 Codex Medium). The service just polls events and
+ * calls this.
+ */
+
+/** Minimal ABI for the two aggregator reads the builder needs. */
+const AGGREGATOR_READ_ABI = [
+  "function proposalSignersCommitment(uint256 proposalId) view returns (bytes32)",
+  "function validatorAtSlot(uint8 slot) view returns (address)",
+];
+
+/** BLSAggregator.SlashExecuted — the event the watcher polls. */
+export const SLASH_EXECUTED_EVENT =
+  "event SlashExecuted(uint256 indexed proposalId, address indexed operator, uint8 level)";
+
+export class WatcherRecordError extends Error {}
+
+/**
+ * Build + self-check the record for one executed slash. THROWS ({@link WatcherRecordError}) when the
+ * capture is UNSAFE to persist — a wrong selector, a proposalId mismatch, or a zero/hole slot — so
+ * the watcher NEVER stores a guessed or partial signer set (an incorrect set is worse than none: it
+ * would misattribute the slash). A `commitmentVerified: false` record (recompute ≠ on-chain, or no
+ * commitment) is still returned — it is durable evidence the capture needs manual review, not a
+ * silent drop.
+ */
+export async function buildGuardianSignerRecord(
+  provider: ethers.Provider,
+  aggregatorAddress: string,
+  chainId: bigint,
+  eventProposalId: bigint,
+  txHash: string,
+  executionBlock: number
+): Promise<GuardianSignerRecord> {
+  const tx = await provider.getTransaction(txHash);
+  if (!tx) throw new WatcherRecordError(`tx ${txHash} not found`);
+
+  // Decode the OUTER verifyAndExecute call. Throws if not that call (intermediary-wrapped calls are
+  // Phase-3; see decodeVerifyAndExecuteCalldata). The decoded fields are exactly what SP hashed.
+  const args = decodeVerifyAndExecuteCalldata(tx.data);
+
+  // Cross-check the event's proposalId against the calldata — a mismatch means this tx is not the
+  // one that produced this event (e.g. a batched/multicall tx we can't attribute); refuse to record.
+  if (args.proposalId !== eventProposalId) {
+    throw new WatcherRecordError(
+      `proposalId mismatch: event ${eventProposalId} vs calldata ${args.proposalId} (tx ${txHash})`
+    );
+  }
+
+  const agg = new ethers.Contract(aggregatorAddress, AGGREGATOR_READ_ABI, provider);
+
+  // Resolve co-signers at the EXECUTION block (SP byte-critical: validatorAtSlot at exec block, NOT
+  // the epoch block). resolveClaimedSigners throws on a zero/hole slot → we never record a partial set.
+  const claimedSigners = await resolveClaimedSigners(
+    provider,
+    aggregatorAddress,
+    args.signerMask,
+    executionBlock
+  );
+
+  // Reconstruct the signed messageHash on the SAME branch SP used (slash-only vs rep/combined), so
+  // the recomputed commitment is byte-identical.
+  const messageHash =
+    args.repUsers.length === 0
+      ? rawSlashMessageHash(
+          chainId,
+          args.proposalId,
+          args.operator,
+          args.slashLevel,
+          args.epoch,
+          args.evidenceHash
+        )
+      : repSlashMessageHash(
+          chainId,
+          args.proposalId,
+          args.operator,
+          args.slashLevel,
+          args.repUsers,
+          args.newScores,
+          args.epoch
+        );
+
+  const localCommitment = computeSignersCommitment(
+    aggregatorAddress,
+    chainId,
+    args.proposalId,
+    messageHash,
+    args.signerMask,
+    claimedSigners
+  );
+
+  // Read the on-chain commitment at the execution block (immutable once set, but pin for reorg
+  // determinism). A match proves our claimedSigners derivation is byte-aligned with SP.
+  const onChainCommitment: string = await agg.proposalSignersCommitment(args.proposalId, {
+    blockTag: executionBlock,
+  });
+  const commitmentVerified =
+    onChainCommitment !== ethers.ZeroHash && localCommitment === onChainCommitment;
+
+  const block = await provider.getBlock(executionBlock);
+  const executionBlockTimestamp = block?.timestamp ?? 0;
+
+  return {
+    proposalId: args.proposalId.toString(),
+    operator: args.operator,
+    slashLevel: args.slashLevel,
+    epoch: args.epoch.toString(),
+    evidenceHash: args.evidenceHash,
+    signerMask: args.signerMask.toString(),
+    claimedSigners,
+    executionBlock,
+    txHash,
+    chainId: chainId.toString(),
+    commitment: onChainCommitment,
+    commitmentVerified,
+    executionBlockTimestamp,
+  };
+}

--- a/src/modules/audit/guardian-slash-watcher.service.spec.ts
+++ b/src/modules/audit/guardian-slash-watcher.service.spec.ts
@@ -1,0 +1,252 @@
+import { promises as fs } from "fs";
+import * as os from "os";
+import * as path from "path";
+import { ethers } from "ethers";
+import { GuardianSlashWatcherService } from "./guardian-slash-watcher.service.js";
+import { LocalGuardianSignerStore } from "./guardian-signer-store.js";
+import {
+  VERIFY_AND_EXECUTE_ABI,
+  rawSlashMessageHash,
+  computeSignersCommitment,
+} from "./guardian-fraud-proof.js";
+import { SLASH_EXECUTED_EVENT } from "./guardian-slash-watcher.core.js";
+
+const coder = ethers.AbiCoder.defaultAbiCoder();
+const S1 = ethers.getAddress("0x0000000000000000000000000000000000001111");
+const S2 = ethers.getAddress("0x0000000000000000000000000000000000002222");
+const S3 = ethers.getAddress("0x0000000000000000000000000000000000003333");
+const OPERATOR = ethers.getAddress("0x000000000000000000000000000000000000abcd");
+const AGG = ethers.getAddress("0x0000000000000000000000000000000000000a99");
+const CHAIN_ID = 11155111n;
+const MASK = 0x7n;
+const EPOCH = 1000n;
+const LEVEL = 2;
+const EVIDENCE = ethers.keccak256(ethers.toUtf8Bytes("ev"));
+const TOPIC = new ethers.Interface([SLASH_EXECUTED_EVENT]).getEvent("SlashExecuted")!.topicHash;
+
+const va = new ethers.Interface([
+  "function validatorAtSlot(uint8 slot) view returns (address)",
+  "function proposalSignersCommitment(uint256 proposalId) view returns (bytes32)",
+]);
+
+function calldataFor(pid: bigint): string {
+  const iface = new ethers.Interface([VERIFY_AND_EXECUTE_ABI]);
+  return iface.encodeFunctionData("verifyAndExecute", [
+    pid,
+    OPERATOR,
+    LEVEL,
+    [],
+    [],
+    EPOCH,
+    EVIDENCE,
+    coder.encode(["uint256", "bytes"], [MASK, "0xdead"]),
+  ]);
+}
+function commitmentFor(pid: bigint): string {
+  const mh = rawSlashMessageHash(CHAIN_ID, pid, OPERATOR, LEVEL, EPOCH, EVIDENCE);
+  return computeSignersCommitment(AGG, CHAIN_ID, pid, mh, MASK, [S1, S2, S3]);
+}
+
+interface FakeLog {
+  topics: string[];
+  transactionHash: string;
+  blockNumber: number;
+  index: number;
+}
+
+/** Mock provider: getLogs returns the configured logs; call/getTransaction dispatch on fixtures. */
+class MockProvider {
+  private readonly validators: Record<number, string> = { 1: S3, 2: S1, 3: S2 };
+  constructor(
+    private readonly head: number,
+    private readonly logs: FakeLog[],
+    private readonly txData: Record<string, string>, // txHash → calldata (absent → getTransaction null)
+    private readonly commitments: Record<string, string> // pid → commitment (absent → ZeroHash)
+  ) {}
+  get provider(): this {
+    return this;
+  }
+  async resolveName(n: string): Promise<string> {
+    return n;
+  }
+  async getBlockNumber(): Promise<number> {
+    return this.head;
+  }
+  async getLogs(): Promise<FakeLog[]> {
+    return this.logs;
+  }
+  async getBlock(): Promise<{ timestamp: number }> {
+    return { timestamp: 1_700_000_000 };
+  }
+  async getTransaction(hash: string): Promise<{ data: string } | null> {
+    return this.txData[hash] ? { data: this.txData[hash] } : null;
+  }
+  async call(tx: { data: string }): Promise<string> {
+    const sel = tx.data.slice(0, 10);
+    if (sel === va.getFunction("validatorAtSlot")!.selector) {
+      const [slot] = va.decodeFunctionData("validatorAtSlot", tx.data);
+      return va.encodeFunctionResult("validatorAtSlot", [
+        this.validators[Number(slot)] ?? ethers.ZeroAddress,
+      ]);
+    }
+    const [pid] = va.decodeFunctionData("proposalSignersCommitment", tx.data);
+    return va.encodeFunctionResult("proposalSignersCommitment", [
+      this.commitments[pid.toString()] ?? ethers.ZeroHash,
+    ]);
+  }
+}
+
+/** Build a service with internals wired to a mock provider + a real temp-dir store. */
+function makeService(store: LocalGuardianSignerStore, provider: MockProvider) {
+  const svc = new GuardianSlashWatcherService(undefined, undefined, store);
+  // Bypass bootstrap (no live RPC): set the fields tick() reads.
+  (svc as any).provider = provider;
+  (svc as any).chainId = CHAIN_ID;
+  (svc as any).aggregatorAddress = AGG;
+  (svc as any).slashExecutedTopic = TOPIC;
+  (svc as any).fromBlock = 0;
+  (svc as any).finalityConfirmations = 0;
+  (svc as any).logChunk = 10_000;
+  return svc;
+}
+
+const logFor = (pid: bigint, tx: string, block: number, index: number): FakeLog => ({
+  topics: [TOPIC, ethers.zeroPadValue(ethers.toBeHex(pid), 32)],
+  transactionHash: tx,
+  blockNumber: block,
+  index,
+});
+
+describe("GuardianSlashWatcherService (CC-89 stage-2 durability)", () => {
+  let dir: string;
+  let store: LocalGuardianSignerStore;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "guardian-svc-"));
+    store = new LocalGuardianSignerStore(dir);
+  });
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("routes a matching capture to VERIFIED and advances the cursor", async () => {
+    const tx = "0x" + "a1".repeat(32);
+    const provider = new MockProvider(
+      100,
+      [logFor(42n, tx, 50, 0)],
+      { [tx]: calldataFor(42n) },
+      { "42": commitmentFor(42n) }
+    );
+    await makeService(store, provider).tick();
+
+    const rec = await store.getVerified(42n);
+    expect(rec?.claimedSigners).toEqual([S1, S2, S3]);
+    expect(rec?.commitmentVerified).toBe(true);
+    expect(await store.readCursor()).toBe(100); // full chunk scanned → cursor at safeHead
+    expect(await store.listFailures()).toHaveLength(0);
+  });
+
+  it("QUARANTINES a commitment mismatch (never canonical) instead of trusting it", async () => {
+    const tx = "0x" + "b2".repeat(32);
+    const provider = new MockProvider(
+      100,
+      [logFor(43n, tx, 50, 0)],
+      { [tx]: calldataFor(43n) },
+      { "43": "0x" + "ff".repeat(32) } // wrong commitment
+    );
+    await makeService(store, provider).tick();
+
+    expect(await store.getVerified(43n)).toBeNull(); // NOT canonical
+    expect(await store.hasTerminal(43n)).toBe(true); // quarantined (won't re-scan)
+    expect(await store.count()).toBe(0);
+  });
+
+  it("DEAD-LETTERS an uncapturable log (tx not found) — visible, not silently lost", async () => {
+    const tx = "0x" + "c3".repeat(32);
+    const provider = new MockProvider(
+      100,
+      [logFor(44n, tx, 50, 0)],
+      {}, // getTransaction returns null → build throws
+      {}
+    );
+    await makeService(store, provider).tick();
+
+    const failures = await store.listFailures();
+    expect(failures).toHaveLength(1);
+    expect(failures[0].proposalId).toBe("44");
+    expect(failures[0].attempts).toBe(1);
+    expect(await store.getVerified(44n)).toBeNull();
+    // Cursor still advances (the failure is durably tracked + retried), not stuck.
+    expect(await store.readCursor()).toBe(100);
+  });
+
+  it("retries a dead-letter and PROMOTES it once the tx becomes fetchable", async () => {
+    const tx = "0x" + "d4".repeat(32);
+    // First tick: tx missing → dead-letter.
+    const p1 = new MockProvider(100, [logFor(45n, tx, 50, 0)], {}, {});
+    await makeService(store, p1).tick();
+    expect(await store.listFailures()).toHaveLength(1);
+
+    // Second tick: tx now available → retryFailures promotes it, dead-letter cleared.
+    const p2 = new MockProvider(
+      100,
+      [], // cursor already advanced past block 50; promotion comes from the retry path
+      { [tx]: calldataFor(45n) },
+      { "45": commitmentFor(45n) }
+    );
+    await makeService(store, p2).tick();
+
+    expect(await store.getVerified(45n)).not.toBeNull();
+    expect(await store.listFailures()).toHaveLength(0);
+  });
+
+  it("scanRange SKIPS an already-dead-lettered log (retry loop owns it — no double-count)", async () => {
+    const tx = "0x" + "f6".repeat(32);
+    // Pre-seed a dead-letter for this exact log (block 50, index 0), attempts already 1.
+    await store.putFailure({
+      block: 50,
+      logIndex: 0,
+      txHash: tx,
+      proposalId: "47",
+      reason: "prior failure",
+      attempts: 1,
+      parked: false,
+    });
+    // Provider CAN now serve the tx — but scanRange must NOT re-process it (retry loop's job).
+    const provider = new MockProvider(
+      100,
+      [logFor(47n, tx, 50, 0)],
+      { [tx]: calldataFor(47n) },
+      { "47": commitmentFor(47n) }
+    );
+    const svc = makeService(store, provider);
+    const completed = await (svc as any).scanRange(0, 100);
+    expect(completed).toBe(true);
+    // Not captured by scanRange; the dead-letter is untouched (attempts still 1).
+    expect(await store.getVerified(47n)).toBeNull();
+    const failures = await store.listFailures();
+    expect(failures).toHaveLength(1);
+    expect(failures[0].attempts).toBe(1);
+  });
+
+  it("scanRange signals INCOMPLETE (false) under shutdown so the cursor never advances past it", async () => {
+    const tx = "0x" + "e5".repeat(32);
+    const provider = new MockProvider(
+      100,
+      [logFor(46n, tx, 50, 0)],
+      { [tx]: calldataFor(46n) },
+      { "46": commitmentFor(46n) }
+    );
+    const svc = makeService(store, provider);
+    (svc as any).stopping = true;
+
+    // scanRange must return false (interrupted) and capture nothing.
+    const completed = await (svc as any).scanRange(0, 100);
+    expect(completed).toBe(false);
+    expect(await store.getVerified(46n)).toBeNull();
+
+    // And the whole tick() early-returns under shutdown → cursor untouched.
+    await svc.tick();
+    expect(await store.readCursor()).toBeNull();
+  });
+});

--- a/src/modules/audit/guardian-slash-watcher.service.ts
+++ b/src/modules/audit/guardian-slash-watcher.service.ts
@@ -1,0 +1,311 @@
+import {
+  Injectable,
+  Logger,
+  Optional,
+  OnApplicationBootstrap,
+  OnApplicationShutdown,
+} from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { ethers } from "ethers";
+import { OpsAlertService } from "../ops-alert/ops-alert.service.js";
+import type { IGuardianSignerStore } from "./guardian-signer-store.js";
+import { LocalGuardianSignerStore } from "./guardian-signer-store.js";
+import { SLASH_EXECUTED_EVENT, buildGuardianSignerRecord } from "./guardian-slash-watcher.core.js";
+
+/**
+ * CC-89 stage-2 — guardian-slash WATCHER (the off-chain data-availability half).
+ *
+ * SP's A' commitment (`proposalSignersCommitment`, PR #371) is an irreversible fingerprint of a
+ * slash's signer ADDRESS set. When a slash is later found fraudulent, the fraud-proof assembler
+ * needs the actual `claimedSigners` that reproduce that commitment — and the commitment can't be
+ * reversed. So each DVT node must capture the signer set AT execution time. This service is that
+ * capture: it polls `BLSAggregator.SlashExecuted`, resolves the co-signer addresses via
+ * `validatorAtSlot` pinned to the verifyAndExecute EXECUTION block, self-checks the recomputed
+ * commitment against on-chain, and durably records `proposalId → {claimedSigners, ...}`.
+ *
+ * It runs IN-PROCESS in every DVT node — the fleet's multiple independent nodes ARE the required
+ * redundancy (a slash whose set no node recorded is permanently un-attributable). It is a pure
+ * OBSERVER: it never signs, files, or slashes — downstream (the assembler + on-chain verifier) do.
+ *
+ * DURABILITY INVARIANTS (Codex CC-89 review):
+ *   - Only SELF-VERIFIED records enter the canonical store (`putVerified`); a self-check miss is
+ *     QUARANTINED (`putUnverified`) + alerted, never trusted by the assembler.
+ *   - A log that can't be captured at all is DEAD-LETTERED (`putFailure`) + retried each tick — a
+ *     transient error self-heals; a permanent one (e.g. a wrapped/undecodable verifyAndExecute)
+ *     stays VISIBLE + RECOVERABLE, never silently lost.
+ *   - The scan cursor advances ONLY after a chunk is FULLY processed (every log reached a durable
+ *     terminal/dead-letter state) and NOT while shutting down — so no log is ever skipped past.
+ *
+ * KNOWN GAP (production, not E2E): only a TOP-LEVEL `verifyAndExecute` tx decodes. A production
+ * execution wrapped by DVTValidator/a relayer/multicall dead-letters (visible, not lost); resolving
+ * the internal call needs trace support (debug_traceTransaction) — Phase-3.
+ *
+ * Opt-in (AUDIT_GUARDIAN_WATCH_ENABLED, default off) and fail-closed: disables itself if the
+ * aggregator address is missing or has no on-chain code. Polling (not a ws subscription) with a
+ * persisted cursor makes it restart-safe — a node that was down backfills from where it left off.
+ */
+@Injectable()
+export class GuardianSlashWatcherService implements OnApplicationBootstrap, OnApplicationShutdown {
+  private static readonly MIN_INTERVAL_MS = 5_000;
+  private static readonly MAX_INTERVAL_MS = 3_600_000; // 1h
+  /** Dead-letter retry cap; past this the entry is PARKED (kept durable, no longer auto-retried). */
+  private static readonly MAX_CAPTURE_ATTEMPTS = 10;
+
+  private readonly logger = new Logger(GuardianSlashWatcherService.name);
+  private readonly enabled: boolean;
+  private readonly aggregatorAddress: string;
+  private readonly rpcUrl: string;
+  private readonly intervalMs: number;
+  private readonly fromBlock: number;
+  private readonly finalityConfirmations: number;
+  private readonly logChunk: number;
+  private readonly store: IGuardianSignerStore;
+
+  private provider: ethers.JsonRpcProvider | null = null;
+  private chainId: bigint | null = null;
+  private slashExecutedTopic = "";
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private inFlight = false;
+  private stopping = false;
+
+  constructor(
+    @Optional() private readonly config?: ConfigService,
+    @Optional() private readonly opsAlert?: OpsAlertService,
+    @Optional() store?: IGuardianSignerStore
+  ) {
+    this.enabled = this.config?.get<boolean>("auditGuardianWatchEnabled") === true;
+    this.aggregatorAddress = this.config?.get<string>("auditBlsAggregatorAddress") ?? "";
+    this.rpcUrl = this.config?.get<string>("ethRpcUrl") ?? "";
+    this.intervalMs = this.config?.get<number>("auditGuardianWatchIntervalMs") ?? 60_000;
+    this.fromBlock = this.config?.get<number>("auditGuardianWatchFromBlock") ?? 0;
+    this.finalityConfirmations = this.config?.get<number>("auditFinalityConfirmations") ?? 12;
+    this.logChunk = this.config?.get<number>("auditRoleLogChunk") ?? 10_000;
+    this.store =
+      store ??
+      new LocalGuardianSignerStore(
+        this.config?.get<string>("auditGuardianWatchDir") ?? "./guardian-signer-records"
+      );
+  }
+
+  onApplicationBootstrap(): void {
+    if (!this.enabled) return;
+    if (!/^0x[0-9a-fA-F]{40}$/.test(this.aggregatorAddress)) {
+      this.logger.warn(
+        "AUDIT_GUARDIAN_WATCH_ENABLED but AUDIT_BLS_AGGREGATOR_ADDRESS is missing/invalid — watcher DISABLED"
+      );
+      return;
+    }
+    if (!this.rpcUrl) {
+      this.logger.warn(
+        "AUDIT_GUARDIAN_WATCH_ENABLED but ETH_RPC_URL is missing — watcher DISABLED"
+      );
+      return;
+    }
+    if (
+      !Number.isFinite(this.intervalMs) ||
+      this.intervalMs < GuardianSlashWatcherService.MIN_INTERVAL_MS ||
+      this.intervalMs > GuardianSlashWatcherService.MAX_INTERVAL_MS
+    ) {
+      this.logger.warn(
+        `AUDIT_GUARDIAN_WATCH_INTERVAL_MS (${this.intervalMs}) out of ` +
+          `[${GuardianSlashWatcherService.MIN_INTERVAL_MS}, ${GuardianSlashWatcherService.MAX_INTERVAL_MS}] — watcher DISABLED`
+      );
+      return;
+    }
+
+    this.provider = new ethers.JsonRpcProvider(this.rpcUrl);
+    // Topic0 derived from the canonical event fragment (single source of truth with the core).
+    this.slashExecutedTopic = new ethers.Interface([SLASH_EXECUTED_EVENT]).getEvent(
+      "SlashExecuted"
+    )!.topicHash;
+    this.logger.log(
+      `Guardian-slash watcher ENABLED — aggregator ${this.aggregatorAddress}, ` +
+        `every ${this.intervalMs}ms, from block ${this.fromBlock}, finality −${this.finalityConfirmations}`
+    );
+    // Verify the aggregator has code (fail-closed), then run the first tick, then poll.
+    void this.bootstrapAndPoll();
+  }
+
+  onApplicationShutdown(): void {
+    this.stopping = true;
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private async bootstrapAndPoll(): Promise<void> {
+    try {
+      const code = await this.provider!.getCode(this.aggregatorAddress);
+      if (code === "0x") {
+        this.logger.warn(
+          `aggregator ${this.aggregatorAddress} has no on-chain code — watcher DISABLED`
+        );
+        return;
+      }
+      const net = await this.provider!.getNetwork();
+      this.chainId = net.chainId;
+    } catch (e: any) {
+      this.logger.warn(`watcher bootstrap read failed — DISABLED: ${e?.message ?? String(e)}`);
+      return;
+    }
+    if (this.stopping) return;
+    void this.tick();
+    this.timer = setInterval(() => void this.tick(), this.intervalMs);
+  }
+
+  /** One cycle: retry dead-letters, then scan cursor → finalized head. Never throws. */
+  async tick(): Promise<void> {
+    if (this.stopping || !this.provider || this.chainId === null) return;
+    if (this.inFlight) {
+      this.logger.debug("watcher tick skipped — previous still in-flight");
+      return;
+    }
+    this.inFlight = true;
+    try {
+      await this.retryFailures();
+
+      const head = await this.provider.getBlockNumber();
+      const safeHead = head - this.finalityConfirmations;
+      if (safeHead < this.fromBlock) return; // nothing finalized to scan yet
+
+      const cursor = await this.store.readCursor();
+      let from = cursor === null ? this.fromBlock : cursor + 1;
+      if (from > safeHead) return;
+
+      while (from <= safeHead && !this.stopping) {
+        const to = Math.min(from + this.logChunk - 1, safeHead);
+        const completed = await this.scanRange(from, to);
+        // Advance the cursor ONLY when the whole chunk was durably accounted for (every log verified,
+        // quarantined, or dead-lettered) and we were not interrupted by shutdown — never skip a log.
+        if (!completed) return;
+        await this.store.writeCursor(to);
+        from = to + 1;
+      }
+    } catch (e: any) {
+      const msg = e?.shortMessage ?? e?.message ?? String(e);
+      this.logger.warn(`watcher tick failed (will retry): ${msg}`);
+      this.opsAlert?.alert("warn", `⚠️ DVT guardian-slash watcher tick failed: ${msg}`);
+    } finally {
+      this.inFlight = false;
+    }
+  }
+
+  /**
+   * Process every SlashExecuted in [from, to]. Returns true iff the whole range was processed
+   * (each log reached a durable terminal/dead-letter state); false if shutdown interrupted it, so
+   * the caller must NOT advance the cursor.
+   */
+  private async scanRange(from: number, to: number): Promise<boolean> {
+    const logs = await this.provider!.getLogs({
+      address: this.aggregatorAddress,
+      topics: [this.slashExecutedTopic],
+      fromBlock: from,
+      toBlock: to,
+    });
+    for (const log of logs) {
+      if (this.stopping) return false; // interrupted — do not advance the cursor past unscanned logs
+      const proposalId = BigInt(log.topics[1]); // topic[1] = indexed proposalId
+      if (await this.store.hasTerminal(proposalId)) continue; // already verified or quarantined
+      // Already dead-lettered (e.g. a shutdown left this range's cursor unadvanced) — the retry loop
+      // owns re-driving it; re-processing here would double-count attempts + double-alert.
+      if (await this.store.hasFailure(log.blockNumber, log.index)) continue;
+      await this.captureOne(proposalId, log.transactionHash, log.blockNumber, log.index);
+    }
+    return true;
+  }
+
+  /** Build + route one log to verified / quarantine / dead-letter. Never throws. */
+  private async captureOne(
+    proposalId: bigint,
+    txHash: string,
+    executionBlock: number,
+    logIndex: number
+  ): Promise<void> {
+    try {
+      const record = await buildGuardianSignerRecord(
+        this.provider!,
+        this.aggregatorAddress,
+        this.chainId!,
+        proposalId,
+        txHash,
+        executionBlock
+      );
+      if (record.commitmentVerified) {
+        await this.store.putVerified(record);
+        this.logger.log(
+          `captured signer set for proposal ${proposalId} ` +
+            `(${record.claimedSigners.length} signers, block ${executionBlock})`
+        );
+      } else {
+        // Recorded but the recompute didn't match on-chain — QUARANTINE (never trusted by the
+        // assembler) + loud alert. Not the canonical store; not a silent drop.
+        await this.store.putUnverified(record);
+        this.logger.warn(
+          `proposal ${proposalId} QUARANTINED — commitment self-check failed (needs manual review)`
+        );
+        this.opsAlert?.alert(
+          "warn",
+          `⚠️ DVT watcher: proposal ${proposalId} signer-set commitment mismatch (quarantined, needs review)`
+        );
+      }
+    } catch (e: any) {
+      // Could not build a record at all (tx fetch error, wrapped/undecodable call, hole slot). Dead-
+      // letter it so it is retried + stays visible — a missed capture erodes attribution redundancy.
+      await this.deadLetter(proposalId, txHash, executionBlock, logIndex, e?.message ?? String(e));
+    }
+  }
+
+  /** Record a capture failure durably (idempotent by block+logIndex; bumps attempts, parks at cap). */
+  private async deadLetter(
+    proposalId: bigint,
+    txHash: string,
+    block: number,
+    logIndex: number,
+    reason: string
+  ): Promise<void> {
+    const existing = (await this.store.listFailures()).find(
+      f => f.block === block && f.logIndex === logIndex
+    );
+    const attempts = (existing?.attempts ?? 0) + 1;
+    const parked = attempts >= GuardianSlashWatcherService.MAX_CAPTURE_ATTEMPTS;
+    await this.store.putFailure({
+      block,
+      logIndex,
+      txHash,
+      proposalId: proposalId.toString(),
+      reason,
+      attempts,
+      parked,
+    });
+    const tail = parked ? " — PARKED (max attempts, manual recovery needed)" : "";
+    this.logger.warn(
+      `could not capture proposal ${proposalId} (attempt ${attempts}) — dead-lettered: ${reason}${tail}`
+    );
+    this.opsAlert?.alert(
+      "warn",
+      `⚠️ DVT watcher: proposal ${proposalId} signer set NOT captured (attempt ${attempts})${tail} — ${reason}`
+    );
+  }
+
+  /** Re-attempt each non-parked dead-letter; on success promote to verified/quarantine + remove. */
+  private async retryFailures(): Promise<void> {
+    const failures = await this.store.listFailures();
+    for (const f of failures) {
+      if (this.stopping) return;
+      if (f.parked) continue;
+      const proposalId = BigInt(f.proposalId);
+      // Already captured elsewhere (e.g. a concurrent scan) → just clear the stale dead-letter.
+      if (await this.store.hasTerminal(proposalId)) {
+        await this.store.removeFailure(f.block, f.logIndex);
+        continue;
+      }
+      // Re-drive. On STILL-failing, captureOne re-dead-letters (bumping attempts); on success it
+      // persists the record and we clear the dead-letter here.
+      await this.captureOne(proposalId, f.txHash, f.block, f.logIndex);
+      if (await this.store.hasTerminal(proposalId)) {
+        await this.store.removeFailure(f.block, f.logIndex);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What & why (CC-89 stage-2, F1)

The over-issue guardian-collusion fraud path (issue #222) needs the **signer ADDRESS set** of each executed slash to build a fraud proof. SP's A' commitment (`proposalSignersCommitment`, SP PR #371) is an **irreversible** `bytes32` — you cannot reverse it back to the addresses. So each DVT node must capture the set **at execution time**. This PR is that capture.

An in-process NestJS watcher (opt-in `AUDIT_GUARDIAN_WATCH_ENABLED`, **default off**) that:
- polls `BLSAggregator.SlashExecuted`, decodes the `verifyAndExecute` calldata,
- resolves the co-signer addresses via `validatorAtSlot` pinned to the **execution block** (SP byte-critical), 
- recomputes SP's A' commitment and **self-checks** it against on-chain,
- durably records `proposalId → {claimedSigners, …}`.

Pure OBSERVER — never signs/files/slashes. The fleet's multiple nodes ARE the required redundancy (a set no node records is permanently un-attributable).

## Durability invariants (Codex Tier-1, 3 rounds)
- Only **self-verified** records enter the canonical store; a self-check miss is **quarantined** + alerted (assembler never trusts it).
- An uncapturable log is **dead-lettered** + retried each tick (attempts cap → parked); **never silently lost**.
- Scan cursor advances **only** after a fully-scanned, non-shutdown-interrupted chunk.
- Atomic writes (temp + rename); restart-safe persisted cursor.

**Known gap (Phase-3, not E2E):** only top-level `verifyAndExecute` decodes; a production wrapper/relayer/multicall dead-letters (visible+recoverable, not lost) — full resolution needs trace support.

## Review
Codex Tier-1 (codex:codex-rescue) **3 rounds**: R1 = 1 Critical + 4 High → fixed; R2 = all 5 confirmed fixed + 1 Medium + 1 Low → fixed; R3 = **clean, no new issues**.

## Tests / gate
- `jest src/modules/audit` = **130 passed** (33 new: store 3-area + dead-letter, core mock-provider byte-alignment golden, service integration routing/cursor/retry/shutdown).
- `type-check` + `lint:check` clean; `build` clean.

## Acceptance (F1) — see docs/design/cc89-stage2-shipping-plan.md §1
- [x] type-check / lint:check / format:check (F1 files) clean
- [x] jest src/modules/audit green
- [x] build clean
- [x] Codex: no unresolved Critical/High
- [x] opt-in default-off + fail-closed disable paths
- [x] never persists a partial/guessed set; self-check miss quarantined+alerted
- [ ] pr-daemon/clestons APPROVE + checks green
- [ ] merged; suite green on master

Refs: Seeder CC-89, issue #222.