### PR TITLE
test(CC-89): DVT-side E2E dry-run + runbook

### DIFF
--- a/docs/design/cc89-e2e-runbook.md
+++ b/docs/design/cc89-e2e-runbook.md
@@ -1,0 +1,118 @@
+# CC-89 Stage-2 — over-issue guardian-slash E2E runbook
+
+> The full over-issue guardian-collusion slash chain, end to end, and the joint
+> testnet acceptance checklist. Scope: **testnet-E2E** (no mainnet activation).
+> Companion to `cc89-stage2-shipping-plan.md` (the shipping plan) and
+> `guardian-collusion-slash.md` (stage-0 threat model + A' spec).
+
+## The chain (who does what)
+
+```
+                         SuperPaymaster (SP)                         DVT (this repo)
+ ┌──────────────────────────────────────────┐   ┌──────────────────────────────────────────┐
+ │ A) craft a FRAUDULENT over-issue slash    │   │                                            │
+ │    verifyAndExecute(pid, op, level, [],[],│   │                                            │
+ │      epoch, evidenceHash, proof)          │   │                                            │
+ │    → _checkSignatures (m guardians)       │   │                                            │
+ │    → stores proposalSignersCommitment[pid]│   │                                            │
+ │      = A' snapshot of the signer ADDRESSES│   │                                            │
+ │    → emits SlashExecuted                  │──▶│ B) WATCHER (F1) observes SlashExecuted     │
+ └──────────────────────────────────────────┘   │    → decode verifyAndExecute calldata       │
+                                                 │    → validatorAtSlot @ EXECUTION block      │
+                                                 │    → recompute A' commitment, SELF-CHECK    │
+                                                 │      == on-chain → durably record            │
+                                                 │      {claimedSigners, …} (VERIFIED)          │
+                                                 │                     │                        │
+                                                 │                     ▼                        │
+                                                 │ C) ASSEMBLER (F2): record + disputedToken +  │
+                                                 │    guiltyGuardians → fraudProof + fraudProofId│
+                                                 │    (refuses unless token binds + guilty ⊆    │
+                                                 │     claimedSigners + record self-verified)   │
+                                                 │                     │ preflightVerify (view) │
+ ┌──────────────────────────────────────────┐   │                     ▼                        │
+ │ D) executeGuardianSlash(fraudProofId,     │◀──│    submitGuardianSlash (armed)              │
+ │      guiltyGuardians, fraudProof)         │   └──────────────────────────────────────────┘
+ │    → OverIssueFraudProofVerifier.verify() │
+ │      (5 checks, #223) == true             │
+ │    → slashByDVT: guilty ROLE_DVT lock → 0 │
+ │    → next verify → _reconstructPkAgg      │
+ │      reverts (< minStake) → AUTO-EJECT    │
+ └──────────────────────────────────────────┘
+```
+
+## Cross-repo evidence convention (MUST match on both sides)
+
+The disputed slash MUST be filed as a **pure over-issue slash** so the DVT
+verifier can reconstruct its message:
+
+- `evidenceHash = keccak256(abi.encode("DVT_OVERISSUE_EVIDENCE_V1", token, operator, epoch))`
+  (`overIssueEvidenceHash` in `guardian-fraud-proof.ts`;
+  `OVERISSUE_EVIDENCE_TAG` in the verifier).
+- **`repUsers` AND `newScores` both empty** — the slash-only branch (8-field
+  messageHash committing `evidenceHash` + chainid). A non-empty rep array
+  changes the messageHash → the verifier rejects.
+- Signer set derivation: `validatorAtSlot[slot]` at the **verifyAndExecute
+  execution block**, uint160 strictly ascending (SP `_computeSignersCommitment`
+  `sorted`; DVT `resolveClaimedSigners`). Byte alignment is pinned by the golden
+  vector in both suites (`OverIssueFraudProofVerifier.t.sol` ⇄
+  `guardian-fraud-proof.spec.ts`).
+
+## DVT-side E2E dry-run (this repo, CI-verified)
+
+`guardian-slash-e2e.spec.ts` stitches the DVT half end to end against a mock
+provider: craft a slash → `buildGuardianSignerRecord` (watcher core)
+self-verifies against the on-chain A' commitment → `assembleOverIssueFraudProof`
+(assembler) builds the fraudProof → assert the fraudProof's embedded data
+**reproduces the same commitment** the verifier will recompute, and that
+`fraudProofId`, `guiltyGuardians ⊆ claimedSigners`, and the decoded fields all
+line up. Negative: a token-swap is refused in the E2E; the non-subset (guilty ⊄
+claimed) refusal is covered in the F2 assembler unit spec
+(`guardian-fraud-proof-assembler.spec.ts`). The byte-level acceptance by the
+Solidity verifier is transitively proven by the golden vector shared with
+`OverIssueFraudProofVerifier.t.sol`.
+
+Run:
+`NODE_OPTIONS=--experimental-vm-modules npx jest src/modules/audit/guardian-slash-e2e.spec.ts`
+
+## Joint testnet run (with SP — the tomorrow step, NOT in the /goal scope)
+
+1. **SP**: deploy the A'-commitment `BLSAggregator` (≥ PR #371) to Sepolia;
+   `setFraudProofVerifier` to the deployed `OverIssueFraudProofVerifier` (#223);
+   register N guardians with ROLE_DVT locks at minStake.
+2. **SP**: craft a fraudulent over-issue slash — call `verifyAndExecute` with
+   the evidence convention above over a token that is **not** actually
+   over-issued (`isOverIssued() == false`), holding that state constant through
+   the run (current-state variant; historical-state is Phase-3).
+3. **DVT**: run a node with `AUDIT_GUARDIAN_WATCH_ENABLED=true` +
+   `AUDIT_BLS_AGGREGATOR_ADDRESS` set; the watcher captures the VERIFIED
+   signer-set record.
+4. **DVT**: `assembleOverIssueFraudProof(record, token, guiltyGuardians)` →
+   `preflightVerify` (expect true) → `submitGuardianSlash`.
+5. **Assert**: guilty guardians' ROLE_DVT lock → 0; a subsequent
+   `verifyAndExecute` whose mask includes a slashed guardian reverts in
+   `_reconstructPkAgg` (auto-eject). Mirrors SP's `GuardianSlashE2E.t.sol` (swap
+   its `MockVerifier` for the real one).
+
+## Acceptance checklist (joint — tracked in issue #222)
+
+DVT side:
+
+- [x] Watcher captures + self-verifies the signer set (F1, #224).
+- [x] Assembler builds a verifier-accepted fraudProof; refuses doomed/harmful
+      inputs (F2, #225).
+- [x] DVT-side E2E dry-run green (`guardian-slash-e2e.spec.ts`).
+- [x] Evidence convention documented (this runbook) + pinned by the shared
+      golden vector.
+
+SP side (tomorrow):
+
+- [ ] A'-commitment BLSAggregator + real verifier wired on Sepolia.
+- [ ] Fraudulent over-issue slash crafted (evidence convention; over-issue state
+      held constant).
+- [ ] `executeGuardianSlash` slashes the guilty guardians → auto-eject verified
+      on-chain.
+
+Deferred (Phase-3, not E2E): historical-state proof (BLOCKHASH + storage proof,
+bounded challenge window); wrapped-call (DVTValidator/relayer/multicall) trace
+resolution in the watcher; production arming of an on-chain-objective slash
+rule; liveness class (gated on CC-29).

--- a/src/modules/audit/guardian-slash-e2e.spec.ts
+++ b/src/modules/audit/guardian-slash-e2e.spec.ts
@@ -1,0 +1,167 @@
+import { ethers } from "ethers";
+import { buildGuardianSignerRecord } from "./guardian-slash-watcher.core.js";
+import { assembleOverIssueFraudProof } from "./guardian-fraud-proof-assembler.js";
+import {
+  VERIFY_AND_EXECUTE_ABI,
+  overIssueEvidenceHash,
+  overIssueSlashMessageHash,
+  computeSignersCommitment,
+  deriveFraudProofId,
+} from "./guardian-fraud-proof.js";
+
+/**
+ * CC-89 stage-2 F3 — DVT-side E2E dry-run. Stitches the whole DVT half end to end:
+ *   craft slash → WATCHER CORE builds + self-verifies the signer record → ASSEMBLER builds the
+ *   fraudProof → assert the fraudProof's embedded data REPRODUCES the same A' commitment the on-chain
+ *   OverIssueFraudProofVerifier recomputes (the load-bearing cross-module invariant).
+ *
+ * Byte-level acceptance by the Solidity verifier is transitively proven by the golden vector shared
+ * with OverIssueFraudProofVerifier.t.sol (#223). See docs/design/cc89-e2e-runbook.md.
+ */
+
+const coder = ethers.AbiCoder.defaultAbiCoder();
+const S1 = ethers.getAddress("0x0000000000000000000000000000000000001111");
+const S2 = ethers.getAddress("0x0000000000000000000000000000000000002222");
+const S3 = ethers.getAddress("0x0000000000000000000000000000000000003333");
+const OPERATOR = ethers.getAddress("0x000000000000000000000000000000000000abcd");
+const AGG = ethers.getAddress("0x0000000000000000000000000000000000000a99");
+const TOKEN = ethers.getAddress("0x000000000000000000000000000000000000beef");
+const CHAIN_ID = 11155111n;
+const PID = 42n;
+const LEVEL = 2;
+const EPOCH = 1000n;
+const MASK = 0x7n;
+const TX_HASH = "0x" + "ab".repeat(32);
+const EXEC_BLOCK = 500;
+
+// The evidenceHash a correct over-issue slash MUST use (cross-repo convention).
+const EVIDENCE = overIssueEvidenceHash(TOKEN, OPERATOR, EPOCH);
+// The commitment SP would store for this slash — a HARDCODED golden literal (NOT computed via the
+// production helper), so the E2E's ground truth is independent of a shared TS-helper drift; a helper
+// or convention change that alters this value fails the pin-check below AND the chain assertions.
+// Params: chainId=11155111, agg=0x…0a99, pid=42, op=…abcd, level=2, epoch=1000, token=…beef,
+// mask=0x7, signers=[S1,S2,S3]. (The TS↔Solidity byte-alignment itself is pinned by the golden
+// vector shared between guardian-fraud-proof.spec.ts and OverIssueFraudProofVerifier.t.sol.)
+const ON_CHAIN_COMMITMENT = "0x9aa1e972757e23b4f909d5d16ea0f2b551c12462dfeaaac2001ebf9a92174752";
+
+const va = new ethers.Interface([
+  "function validatorAtSlot(uint8 slot) view returns (address)",
+  "function proposalSignersCommitment(uint256 proposalId) view returns (bytes32)",
+]);
+
+/** Mock chain: the crafted over-issue slash (calldata, A' commitment, slot→address map). */
+class MockProvider {
+  private readonly validators: Record<number, string> = { 1: S3, 2: S1, 3: S2 }; // scrambled → sorts to S1,S2,S3
+  get provider(): this {
+    return this;
+  }
+  async resolveName(n: string): Promise<string> {
+    return n;
+  }
+  async getTransaction(): Promise<{ data: string }> {
+    const iface = new ethers.Interface([VERIFY_AND_EXECUTE_ABI]);
+    return {
+      data: iface.encodeFunctionData("verifyAndExecute", [
+        PID,
+        OPERATOR,
+        LEVEL,
+        [],
+        [],
+        EPOCH,
+        EVIDENCE,
+        coder.encode(["uint256", "bytes"], [MASK, "0xdead"]),
+      ]),
+    };
+  }
+  async getBlock(): Promise<{ timestamp: number }> {
+    return { timestamp: 1_700_000_000 };
+  }
+  async call(tx: { data: string }): Promise<string> {
+    const sel = tx.data.slice(0, 10);
+    if (sel === va.getFunction("validatorAtSlot")!.selector) {
+      const [slot] = va.decodeFunctionData("validatorAtSlot", tx.data);
+      return va.encodeFunctionResult("validatorAtSlot", [
+        this.validators[Number(slot)] ?? ethers.ZeroAddress,
+      ]);
+    }
+    return va.encodeFunctionResult("proposalSignersCommitment", [ON_CHAIN_COMMITMENT]);
+  }
+}
+
+describe("CC-89 stage-2 DVT-side E2E dry-run (watcher core → assembler)", () => {
+  it("pins the golden commitment — the production helper still reproduces the hardcoded ground truth", () => {
+    // Guards the OTHER direction: if computeSignersCommitment / overIssueSlashMessageHash drift, this
+    // fails here (loudly) rather than silently moving the ground truth with the code under test.
+    expect(
+      computeSignersCommitment(
+        AGG,
+        CHAIN_ID,
+        PID,
+        overIssueSlashMessageHash(CHAIN_ID, PID, OPERATOR, LEVEL, EPOCH, TOKEN),
+        MASK,
+        [S1, S2, S3]
+      )
+    ).toBe(ON_CHAIN_COMMITMENT);
+  });
+
+  it("captures a slash, self-verifies, and assembles a fraudProof that reproduces the on-chain commitment", async () => {
+    const provider = new MockProvider() as unknown as ethers.Provider;
+
+    // B) WATCHER CORE — capture + self-verify.
+    const record = await buildGuardianSignerRecord(
+      provider,
+      AGG,
+      CHAIN_ID,
+      PID,
+      TX_HASH,
+      EXEC_BLOCK
+    );
+    expect(record.commitmentVerified).toBe(true);
+    expect(record.claimedSigners).toEqual([S1, S2, S3]);
+    expect(record.commitment).toBe(ON_CHAIN_COMMITMENT);
+
+    // C) ASSEMBLER — accuse two of the colluding signers.
+    const assembled = assembleOverIssueFraudProof(record, TOKEN, [S1, S3]);
+    expect(assembled.fraudProofId).toBe(deriveFraudProofId(PID));
+    expect(assembled.guiltyGuardians).toEqual([S1, S3]);
+
+    // LOAD-BEARING E2E INVARIANT — decode the assembled fraudProof and independently recompute the
+    // commitment the on-chain verifier will derive from it; it MUST equal the stored A' commitment.
+    const [pid, op, level, epoch, token, mask, claimed] = coder.decode(
+      ["uint256", "address", "uint8", "uint256", "address", "uint256", "address[]"],
+      assembled.fraudProof
+    );
+    const recomputed = computeSignersCommitment(
+      AGG,
+      CHAIN_ID,
+      BigInt(pid),
+      overIssueSlashMessageHash(
+        CHAIN_ID,
+        BigInt(pid),
+        ethers.getAddress(op),
+        Number(level),
+        BigInt(epoch),
+        ethers.getAddress(token)
+      ),
+      BigInt(mask),
+      [...claimed].map((a: string) => ethers.getAddress(a))
+    );
+    expect(recomputed).toBe(ON_CHAIN_COMMITMENT); // ⇒ the verifier's commitment check passes
+    // guilty ⊆ claimedSigners (the verifier's innocent-protection check).
+    for (const g of assembled.guiltyGuardians) expect(record.claimedSigners).toContain(g);
+  });
+
+  it("refuses the chain when the disputed token does not bind (token-swap defense)", async () => {
+    const provider = new MockProvider() as unknown as ethers.Provider;
+    const record = await buildGuardianSignerRecord(
+      provider,
+      AGG,
+      CHAIN_ID,
+      PID,
+      TX_HASH,
+      EXEC_BLOCK
+    );
+    const wrongToken = ethers.getAddress("0x000000000000000000000000000000000000c0de");
+    expect(() => assembleOverIssueFraudProof(record, wrongToken, [S1])).toThrow(/does not bind/);
+  });
+});


### PR DESCRIPTION
## What & why (CC-89 stage-2, F3 — final)

Stitches the DVT half of the over-issue guardian-slash chain end to end, and documents the full chain + the joint-testnet acceptance checklist. TEST + DOCS only (no new production code).

- **`guardian-slash-e2e.spec.ts`** — craft an over-issue slash (mock provider) → `buildGuardianSignerRecord` (F1 watcher core) self-verifies against the on-chain A' commitment → `assembleOverIssueFraudProof` (F2) → decode the assembled `fraudProof` and **independently recompute** the commitment the on-chain `OverIssueFraudProofVerifier` will derive, asserting it equals a **hardcoded golden** commitment (independent ground truth, not the production helper). Plus a golden pin-check (the helper still reproduces the literal → catches TS-helper drift) and a token-swap negative.
- **`docs/design/cc89-e2e-runbook.md`** — the chain (SP ⇄ DVT), the cross-repo evidence convention (`DVT_OVERISSUE_EVIDENCE_V1` + empty rep arrays + execution-block signer derivation), the DVT-side dry-run, the joint-testnet steps (tomorrow, with SP), and the issue #222 acceptance checklist.

## Review
Codex Tier-1 (codex:codex-rescue) 1 round: confirmed the positive-path assertion is a **real invariant, not a tautology** (it fails if the assembler drops/reorders signers, uses the wrong token, or mis-encodes). Findings: Medium (ground truth shared the production helper) → **hardcoded golden literal + pin-check**; Low (doc overclaimed non-subset coverage) → **narrowed**. Both fixes self-proving via the green golden pin-check; not re-run (mechanical test/doc change).

## Tests / gate
- `jest src/modules/audit` = **147 passed** (3 new E2E: golden pin, full chain, token-swap negative).
- `type-check` + `lint:check` + `format:check` clean; `build` clean.

## Acceptance (F3) — docs/design/cc89-stage2-shipping-plan.md §1
- [x] Runbook documents the full chain + evidence convention
- [x] DVT-side E2E dry-run green (watcher core → assembler → commitment reproduction)
- [x] Issue #222 acceptance checklist enumerated (posted on merge)
- [x] Handoff for the tomorrow joint testnet run documented
- [ ] pr-daemon/clestons APPROVE + checks green; merged

Refs: Seeder CC-89, issue #222. Builds on #224 (F1), #225 (F2).