### PR TITLE
fix(security): ignore ALL node_dev_*.json (drop stale !node_dev_001.json un-ignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,11 @@ data/*
 .agent/
 .env
 
-# Node development config files
+# Node development config files — ALL contain BLS private keys, NEVER commit.
+# (No exception for node_dev_001.json: the old `!node_dev_001.json` un-ignore was a stale
+#  footgun — the file is no longer tracked, so the negation only risked re-committing a fresh
+#  private key. See CLAUDE.md: "all node_*.json files contain private keys and are git-ignored".)
 node_dev_*.json
-!node_dev_001.json
 
 # Node state files (contain the node's BLS private key — NEVER commit).
 # The root node_state.json is git-ignored: each deployment MUST generate its own


### PR DESCRIPTION
## Security hygiene — found during CC-89 joint-run key prep

`.gitignore` had:
```
node_dev_*.json
!node_dev_001.json   ← force-INCLUDES a private-key filename
```
`node_dev_*.json` files each hold a BLS12-381 **private key**. The `!node_dev_001.json` negation force-**un-ignored** slot 1. `node_dev_001.json` is **not tracked** (not in HEAD; removed long ago — `git log` shows an old "Add node_dev_*.json to .gitignore" commit), so the negation served no purpose except a **footgun**: generating a fresh `node_dev_001.json` (e.g. minting guardian keys for a multi-node dev/testnet setup — exactly the CC-89 joint run) leaves a real private key **stage-able by `git add -A`**.

## Fix
Remove the negation → all three dev node files are git-ignored, matching:
- CLAUDE.md: *"all `node_*.json` files contain private keys and are git-ignored — never commit them."*
- the sibling `node_dev_002.json` / `node_dev_003.json` behavior (already ignored).

No tracked file is affected (`node_dev_001.json` is not in HEAD). Verified: after the change, `git check-ignore` reports all of `node_dev_00{1,2,3}.json` as IGNORED.

Refs CC-89 (joint-testnet guardian key prep).