### PR TITLE
chore(CC-89): OverIssueFraudProofVerifier Sepolia deploy script

### DIFF
--- a/contracts/script/DeployOverIssueVerifier.s.sol
+++ b/contracts/script/DeployOverIssueVerifier.s.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.19;
+
+/**
+ * @title DeployOverIssueVerifier
+ * @dev CC-89 stage-2 joint-testnet prerequisite. Deploys the DVT `OverIssueFraudProofVerifier`
+ *      (#223) and binds it to SuperPaymaster's A'-commitment `BLSAggregator` (≥ SP PR #371).
+ *
+ *      Deploy ORDER (chicken-egg — see CC-89 cf63e699):
+ *        1. SP deploys the A' BLSAggregator to Sepolia → publishes its canonical address.
+ *        2. Set CANONICAL_AGGREGATOR below to that address (or pass EXPECTED_AGGREGATOR); THIS
+ *           script deploys the verifier bound to it → hand the verifier address to SP.
+ *        3. SP calls setFraudProofVerifier(verifier).
+ *
+ *      The verifier binds `address(this)==AGGREGATOR` into every commitment recompute and reads
+ *      `proposalSignersCommitment` from it — so a WRONG aggregator does NOT revert, it silently
+ *      breaks all future verification. This script therefore ENFORCES a canonical-address identity
+ *      match (not merely "some contract with code"), and refuses to deploy against an unverified
+ *      address unless the operator explicitly acknowledges it.
+ *
+ *      Env:
+ *        AGGREGATOR                  (REQUIRED) SP's on-chain BLSAggregator address.
+ *        EXPECTED_AGGREGATOR         (optional) overrides the CANONICAL_AGGREGATOR constant for the
+ *                                    identity match (use before the constant is filled in).
+ *        ALLOW_UNVERIFIED_AGGREGATOR (optional) must be "true" to deploy when NO canonical/expected
+ *                                    address is available yet — a conscious "I verified out-of-band".
+ *        EXPECTED_CHAIN_ID           (optional, default 11155111 Sepolia) guards against a wrong RPC.
+ *
+ *      AGGREGATOR=0x... forge script script/DeployOverIssueVerifier.s.sol \
+ *        --rpc-url <RPC> --private-key <KEY> --broadcast
+ */
+
+import "forge-std/Script.sol";
+import "../src/verifiers/OverIssueFraudProofVerifier.sol";
+
+/// @dev Positive-identity probe: getters only a real A' BLSAggregator exposes.
+interface IAggregatorProbe {
+    function proposalSignersCommitment(uint256 proposalId) external view returns (bytes32);
+    function validatorAtSlot(uint8 slot) external view returns (address);
+}
+
+contract DeployOverIssueVerifier is Script {
+    /// @notice The canonical SP A' BLSAggregator on the target testnet. Fill in once SP publishes it
+    ///         (CC-89) → the deploy then HARD-REQUIRES AGGREGATOR == this. address(0) = not yet known.
+    address internal constant CANONICAL_AGGREGATOR = address(0);
+
+    function run() external {
+        // Wrong-RPC guard: default Sepolia, overridable for another testnet/local fork.
+        uint256 expectedChainId = vm.envOr("EXPECTED_CHAIN_ID", uint256(11155111));
+        require(block.chainid == expectedChainId, "wrong chain: set EXPECTED_CHAIN_ID for this RPC");
+
+        // envAddress reverts if AGGREGATOR is unset — fail-closed rather than deploy against 0x0.
+        address aggregator = vm.envAddress("AGGREGATOR");
+        require(aggregator != address(0), "AGGREGATOR must be non-zero");
+        require(aggregator.code.length > 0, "AGGREGATOR has no code (deploy the BLSAggregator first)");
+
+        // MANDATORY canonical-identity match. Precedence: a NON-ZERO EXPECTED_AGGREGATOR env overrides
+        // the CANONICAL constant; a zero/unset env falls THROUGH to the constant (so a zero env can
+        // never clear a real canonical pin). If neither yields a nonzero address, the operator MUST
+        // explicitly acknowledge deploying against an address verified out-of-band — never silent.
+        address expectedEnv = vm.envOr("EXPECTED_AGGREGATOR", address(0));
+        address expected = expectedEnv != address(0) ? expectedEnv : CANONICAL_AGGREGATOR;
+        if (expected != address(0)) {
+            require(aggregator == expected, "AGGREGATOR != canonical/expected aggregator");
+        } else {
+            require(
+                vm.envOr("ALLOW_UNVERIFIED_AGGREGATOR", false),
+                "no canonical aggregator known: set CANONICAL_AGGREGATOR/EXPECTED_AGGREGATOR, or ALLOW_UNVERIFIED_AGGREGATOR=true to accept"
+            );
+        }
+
+        // Positive-identity probe (defense-in-depth): a wrong contract with bytecode passes
+        // code.length>0, but won't expose BOTH aggregator getters — a missing selector reverts here,
+        // before broadcast. Slot 1 (slots are 1-indexed; a real aggregator may range-check slot 0).
+        try IAggregatorProbe(aggregator).proposalSignersCommitment(0) returns (bytes32) {
+            // ok — exposes the A' commitment getter
+        } catch {
+            revert("AGGREGATOR is not an A' BLSAggregator (no proposalSignersCommitment)");
+        }
+        try IAggregatorProbe(aggregator).validatorAtSlot(1) returns (address) {
+            // ok — exposes the slot registry getter
+        } catch {
+            revert("AGGREGATOR is not a BLSAggregator (no validatorAtSlot)");
+        }
+
+        vm.startBroadcast();
+        OverIssueFraudProofVerifier verifier = new OverIssueFraudProofVerifier(aggregator);
+        vm.stopBroadcast();
+
+        console.log("=== CC-89 OverIssueFraudProofVerifier deployed ===");
+        console.log("chainId:   ", block.chainid);
+        console.log("verifier:  ", address(verifier));
+        console.log("aggregator:", aggregator);
+        console.log("Next: SP calls setFraudProofVerifier(", address(verifier), ")");
+    }
+}


### PR DESCRIPTION
## What & why (CC-89 joint-testnet prerequisite)

The over-issue verifier (#223) has the contract + 16 Foundry tests but **no deploy script**. The joint testnet run (CC-89 `cf63e699`) needs it deployed to Sepolia + bound to SP's A' `BLSAggregator` so SP can `setFraudProofVerifier`. This adds that script.

Deploy order (chicken-egg): SP deploys A'-BLSAggregator → publishes address → **this script** deploys `OverIssueFraudProofVerifier(aggregator)` → hand address to SP → SP `setFraudProofVerifier`.

## Fail-closed identity gates
A wrong aggregator does **not** revert — it silently breaks all verification (the verifier binds `address(this)==AGGREGATOR` into every commitment recompute). So the script refuses to deploy against anything but a positively-identified aggregator:
- **chainid guard** — `EXPECTED_CHAIN_ID` (default 11155111 Sepolia).
- **mandatory canonical-identity match** — `CANONICAL_AGGREGATOR` constant (fill in once SP publishes) / `EXPECTED_AGGREGATOR` env override; a zero/unset env falls through to the constant (can't clear the pin); with neither known, deploy **reverts** unless `ALLOW_UNVERIFIED_AGGREGATOR=true` (conscious out-of-band ack).
- **positive-identity probe** — try/catch `proposalSignersCommitment(0)` + `validatorAtSlot(1)` (1-indexed) before broadcast; a bytecode'd non-aggregator reverts here.

## Review
Codex Tier-1 (codex:codex-rescue) **4 rounds** — it caught real issues in a "trivial" script: R1 High (`code.length`-only identity) + Medium (no chainid); R2 residual High (identity optional) + Medium (slot-0 probe); R3 High (zero env clears the canonical pin); R4 **clean**.

## Gate
- `forge build` compiles; `OverIssueFraudProofVerifier` suite **16/16**.
- Solidity-only change; no TS/jest impact.

Refs: Seeder CC-89, issue #222. Deploy prerequisite for the SP joint testnet run.