### PR TITLE
feat(CC-89): fraud-proof assembler — over-issue guardian-slash

### DIFF
--- a/docs/AUDIT_SLASH_MODEL.md
+++ b/docs/AUDIT_SLASH_MODEL.md
@@ -5,8 +5,9 @@
 > stake-slash rules. See PR #205.
 >
 > This doc covers the quorum auditing **operators**. For the inverse — slashing
-> the **guardians** (co-signers) themselves when ≥m collude to pass a false slash
-> — see [`design/guardian-collusion-slash.md`](design/guardian-collusion-slash.md)
+> the **guardians** (co-signers) themselves when ≥m collude to pass a false
+> slash — see
+> [`design/guardian-collusion-slash.md`](design/guardian-collusion-slash.md)
 > (CC-89, Protocol B).
 
 ## 1. Two enforcement mechanisms

--- a/docs/design/guardian-collusion-slash.md
+++ b/docs/design/guardian-collusion-slash.md
@@ -1,9 +1,10 @@
 # Guardian-Collusion Slashing (CC-89, Protocol B)
 
-> Stage-0 design doc. Companion to [`../AUDIT_SLASH_MODEL.md`](../AUDIT_SLASH_MODEL.md),
-> which covers the DVT node auditing **operators**. This doc covers the inverse:
-> slashing the **guardians** (the DVT co-signers themselves) when they collude.
-> Origin: CC-89 evaluation request from the RepCredit paper (DSR-Research-Flow).
+> Stage-0 design doc. Companion to
+> [`../AUDIT_SLASH_MODEL.md`](../AUDIT_SLASH_MODEL.md), which covers the DVT
+> node auditing **operators**. This doc covers the inverse: slashing the
+> **guardians** (the DVT co-signers themselves) when they collude. Origin: CC-89
+> evaluation request from the RepCredit paper (DSR-Research-Flow).
 
 ## 1. Why this exists — the threat the operator-audit model doesn't cover
 
@@ -32,18 +33,18 @@ k · C_max  <  m · ρ · S_op · p_G
   `defaultThreshold=7`** (`defaultThreshold` is the reputation-consensus path
   only). Using 7 overstates collusion resistance ~2–3×.
 - `S_op` = a guardian's ROLE_DVT GToken lock.
-- `ρ` = probability the collusion is detected **and** leads to a slash — the term
-  with no code correspondent until the detection layer (stage 2) exists.
+- `ρ` = probability the collusion is detected **and** leads to a slash — the
+  term with no code correspondent until the detection layer (stage 2) exists.
 
 ### Asset distinction — not "party" distinction
 
 The slashed operator (`operators[operator].aPNTsBalance`, requires
 ROLE_PAYMASTER_SUPER config) and the co-signing guardian (ROLE_DVT lock) are
 **different assets, not guaranteed-different parties**: the BLS slash path does
-**not** enforce ROLE_PAYMASTER_SUPER at slash time, and one address can hold both
-roles. What is guaranteed distinct is the asset — **aPNTs balance ≠ ROLE_DVT
-GToken lock**, even at a shared address. The gap is that the paper's `ρ · S_op`
-(a ROLE_DVT-stake loss) has no execution path targeting that asset.
+**not** enforce ROLE_PAYMASTER_SUPER at slash time, and one address can hold
+both roles. What is guaranteed distinct is the asset — **aPNTs balance ≠
+ROLE_DVT GToken lock**, even at a shared address. The gap is that the paper's
+`ρ · S_op` (a ROLE_DVT-stake loss) has no execution path targeting that asset.
 
 ## 2. The auto-eject property (the free half of the mechanism)
 
@@ -59,29 +60,29 @@ if (uint256(amount) < minStake) revert SlotValidatorStakeBelowMinimum(...);   //
 > **Consequence:** a guardian whose ROLE_DVT lock drops **below** `minStake` is
 > automatically ejected from all future signing — any proof that includes its
 > slot reverts. No separate "kick" logic is needed. The penalty shape for
-> collusion is therefore *slash the full lock → 0 < minStake → auto-eject*, which
-> both burns `S_op` and removes eligibility in one step.
+> collusion is therefore _slash the full lock → 0 < minStake → auto-eject_,
+> which both burns `S_op` and removes eligibility in one step.
 
-Note the boundary (SP review): the check is strict `<`. To **guarantee** ejection
-the slash must take the **full** lock (leaving 0), not `minStake` — leaving
-exactly `minStake` still passes the check. `executeGuardianSlash` slashes the
-full lock for this reason.
+Note the boundary (SP review): the check is strict `<`. To **guarantee**
+ejection the slash must take the **full** lock (leaving 0), not `minStake` —
+leaving exactly `minStake` still passes the check. `executeGuardianSlash`
+slashes the full lock for this reason.
 
 ## 3. Trigger authority — how the circular dependency is broken
 
 The obvious problem: `queueSlashWithConsensus` / `verifyAndExecute` require
-`msg.sender == DVT_VALIDATOR || owner()`, and the colluders **are** that quorum —
-they will never slash themselves. A same-quorum trigger cannot work.
+`msg.sender == DVT_VALIDATOR || owner()`, and the colluders **are** that quorum
+— they will never slash themselves. A same-quorum trigger cannot work.
 
 SP's `executeGuardianSlash` (BLSAggregator 4.2.0, **PR #370 — merged, but
 dormant** until a verifier is wired) resolves this at the contract layer:
 
-| Property | How | Why it matters |
-| --- | --- | --- |
-| **Permissionless call, verifier-gated** | no caller-identity check; gated by `IFraudProofVerifier.verify(...)` | fraud *validity*, not caller identity, authorizes the slash → bypasses the colluding quorum |
-| **Address-based** (not slot) | slashes `roleLocks(guardian, ROLE_DVT)` by address | `validatorAtSlot` is reassignable (`revokeBLSPublicKey`); a slot captured at fraud time could resolve to an innocent validator later. Also blocks the revoke-key-to-escape trick |
-| **Full slash, no 30% cap** | slashes the entire lock | proven collusion must lose eligibility; the operator-path 30% cap protects *honest* operators from one bad epoch — a different threat model |
-| **fail-closed** | `fraudProofVerifier == address(0)` → revert | dormant until governance wires a verifier; safe to ship |
+| Property                                | How                                                                  | Why it matters                                                                                                                                                                   |
+| --------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Permissionless call, verifier-gated** | no caller-identity check; gated by `IFraudProofVerifier.verify(...)` | fraud _validity_, not caller identity, authorizes the slash → bypasses the colluding quorum                                                                                      |
+| **Address-based** (not slot)            | slashes `roleLocks(guardian, ROLE_DVT)` by address                   | `validatorAtSlot` is reassignable (`revokeBLSPublicKey`); a slot captured at fraud time could resolve to an innocent validator later. Also blocks the revoke-key-to-escape trick |
+| **Full slash, no 30% cap**              | slashes the entire lock                                              | proven collusion must lose eligibility; the operator-path 30% cap protects _honest_ operators from one bad epoch — a different threat model                                      |
+| **fail-closed**                         | `fraudProofVerifier == address(0)` → revert                          | dormant until governance wires a verifier; safe to ship                                                                                                                          |
 
 So the trigger is **solved**. The remaining unbuilt half is purely the
 **detection**: what does `verify()` actually check.
@@ -100,28 +101,28 @@ builds the verifier + the off-chain cross-monitoring that feeds it.
 
 ### The `view` constraint bounds ρ
 
-`verify` is `view` → the fraud proof must reduce to **on-chain-checkable facts**.
-That bounds which collusion is objectively provable:
+`verify` is `view` → the fraud proof must reduce to **on-chain-checkable
+facts**. That bounds which collusion is objectively provable:
 
-| Slash's underlying evidence | Trustless `view` fraud proof? | ρ status |
-| --- | --- | --- |
-| over-issue (`isOverIssued()` bool) | ⚠️ **only within a challenge window** — a `view` verifier reads *current* state, not the `epoch`-block state the slash was pinned to (see "historical-state gap" in §4b) | system property **only** while the disputed block's state is on-chain-provable (bounded window) |
-| liveness / gossip heartbeat (today's active rule ②) | ❌ `evidenceHash` is opaque on-chain; `view` can't adjudicate | needs **CC-29 LivenessRegistry** to put liveness on-chain first |
-| purely off-chain evidence | ❌ | stays a governance assumption |
+| Slash's underlying evidence                         | Trustless `view` fraud proof?                                                                                                                                            | ρ status                                                                                        |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| over-issue (`isOverIssued()` bool)                  | ⚠️ **only within a challenge window** — a `view` verifier reads _current_ state, not the `epoch`-block state the slash was pinned to (see "historical-state gap" in §4b) | system property **only** while the disputed block's state is on-chain-provable (bounded window) |
+| liveness / gossip heartbeat (today's active rule ②) | ❌ `evidenceHash` is opaque on-chain; `view` can't adjudicate                                                                                                            | needs **CC-29 LivenessRegistry** to put liveness on-chain first                                 |
+| purely off-chain evidence                           | ❌                                                                                                                                                                       | stays a governance assumption                                                                   |
 
-> **ρ is only a system property for on-chain-objective violation classes, and even
-> then only within a bounded challenge window** (§4b historical-state gap). For
-> off-chain-evidence slashes it remains a detection/governance assumption. This
-> is the same lesson as `AUDIT_SLASH_MODEL.md §2` (only objective on-chain
+> **ρ is only a system property for on-chain-objective violation classes, and
+> even then only within a bounded challenge window** (§4b historical-state gap).
+> For off-chain-evidence slashes it remains a detection/governance assumption.
+> This is the same lesson as `AUDIT_SLASH_MODEL.md §2` (only objective on-chain
 > evidence may slash) applied to the accusers instead of the accused.
 
 ### Design notes for the verifier
 
 - **`fraudProofId` must be verifier-bound to the fraud content** (e.g. a
   deterministic derivation of the disputed proposalId), not a caller-arbitrary
-  value, so a valid proof cannot be "consumed" under an unrelated id.
-  (SP's `guardianSlashed[fraudProofId][guardian]` is a replay guard, not a
-  content binding.)
+  value, so a valid proof cannot be "consumed" under an unrelated id. (SP's
+  `guardianSlashed[fraudProofId][guardian]` is a replay guard, not a content
+  binding.)
 - Guilty parties are bound to the **signer address at fraud time**, not the slot
   (slot reuse — see §3).
 - Replay/double-slash guard is **per-`(fraudProofId, guardian)`**
@@ -142,10 +143,10 @@ proves it actually ran (view-readable).
 
 **The verifier must confirm BOTH:**
 
-| # | Claim | Difficulty |
-| --- | --- | --- |
-| (i) | the cited violation was **false at `epoch`** (the slash was unjustified) | **not as easy as it looks** — a `view` verifier reads *current* state, not the `epoch` block. `isOverIssued()` now ≠ at `epoch`. Needs a historical-state mechanism (see "historical-state gap"). |
-| (ii) | a specific set of **guardian addresses co-signed** this exact proposal | resolved by A' (SP commitment) — see "attribution gap" |
+| #    | Claim                                                                    | Difficulty                                                                                                                                                                                        |
+| ---- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| (i)  | the cited violation was **false at `epoch`** (the slash was unjustified) | **not as easy as it looks** — a `view` verifier reads _current_ state, not the `epoch` block. `isOverIssued()` now ≠ at `epoch`. Needs a historical-state mechanism (see "historical-state gap"). |
+| (ii) | a specific set of **guardian addresses co-signed** this exact proposal   | resolved by A' (SP commitment) — see "attribution gap"                                                                                                                                            |
 
 ### The attribution gap (ii) — the real stage-2 blocker
 
@@ -154,18 +155,18 @@ does **not** store the signer set, the `signerMask`, or the signature; the
 `SlashExecuted` / `SlashConsensusReached` events carry some of it but **a `view`
 verifier cannot read logs**. And `signerMask → validatorAtSlot` is **not**
 back-resolvable: slots are reassignable (`revokeBLSPublicKey`), so today's
-mapping ≠ the fraud-time mapping. **Result: after the fact, on-chain state cannot
-tell you which addresses co-signed a past slash.** You can prove the slash was
-wrong (i) but not who to punish (ii).
+mapping ≠ the fraud-time mapping. **Result: after the fact, on-chain state
+cannot tell you which addresses co-signed a past slash.** You can prove the
+slash was wrong (i) but not who to punish (ii).
 
-**Resolved: A' (commitment compromise)** — decided with SP on CC-89 (Codex-reviewed).
-Three options were weighed:
+**Resolved: A' (commitment compromise)** — decided with SP on CC-89
+(Codex-reviewed). Three options were weighed:
 
-| Option | Mechanism | Verdict |
-| --- | --- | --- |
-| A — SP stores the full **signer address set** per proposal | robust | rejected: N-address `SSTORE` per slash, heavy |
-| B — proof carries `{message, claimedSigners[], sigG2}`, verifier re-checks the pairing against **current** BLS keys | dvt-only | rejected: **breaks if a colluder revokes/rotates its BLS key post-attack** (a normal guardian right + a natural escape) |
-| **A' — SP stores a 1-word fraud-time commitment** | chosen | ~1/N the gas of A; the commitment is a fraud-time snapshot, so post-attack key revoke can't break it |
+| Option                                                                                                              | Mechanism | Verdict                                                                                                                 |
+| ------------------------------------------------------------------------------------------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------- |
+| A — SP stores the full **signer address set** per proposal                                                          | robust    | rejected: N-address `SSTORE` per slash, heavy                                                                           |
+| B — proof carries `{message, claimedSigners[], sigG2}`, verifier re-checks the pairing against **current** BLS keys | dvt-only  | rejected: **breaks if a colluder revokes/rotates its BLS key post-attack** (a normal guardian right + a natural escape) |
+| **A' — SP stores a 1-word fraud-time commitment**                                                                   | chosen    | ~1/N the gas of A; the commitment is a fraud-time snapshot, so post-attack key revoke can't break it                    |
 
 **A' mechanics.** In `verifyAndExecute`, after `_checkSignatures` succeeds and
 before any `revokeBLSPublicKey`, SP persists one word per proposal (reusing the
@@ -180,32 +181,36 @@ commitment = keccak256(abi.encode(
 ```
 
 The `verify(fraudProofId, guiltyGuardians, fraudProof)` verifier then:
+
 1. decodes the disputed `proposalId` + `claimedSigners` from `fraudProof`;
-2. reads `proposalSignersCommitment[proposalId]`, checks `keccak(same-structure) == commitment`;
+2. reads `proposalSignersCommitment[proposalId]`, checks
+   `keccak(same-structure) == commitment`;
 3. **enforces `guiltyGuardians ⊆ claimedSigners`** — the commitment only proves
-   the *set*, not that the accused are in it; without this subset check a valid
+   the _set_, not that the accused are in it; without this subset check a valid
    commitment could slash **innocent** addresses (the actual slash targets the
-   externally-supplied `guiltyGuardians`). This check is mandatory, verifier-side;
+   externally-supplied `guiltyGuardians`). This check is mandatory,
+   verifier-side;
 4. recomputes the disputed evidence (subject to the historical-state gap below).
 
-**Data availability (dvt).** The commitment is irreversible — it cannot reproduce
-the address set. So the detection layer's watcher **must record `claimedSigners`
-at fraud-observation time**, and watchers must be **redundant / multi-point**: if
-every watcher misses the fraud-time signer set, attribution is permanently lost.
+**Data availability (dvt).** The commitment is irreversible — it cannot
+reproduce the address set. So the detection layer's watcher **must record
+`claimedSigners` at fraud-observation time**, and watchers must be **redundant /
+multi-point**: if every watcher misses the fraud-time signer set, attribution is
+permanently lost.
 
 ### The historical-state gap (i) — over-issue is not free either
 
 Claim (i) — "the cited violation was false at `epoch`" — is **not** trivially a
 `view` read. `IFraudProofVerifier.verify` is called on-chain from
 `executeGuardianSlash`, where an ordinary Solidity `view` reads **current**
-state. `isOverIssued()` *now* is not `isOverIssued()` at `epoch`. If the token's
+state. `isOverIssued()` _now_ is not `isOverIssued()` at `epoch`. If the token's
 state changes between the false slash and the fraud-proof submission, a naive
 `isOverIssued()` read either fails to slash or adjudicates against the wrong
 block. Closing it needs one of:
 
-- a **bounded challenge window** using `BLOCKHASH` (only the last ~256 blocks are
-  reachable on-chain) + an EIP-1186 storage proof against the `epoch` block's
-  state root → trustless but time-bounded;
+- a **bounded challenge window** using `BLOCKHASH` (only the last ~256 blocks
+  are reachable on-chain) + an EIP-1186 storage proof against the `epoch`
+  block's state root → trustless but time-bounded;
 - extending A''s commitment to also anchor the **objective evidence value** at
   fraud time (only helps if that value is itself objective, not the guardians'
   claim);
@@ -213,24 +218,25 @@ block. Closing it needs one of:
   assumption.
 
 **Consequence for the paper:** over-issue ρ is a system property **only within a
-bounded challenge window**, not indefinitely. This must be stated. (It also means
-the challenge-period design SP deferred for the stake-exit escape is needed for
-evidence-recompute too, not just for exit.)
+bounded challenge window**, not indefinitely. This must be stated. (It also
+means the challenge-period design SP deferred for the stake-exit escape is
+needed for evidence-recompute too, not just for exit.)
 
 ### fraudProofId binding
 
 `fraudProofId` must be a **deterministic derivation of the disputed
 `proposalId`** (e.g. `keccak256("GUARDIAN_FRAUD", proposalId)`), computed by the
 verifier — never a caller-free value — so a valid proof can't be consumed under
-an unrelated id and the same fraud can't be double-filed. SP's per-`(proof,
-guardian)` `guardianSlashed` map is then a correct replay guard.
+an unrelated id and the same fraud can't be double-filed. SP's
+per-`(proof, guardian)` `guardianSlashed` map is then a correct replay guard.
 
 ### Over-issue evidence & slash convention (the filer MUST match)
 
 To bind the disputed `token` into the commitment (closing the token-swap forgery
 a naive verifier allows — CC-89 Codex review), the verifier does **not** trust a
-caller-supplied message hash. It reconstructs SP's slash-only `expectedMessageHash`
-from the slash fields, where the over-issue `evidenceHash` has a **fixed preimage**:
+caller-supplied message hash. It reconstructs SP's slash-only
+`expectedMessageHash` from the slash fields, where the over-issue `evidenceHash`
+has a **fixed preimage**:
 
 ```
 evidenceHash = keccak256(abi.encode("DVT_OVERISSUE_EVIDENCE_V1", token, operator, epoch))
@@ -241,45 +247,49 @@ commitment   = keccak256(abi.encode("BLS_SIGNERS_COMMITMENT_V1", chainid, aggreg
                                     proposalId, messageHash, signerMask, claimedSigners))
 ```
 
-**Whoever files an over-issue slash (the E2E filer / the future audit rule) MUST**:
-1. set `evidenceHash = keccak256(abi.encode("DVT_OVERISSUE_EVIDENCE_V1", token, operator, epoch))`;
+**Whoever files an over-issue slash (the E2E filer / the future audit rule)
+MUST**:
+
+1. set
+   `evidenceHash = keccak256(abi.encode("DVT_OVERISSUE_EVIDENCE_V1", token, operator, epoch))`;
 2. file it as a **pure** slash — `repUsers` **and** `newScores` both empty. SP's
-   slash-only branch fires on `repUsers.length == 0` alone, but the verifier only
-   recognises the canonical empty/empty form; a non-empty `newScores` yields a
-   different `messageHash` and the proof will (fail-closed) not verify.
+   slash-only branch fires on `repUsers.length == 0` alone, but the verifier
+   only recognises the canonical empty/empty form; a non-empty `newScores`
+   yields a different `messageHash` and the proof will (fail-closed) not verify.
 
 Any deviation just means that slash cannot be fraud-proven (no wrongful slash) —
-but it is a **cross-repo alignment point**, not something the verifier can self-enforce.
+but it is a **cross-repo alignment point**, not something the verifier can
+self-enforce.
 
 ### Prerequisites (why stage-2 implementation can't start yet)
 
 1. **An armed, on-chain-objective slash rule** to defend. Today none exists:
-   over-issue is a *view* (not a slash), liveness is *auto-jail* (not a
+   over-issue is a _view_ (not a slash), liveness is _auto-jail_ (not a
    stake-slash), the slash pipeline is dormant (`AUDIT_SLASH_MODEL.md §4`). No
    armed slash ⇒ nothing to fraud-prove.
 2. **A historical-state / challenge-window mechanism** for claim (i) — a `view`
-   verifier can't read `epoch`-block state (above). Bounds when a fraud proof can
-   be filed.
-3. **The claimedSigners watcher** (dvt, redundant) — needed to reproduce the
-   set the A' commitment only anchors.
+   verifier can't read `epoch`-block state (above). Bounds when a fraud proof
+   can be filed.
+3. **The claimedSigners watcher** (dvt, redundant) — needed to reproduce the set
+   the A' commitment only anchors.
 4. **Liveness class only:** CC-29 `LivenessRegistry` deployed (liveness must be
    an on-chain fact before a `view` proof can dispute an offline-slash).
 5. Attribution direction (A') is **decided**; SP changing `verifyAndExecute` (a
    load-bearing consensus path) still requires spec alignment before code.
 
-The **spec is complete enough to build against**; the **implementation** waits on
-1–3 (+ 4 for liveness). Orthogonal: the **stake-exit escape** (a guardian
+The **spec is complete enough to build against**; the **implementation** waits
+on 1–3 (+ 4 for liveness). Orthogonal: the **stake-exit escape** (a guardian
 withdrawing its ROLE_DVT lock to 0 before the proof → `executeGuardianSlash`
 skips) is a challenger-mechanism concern (challenge period / withdrawal freeze),
 tracked separately.
 
 ## 5. Ownership & sequencing
 
-| Stage | Owner | Status |
-| --- | --- | --- |
-| 1 — `executeGuardianSlash` thin entry | SP | ✅ **merged** (PR #370, BLSAggregator 4.2.0) — but **dormant/fail-closed** (`fraudProofVerifier == 0` → revert), address-based, per-`(proof,guardian)` idempotent. Code is in-tree but inert until a verifier is wired. |
-| 0 — this doc (auto-eject + threat model + trigger authority) | dvt | PR #221 |
-| 2 — `IFraudProofVerifier` + off-chain detection (produces ρ) | dvt (+ SP `proposalSignersCommitment`, §4b) | ⏳ spec drafted (§4b, attribution = A'); impl blocked on: an armed slash rule + a historical-state/challenge-window mechanism + (liveness) CC-29 |
+| Stage                                                        | Owner                                       | Status                                                                                                                                                                                                                  |
+| ------------------------------------------------------------ | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1 — `executeGuardianSlash` thin entry                        | SP                                          | ✅ **merged** (PR #370, BLSAggregator 4.2.0) — but **dormant/fail-closed** (`fraudProofVerifier == 0` → revert), address-based, per-`(proof,guardian)` idempotent. Code is in-tree but inert until a verifier is wired. |
+| 0 — this doc (auto-eject + threat model + trigger authority) | dvt                                         | PR #221                                                                                                                                                                                                                 |
+| 2 — `IFraudProofVerifier` + off-chain detection (produces ρ) | dvt (+ SP `proposalSignersCommitment`, §4b) | ⏳ spec drafted (§4b, attribution = A'); impl blocked on: an armed slash rule + a historical-state/challenge-window mechanism + (liveness) CC-29                                                                        |
 
 **When to activate:** N large + operators independent (not co-located) + an
 on-chain-verifiable independent adjudication path. At the current 3-node,
@@ -291,5 +301,6 @@ inequality is a **decentralized-phase target**, not a current deployed property.
 
 - CC-89 (coordination task) — evaluation thread and division of labour.
 - `SuperPaymaster` PR #370 — `executeGuardianSlash` + `IFraudProofVerifier`.
-- [`../AUDIT_SLASH_MODEL.md`](../AUDIT_SLASH_MODEL.md) — the operator-audit side.
+- [`../AUDIT_SLASH_MODEL.md`](../AUDIT_SLASH_MODEL.md) — the operator-audit
+  side.
 - CC-29 — LivenessRegistry (prerequisite for the liveness fraud-proof class).

--- a/src/modules/audit/guardian-fraud-proof-assembler.spec.ts
+++ b/src/modules/audit/guardian-fraud-proof-assembler.spec.ts
@@ -1,0 +1,157 @@
+import { ethers } from "ethers";
+import {
+  assembleOverIssueFraudProof,
+  preflightVerify,
+  AssembledFraudProof,
+} from "./guardian-fraud-proof-assembler.js";
+import {
+  overIssueEvidenceHash,
+  deriveFraudProofId,
+  encodeOverIssueFraudProof,
+} from "./guardian-fraud-proof.js";
+import type { GuardianSignerRecord } from "./guardian-signer-store.js";
+
+const S1 = ethers.getAddress("0x0000000000000000000000000000000000001111");
+const S2 = ethers.getAddress("0x0000000000000000000000000000000000002222");
+const S3 = ethers.getAddress("0x0000000000000000000000000000000000003333");
+const OUTSIDER = ethers.getAddress("0x0000000000000000000000000000000000009999");
+const OPERATOR = ethers.getAddress("0x000000000000000000000000000000000000abcd");
+const TOKEN = ethers.getAddress("0x000000000000000000000000000000000000beef");
+const EPOCH = 1000n;
+
+const verifiedRecord = (over?: Partial<GuardianSignerRecord>): GuardianSignerRecord => ({
+  proposalId: "42",
+  operator: OPERATOR,
+  slashLevel: 2,
+  epoch: EPOCH.toString(),
+  evidenceHash: overIssueEvidenceHash(TOKEN, OPERATOR, EPOCH), // binds TOKEN
+  signerMask: "7",
+  claimedSigners: [S1, S2, S3],
+  executionBlock: 500,
+  txHash: "0x" + "ab".repeat(32),
+  chainId: "11155111",
+  commitment: "0x" + "22".repeat(32),
+  commitmentVerified: true,
+  executionBlockTimestamp: 1_700_000_000,
+  ...over,
+});
+
+describe("guardian-fraud-proof assembler (CC-89 stage-2 F2)", () => {
+  it("assembles a fraudProof the verifier will accept from a verified record", () => {
+    const out = assembleOverIssueFraudProof(verifiedRecord(), TOKEN, [S2, S1]); // unsorted input
+    expect(out.fraudProofId).toBe(deriveFraudProofId(42n));
+    expect(out.guiltyGuardians).toEqual([S1, S2]); // canonicalized ascending
+    // fraudProof matches the exact encoding the verifier decodes.
+    expect(out.fraudProof).toBe(
+      encodeOverIssueFraudProof({
+        proposalId: 42n,
+        operator: OPERATOR,
+        slashLevel: 2,
+        epoch: EPOCH,
+        disputedToken: TOKEN,
+        signerMask: 0x7n,
+        claimedSigners: [S1, S2, S3],
+      })
+    );
+  });
+
+  it("REFUSES an unverified record (never assemble from a non-self-checked set)", () => {
+    expect(() =>
+      assembleOverIssueFraudProof(verifiedRecord({ commitmentVerified: false }), TOKEN, [S1])
+    ).toThrow(/not self-verified/);
+  });
+
+  it("REFUSES a truthy-but-not-true commitmentVerified (strict === true gate)", () => {
+    expect(() =>
+      assembleOverIssueFraudProof(
+        verifiedRecord({ commitmentVerified: "false" as unknown as boolean }),
+        TOKEN,
+        [S1]
+      )
+    ).toThrow(/not self-verified/);
+  });
+
+  it("REFUSES a corrupt record whose claimedSigners are not canonical (unsorted)", () => {
+    expect(() =>
+      assembleOverIssueFraudProof(verifiedRecord({ claimedSigners: [S2, S1, S3] }), TOKEN, [S1])
+    ).toThrow(/not strictly ascending/);
+  });
+
+  it("REFUSES a corrupt record with duplicate claimedSigners", () => {
+    expect(() =>
+      assembleOverIssueFraudProof(verifiedRecord({ claimedSigners: [S1, S1] }), TOKEN, [S1])
+    ).toThrow(/not strictly ascending/);
+  });
+
+  it("REFUSES a corrupt record with a zero-address claimed signer", () => {
+    expect(() =>
+      assembleOverIssueFraudProof(
+        verifiedRecord({ claimedSigners: [ethers.ZeroAddress, S1] }),
+        TOKEN,
+        [S1]
+      )
+    ).toThrow(/zero address/);
+  });
+
+  it("REFUSES a corrupt record with too many claimedSigners (> MAX_VALIDATORS)", () => {
+    const many = Array.from({ length: 14 }, (_, i) =>
+      ethers.getAddress("0x" + (i + 1).toString(16).padStart(40, "0"))
+    );
+    expect(() =>
+      assembleOverIssueFraudProof(verifiedRecord({ claimedSigners: many }), TOKEN, [many[0]])
+    ).toThrow(/exceeds MAX/);
+  });
+
+  it("REFUSES a token that does not bind to the slash (token-swap guard)", () => {
+    const wrongToken = ethers.getAddress("0x000000000000000000000000000000000000c0de");
+    expect(() => assembleOverIssueFraudProof(verifiedRecord(), wrongToken, [S1])).toThrow(
+      /does not bind/
+    );
+  });
+
+  it("REFUSES guilty guardians not ⊆ claimedSigners (cannot slash an innocent address)", () => {
+    expect(() => assembleOverIssueFraudProof(verifiedRecord(), TOKEN, [OUTSIDER])).toThrow(
+      /not among the slash's signers/
+    );
+  });
+
+  it("REFUSES an empty guilty set", () => {
+    expect(() => assembleOverIssueFraudProof(verifiedRecord(), TOKEN, [])).toThrow(/empty/);
+  });
+
+  it("REFUSES a zero address in the guilty set", () => {
+    expect(() =>
+      assembleOverIssueFraudProof(verifiedRecord(), TOKEN, [ethers.ZeroAddress, S1])
+    ).toThrow(/zero address/);
+  });
+
+  it("REFUSES a duplicate in the guilty set", () => {
+    expect(() => assembleOverIssueFraudProof(verifiedRecord(), TOKEN, [S1, S1])).toThrow(
+      /duplicate/
+    );
+  });
+
+  describe("preflightVerify", () => {
+    const iface = new ethers.Interface([
+      "function verify(uint256 fraudProofId, address[] guiltyGuardians, bytes fraudProof) view returns (bool)",
+    ]);
+    const assembled: AssembledFraudProof = assembleOverIssueFraudProof(verifiedRecord(), TOKEN, [
+      S1,
+    ]);
+
+    const mockProvider = (result: boolean) =>
+      ({
+        provider: null as any,
+        resolveName: async (n: string) => n,
+        call: async () => iface.encodeFunctionResult("verify", [result]),
+      }) as unknown as ethers.Provider;
+
+    it("returns true when the on-chain verifier accepts", async () => {
+      expect(await preflightVerify(mockProvider(true), S3, assembled)).toBe(true);
+    });
+
+    it("returns false when the on-chain verifier rejects (no throw)", async () => {
+      expect(await preflightVerify(mockProvider(false), S3, assembled)).toBe(false);
+    });
+  });
+});

--- a/src/modules/audit/guardian-fraud-proof-assembler.ts
+++ b/src/modules/audit/guardian-fraud-proof-assembler.ts
@@ -1,0 +1,188 @@
+import { ethers } from "ethers";
+import {
+  encodeOverIssueFraudProof,
+  deriveFraudProofId,
+  overIssueEvidenceHash,
+  MAX_VALIDATORS,
+} from "./guardian-fraud-proof.js";
+import type { GuardianSignerRecord } from "./guardian-signer-store.js";
+
+/**
+ * CC-89 stage-2 F2 — the fraud-proof ASSEMBLER (downstream of the watcher, upstream of
+ * `BLSAggregator.executeGuardianSlash`).
+ *
+ * Given a VERIFIED watcher record (the signer set of a disputed slash), the token that was over-
+ * issued, and the accused colluders, it builds the exact `(fraudProofId, guiltyGuardians, fraudProof)`
+ * the on-chain `OverIssueFraudProofVerifier` (PR #223) accepts. It REFUSES to assemble anything the
+ * verifier would reject, so a caller never files a proof that reverts / returns false:
+ *   - only from a self-VERIFIED record (its claimedSigners reproduce SP's A' commitment),
+ *   - `guiltyGuardians` non-empty, canonical (strictly ascending uint160), ⊆ `claimedSigners`
+ *     (the verifier's subset check — without it a valid commitment could slash an innocent address),
+ *   - the disputed token BINDS to the slash: `overIssueEvidenceHash(token, operator, epoch)` MUST
+ *     equal the record's on-chain `evidenceHash` (else this token isn't what the slash cited → the
+ *     verifier's messageHash→commitment recompute won't match → every proof rejected).
+ *
+ * The assembler is PURE. Submitting is a separate, explicitly-armed step (`submitGuardianSlash`);
+ * `preflightVerify` lets a caller confirm the proof passes on-chain BEFORE broadcasting.
+ */
+
+export interface AssembledFraudProof {
+  /** deriveFraudProofId(proposalId) — the verifier binds this to the disputed proposal. */
+  fraudProofId: bigint;
+  /** Accused colluders, strictly ascending uint160, ⊆ claimedSigners. */
+  guiltyGuardians: string[];
+  /** abi-encoded fraudProof bytes the verifier decodes. */
+  fraudProof: string;
+}
+
+/** Sorted-ascending, deduped, non-zero copy of `addrs`; throws on a zero address. */
+function canonicalize(addrs: string[]): string[] {
+  const norm = addrs.map(a => ethers.getAddress(a));
+  for (const a of norm) {
+    if (a === ethers.ZeroAddress)
+      throw new Error("assembler: guiltyGuardians contains the zero address");
+  }
+  const sorted = [...norm].sort((a, b) => {
+    const x = BigInt(a);
+    const y = BigInt(b);
+    return x < y ? -1 : x > y ? 1 : 0;
+  });
+  for (let i = 1; i < sorted.length; i++) {
+    if (BigInt(sorted[i - 1]) >= BigInt(sorted[i])) {
+      throw new Error(`assembler: duplicate guilty guardian ${sorted[i]}`);
+    }
+  }
+  return sorted;
+}
+
+/**
+ * Assert the record's `claimedSigners` are already canonical — MIRRORS the verifier's
+ * `_canonicalSigners` exactly (non-empty, ≤ MAX_VALIDATORS, non-zero, strictly ascending by uint160,
+ * no dup). NOT re-sorted: the encoded array must stay byte-identical to SP's commitment `sorted`, so a
+ * non-canonical record is corrupt → throw rather than "fix" it into a mismatching proof.
+ */
+function assertCanonicalClaimedSigners(claimed: string[]): void {
+  if (claimed.length === 0) throw new Error("assembler: record has no claimedSigners");
+  if (claimed.length > MAX_VALIDATORS) {
+    throw new Error(
+      `assembler: claimedSigners length ${claimed.length} exceeds MAX ${MAX_VALIDATORS}`
+    );
+  }
+  for (let i = 0; i < claimed.length; i++) {
+    if (claimed[i] === ethers.ZeroAddress) {
+      throw new Error("assembler: claimedSigners contains the zero address (corrupt record)");
+    }
+    if (i > 0 && BigInt(claimed[i - 1]) >= BigInt(claimed[i])) {
+      throw new Error(
+        `assembler: claimedSigners not strictly ascending at ${claimed[i]} (corrupt record)`
+      );
+    }
+  }
+}
+
+/**
+ * Build the fraud proof for an over-issue guardian-collusion slash. THROWS if the inputs could not
+ * produce an accepted proof (unverified record, token not bound to the slash, guilty set not a
+ * canonical subset). `disputedToken` is the community xPNTs the operator over-issued; the caller
+ * (detector) supplies it — the record only holds the opaque on-chain evidenceHash.
+ */
+export function assembleOverIssueFraudProof(
+  record: GuardianSignerRecord,
+  disputedToken: string,
+  guiltyGuardians: string[]
+): AssembledFraudProof {
+  // Strict === true: a malformed record with commitmentVerified: "false"/"0" (truthy string) must
+  // NOT slip past the assembler's most important local safety gate.
+  if (record.commitmentVerified !== true) {
+    throw new Error(
+      `assembler: record for proposal ${record.proposalId} is not self-verified — refusing to assemble`
+    );
+  }
+
+  const proposalId = BigInt(record.proposalId);
+  const operator = ethers.getAddress(record.operator);
+  const epoch = BigInt(record.epoch);
+  const token = ethers.getAddress(disputedToken);
+
+  // Token binding: the disputed token MUST reproduce the on-chain evidenceHash, else the verifier's
+  // evidenceHash→messageHash→commitment recompute won't match (this is the token-swap Critical guard,
+  // the assembler's mirror of it — fail early instead of filing a doomed proof).
+  const expectedEvidence = overIssueEvidenceHash(token, operator, epoch);
+  if (expectedEvidence.toLowerCase() !== record.evidenceHash.toLowerCase()) {
+    throw new Error(
+      `assembler: disputedToken ${token} does not bind to proposal ${record.proposalId}'s slash ` +
+        `(evidenceHash ${expectedEvidence} != on-chain ${record.evidenceHash})`
+    );
+  }
+
+  const claimed = record.claimedSigners.map(a => ethers.getAddress(a));
+  // Defense-in-depth: the watcher only stores canonical sets, but never trust a possibly-corrupted
+  // record — re-assert exactly what the on-chain verifier requires before encoding.
+  assertCanonicalClaimedSigners(claimed);
+  const guilty = canonicalize(guiltyGuardians);
+  if (guilty.length === 0) throw new Error("assembler: guiltyGuardians is empty");
+  if (guilty.length > claimed.length) {
+    throw new Error("assembler: more guilty guardians than signers — cannot be a subset");
+  }
+  const claimedSet = new Set(claimed.map(a => a.toLowerCase()));
+  for (const g of guilty) {
+    if (!claimedSet.has(g.toLowerCase())) {
+      throw new Error(
+        `assembler: guilty guardian ${g} is not among the slash's signers (not a subset)`
+      );
+    }
+  }
+
+  const fraudProof = encodeOverIssueFraudProof({
+    proposalId,
+    operator,
+    slashLevel: record.slashLevel,
+    epoch,
+    disputedToken: token,
+    signerMask: BigInt(record.signerMask),
+    claimedSigners: claimed,
+  });
+
+  return { fraudProofId: deriveFraudProofId(proposalId), guiltyGuardians: guilty, fraudProof };
+}
+
+/** Minimal verifier ABI (staticcall preflight) + aggregator submit ABI. */
+const VERIFIER_ABI = [
+  "function verify(uint256 fraudProofId, address[] guiltyGuardians, bytes fraudProof) view returns (bool)",
+];
+const AGGREGATOR_SLASH_ABI = [
+  "function executeGuardianSlash(uint256 fraudProofId, address[] guiltyGuardians, bytes fraudProof)",
+];
+
+/**
+ * Preflight: staticcall the on-chain verifier so a caller confirms the proof WILL be accepted before
+ * broadcasting `executeGuardianSlash`. Returns the verifier's boolean; never throws on a `false`
+ * (the verifier is fail-closed and returns false rather than reverting), only on RPC failure.
+ */
+export async function preflightVerify(
+  provider: ethers.Provider,
+  verifierAddress: string,
+  assembled: AssembledFraudProof
+): Promise<boolean> {
+  const verifier = new ethers.Contract(verifierAddress, VERIFIER_ABI, provider);
+  return verifier.verify(assembled.fraudProofId, assembled.guiltyGuardians, assembled.fraudProof);
+}
+
+/**
+ * Submit `executeGuardianSlash` (ARMED — broadcasts a tx that slashes the guilty guardians' ROLE_DVT
+ * stake). Callers should `preflightVerify` first. Permissionless at the contract (the verifier's
+ * boolean authorizes, not the sender), so any funded signer can file. Returns the tx hash.
+ */
+export async function submitGuardianSlash(
+  signer: ethers.Signer,
+  aggregatorAddress: string,
+  assembled: AssembledFraudProof
+): Promise<string> {
+  const agg = new ethers.Contract(aggregatorAddress, AGGREGATOR_SLASH_ABI, signer);
+  const tx = await agg.executeGuardianSlash(
+    assembled.fraudProofId,
+    assembled.guiltyGuardians,
+    assembled.fraudProof
+  );
+  return tx.hash;
+}


### PR DESCRIPTION
## What & why (CC-89 stage-2, F2)

The bridge from the watcher's captured signer set (F1, #224) to the on-chain `OverIssueFraudProofVerifier` (#223). Given a **verified** watcher record + the over-issued token + the accused colluders, it builds the exact `(fraudProofId, guiltyGuardians, fraudProof)` that `BLSAggregator.executeGuardianSlash` (SP #370) accepts — and **refuses to assemble anything the verifier would reject**, so a caller never files a doomed or harmful proof.

## Safety gates (assembler mirrors the verifier)
- **only self-verified records** — `record.commitmentVerified === true` (strict; a truthy `"false"` string can't slip through).
- **token binding** — `overIssueEvidenceHash(token, operator, epoch) === record.evidenceHash` (the token-swap Critical guard; a wrong token → refuse).
- **claimedSigners canonical** — re-asserts the verifier's `_canonicalSigners` (non-empty, ≤MAX_VALIDATORS=13, non-zero, strictly ascending, no dup); a corrupt record throws rather than producing a mismatching proof.
- **guiltyGuardians** — canonicalized (ascending, non-zero, dedup) and **⊆ claimedSigners** (can't slash an innocent address).
- `preflightVerify` (staticcall) to confirm on-chain acceptance before `submitGuardianSlash` (explicitly-armed broadcast).

## Review
Codex Tier-1 (codex:codex-rescue) **2 rounds**: R1 = 2 Medium (truthiness gate + claimedSigners revalidation) → fixed; R2 = **clean, no new issues**. No Critical/High; no innocent-slash path found.

## Tests / gate
- `jest src/modules/audit` = **144 passed** (14 new assembler tests: happy + all refusal paths + preflight true/false).
- `type-check` + `lint:check` clean; `build` clean.
- **`format:check` now GREEN** — this PR also formats two pre-existing doc-debt files (`docs/AUDIT_SLASH_MODEL.md`, `docs/design/guardian-collusion-slash.md`, untouched since #221/#223) so the Code Quality check passes.

## Acceptance (F2) — docs/design/cc89-stage2-shipping-plan.md §1
- [x] cross-check: assembler output matches the verifier's expected encoding (golden)
- [x] guiltyGuardians ⊆ claimedSigners enforced; throws otherwise
- [x] submit path dry-run-able (preflightVerify staticcall) + not broadcast unless armed
- [x] type-check / lint / format / jest / build clean; Codex no Critical/High
- [ ] pr-daemon/clestons APPROVE + checks green; merged; tests green on master

Refs: Seeder CC-89, issue #222. Builds on #224 (F1 watcher).