### PR TITLE
feat(CC-89): 3-of-3 guardian BLS co-sign CLI (cc89-cosign.mjs)

### DIFF
--- a/.claude/commands/goal.md
+++ b/.claude/commands/goal.md
@@ -1,0 +1,108 @@
+---
+description:
+  Ship all remaining CC-89 stage-2 DVT features to testnet-E2E — each feature
+  its own Codex-reviewed, bot-approved, merged PR, then run E2E, then hand off
+  to the SP joint run.
+argument-hint:
+  "[optional: F1|F2|F3 to run just one feature, else all remaining]"
+---
+
+# /goal — CC-89 stage-2 DVT shipping pipeline
+
+You are the DVT (`YetAnotherAA-Validator`) repo agent. Execute the shipping plan
+in `docs/design/cc89-stage2-shipping-plan.md` end-to-end. Respond in **中文**.
+Be strict and adversarial in review (money-adjacent slash code).
+
+## Prime directives (never violate)
+
+1. **Review before every PR.** Codex Tier-1 (`codex:codex-rescue`) on the diff;
+   fix all Critical/High; loop until clean or a finding is explicitly deferred
+   with rationale. This is the "所有都要扣 review" rule — no PR opens without
+   it.
+2. **Wait for the background bot.** After opening a PR, add `clestons` as
+   reviewer to trigger the pr-daemon bot; do NOT merge until it APPROVES **and**
+   required checks are green.
+3. **Never bypass branch protection** (no enforce_admins toggle, no self-merge
+   to skip review).
+4. **Never force-push / amend a pushed commit.** Fix findings with NEW commits.
+5. **One feature = one PR.** Do not batch F1/F2/F3 into one PR.
+6. **Resumable.** Re-running `/goal` must detect already-merged features (via
+   `git log` on master
+   - PR state) and skip them — safe to run across context windows.
+
+## Steps
+
+### 0. Orient
+
+- `git fetch origin && git checkout master && git pull --ff-only`.
+- Read `docs/design/cc89-stage2-shipping-plan.md`. Determine which of F1/F2/F3
+  are still outstanding: a feature is DONE if its PR is merged to master (grep
+  `git log --oneline` for its marker / check `gh pr list --state merged`). If
+  `$ARGUMENTS` names a single feature, do only that.
+- Print the plan: which features remain, in order F1 → F2 → F3.
+
+### 1. For each remaining feature, run the loop in `§2` of the plan doc
+
+Concretely, per feature F:
+
+1. **Sync + branch.** `git checkout master && git pull`. If F's branch already
+   exists with built changes (F1 = `feat/cc89-guardian-watcher`, already built &
+   UNCOMMITTED), check it out. Else create `feat/cc89-<slug>` off master and
+   implement F per its spec in the plan doc.
+2. **Gate (all must pass before review):**
+   ```
+   npm run type-check && npm run lint:check && npm run format:check \
+     && NODE_OPTIONS=--experimental-vm-modules npx jest <F's specs> && npm run build
+   ```
+   If F touches `contracts/`: also `cd contracts && forge test`. Fix reds; never
+   proceed on red.
+3. **Codex review loop** (prime directive 1). Send the full diff; ask for
+   correctness / races / fail-closed / fund-safety. Fix → re-review → repeat.
+   Tell the user how many rounds + the final Codex verdict.
+4. **Commit** with the security-fix message convention:
+   `feat(CC-89): <F summary> (Codex Tier-1 reviewed)`.
+5. **PR:** `git push -u origin <branch>` then
+   `gh pr create --base master --reviewer clestons --title "…" --body "…"`. Body
+   must link CC-89 + issue #222 and paste F's acceptance checklist from the plan
+   doc.
+6. **Wait for the bot.** Arm a Monitor / `/loop 5m` on
+   `gh pr view <n> --json reviewDecision,statusCheckRollup,reviews`:
+   - `REQUEST_CHANGES` → fix (goutou PR-review branch or Codex), push a NEW
+     commit, re-request review, keep looping.
+   - `APPROVED` + required checks green → merge. (Pre-existing non-required reds
+     — Security Audit / Code Quality / forge-coverage viaIR — are the repo's
+     UNSTABLE baseline, NOT this PR's regression: verify they predate the diff,
+     document, and do not block.)
+7. **Merge:** `gh pr merge <n> --squash --delete-branch`.
+8. **Verify on master:** `git checkout master && git pull`; re-run F's suite →
+   must be green.
+9. **Report:** via `/goutou` post `[repo:dvt] F<n> 交付 ✅ (PR #<n> merged)` to
+   CC-89; tick F's boxes in the plan doc; update the
+   `guardian-collusion-slash-gap` memory.
+
+### 2. After ALL features merged — E2E phase (plan §3)
+
+- Run the F3 driver dry-run (`scripts/cc89-e2e.mjs`) — DVT half end-to-end;
+  assert the watcher's recompute == on-chain commitment and the verifier returns
+  `true` for the crafted over-issue fraud and `false` for token-swap /
+  non-subset / still-over-issued.
+- Confirm issue #222 acceptance checklist (DVT items) all ticked.
+
+### 3. Handoff (plan §4) — do NOT do the joint run now
+
+- Post CC-89: "DVT stage-2 dev complete + E2E dry-run green; ready for joint
+  testnet" with the SP action (deploy A'-BLSAggregator to Sepolia + swap real
+  verifier into `GuardianSlashE2E`) and the DVT action (run watcher + assembler
+  against it). The joint run is **tomorrow**, out of this scope.
+
+### 4. Final report to the user
+
+Summarize: features shipped (with PR #s + Codex rounds + bot verdict), suites
+green, E2E dry-run result, issue #222 / CC-89 / memory updates, and the
+tomorrow-joint-run handoff. Flag anything deferred.
+
+## Acceptance / 验收 (Definition of Done)
+
+See plan §5. In short: F1+F2+F3 each Codex-clean + bot-approved + merged +
+suite-green on master; DVT E2E dry-run green; issue #222 + CC-89 + memory
+updated; SP joint-run handoff posted.

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ audit-proofs/
 
 # Drill proof-archive backups (Stage-3 dry-run artifacts) — never commit
 deploy/.drill-archive-backup/
+
+# Foundry broadcast logs (auto-generated per deploy; addresses recorded in docs)
+contracts/broadcast/

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ contracts/cache/
 
 # Generated x402 conformance fixtures (byte-exact generator output; see scripts/x402/)
 conformance/x402/fixtures.json
+contracts/broadcast/

--- a/contracts/src/mocks/MockOverIssuableToken.sol
+++ b/contracts/src/mocks/MockOverIssuableToken.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.19;
+
+/**
+ * @title MockOverIssuableToken
+ * @notice CC-89 joint-testnet E2E fixture. Exposes the CC-28 `isOverIssued()` shape so the
+ *         over-issue guardian-slash chain can cite it as the disputed token. Defaults to
+ *         `false` (NOT over-issued) → a slash accusing it of over-issue is FRAUDULENT, which is
+ *         exactly what `OverIssueFraudProofVerifier` proves (step 5) to justify slashing the
+ *         colluding guardians. `setOverIssued` lets the operator flip it to also exercise the
+ *         negative path (verifier must REJECT when the token really is over-issued).
+ */
+contract MockOverIssuableToken {
+    bool public over;
+    address public immutable owner;
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    function isOverIssued() external view returns (bool) {
+        return over;
+    }
+
+    function setOverIssued(bool v) external {
+        require(msg.sender == owner, "only owner");
+        over = v;
+    }
+}

--- a/docs/design/cc89-e2e-record.md
+++ b/docs/design/cc89-e2e-record.md
@@ -1,0 +1,122 @@
+# CC-89 — over-issue guardian-collusion slash: testnet E2E record (for RepCredit paper)
+
+> Authoritative record of the CC-89 stage-2 mechanism and its **end-to-end
+> Sepolia run**, for the RepCredit paper (IET Blockchain). Everything below is
+> on-chain-verifiable. Companion: `guardian-collusion-slash.md` (threat model +
+> A' spec), `cc89-e2e-runbook.md` (chain + convention),
+> `cc89-stage2-shipping-plan.md` (delivery). Coordination thread: Seeder CC-89.
+
+## 1. The gap the paper identified (confirmed)
+
+BLSAggregator's `verifyAndExecute` verifies `m` guardian signatures and binds an
+`evidenceHash`, but **never re-checks the evidence content**. So `≥ m` colluding
+DVT guardians can pass a _valid_ slash of an innocent operator at zero cost. The
+paper's anti-collusion deterrent `k·C_max < m·ρ·S_op·p_G` has **no on-chain
+counterpart for `ρ·S_op`**: the executed slash burns the operator's `aPNTs`, not
+the colluding guardians' `ROLE_DVT` GToken stake (asset distinction, not party —
+addresses may overlap). Two corrections the paper must carry: **(a)** for the
+slash path `m = slashThresholds[level]` (bootstrap WARNING/MINOR/MAJOR = 2/3/3),
+**not** `defaultThreshold=7`; **(b)** the gap is "different **asset**" (aPNTs ≠
+ROLE_DVT lock), not "different party".
+
+## 2. The mechanism (built + deployed)
+
+Two halves ship together (SP = SuperPaymaster, DVT = this repo):
+
+- **SP `executeGuardianSlash`** (BLSAggregator, permissionless +
+  verifier-gated): a fraud proof's _validity_ (not the caller) authorizes
+  slashing the guilty guardians' ROLE_DVT lock **in full → 0 < minStake →
+  `_reconstructPkAgg` auto-ejects** them from the signer set. Breaks the
+  "colluding quorum won't slash itself" circular dependency.
+- **SP A' commitment** (`proposalSignersCommitment[proposalId]`):
+  `verifyAndExecute` stores a `bytes32` fingerprint of the fraud-time signer
+  ADDRESS set (irreversible), so a later fraud proof can attribute the slash to
+  real addresses.
+- **DVT `OverIssueFraudProofVerifier`** (`IFraudProofVerifier.verify` view,
+  fail-closed): 5 checks — fraudProofId content-binding; canonical
+  claimedSigners; reconstruct `evidenceHash → messageHash → commitment` (binds
+  the disputed token, blocking a token-swap forgery);
+  `guiltyGuardians ⊆ claimedSigners` (never slash an innocent address);
+  `isOverIssued(token) == false` (the slash was a lie).
+- **DVT watcher + assembler** (off-chain data-availability): capture
+  `claimedSigners` at the execution block (`validatorAtSlot`, uint160-sorted,
+  byte-identical to SP's commitment) → build the `fraudProof`.
+  Multi-node-redundant (commitment is irreversible → a set no node records is
+  permanently un-attributable).
+
+Cross-repo evidence convention (frozen):
+`evidenceHash = keccak256(abi.encode( "DVT_OVERISSUE_EVIDENCE_V1", disputedToken, operator, epoch))`,
+pure slash (`repUsers` & `newScores` empty). The verifier couples `operator`
+between the messageHash field and the evidence op — for a no-real-victim demo,
+`operator = op = address(0)`.
+
+## 3. The end-to-end Sepolia run — PASSED ✅
+
+**On-chain material (Sepolia, chainId 11155111):**
+
+| Contract                                           | Address                                      |
+| -------------------------------------------------- | -------------------------------------------- |
+| BLSAggregator 4.3.0 (A' commitment), owner = jason | `0xf44E7E51EFFa867114BE48fA92411fE216b1A285` |
+| OverIssueFraudProofVerifier (bound to aggregator)  | `0xd7111fcC31B52dC451f2B7400Cd75B434E2b1abd` |
+| GTokenStaking                                      | `0x472297B557c1d0F030f281a5Bb8A535f6c5AB65e` |
+| MockOverIssuableToken (`isOverIssued()==false`)    | `0x8dE1b6585Bdf5a3e6F13B3125B2d40CC34fc005b` |
+
+3 guardians registered at slots 1/2/3, each with **30e18 ROLE_DVT** locked
+(`ROLE_DVT = keccak256("DVT")`): `0xb5600060…` (slot1), `0x6F7D30f2…F96E`
+(slot2), `0x09a0ca08…5c93` (slot3).
+
+**The chain, step by step (each independently on-chain-verified):**
+
+1. **Craft the fraudulent slash.** DVT's 3 guardian keys co-sign SP's slash
+   `expectedMessageHash` (`cc89-cosign.mjs`, 3-of-3 BLS aggregate,
+   `signerMask=0x7`). Pre-verified on-chain:
+   `aggregator.verify(messageHash, 0x7, 3, sigG2) == true`. Bundle:
+   `proposalId=8900001`, `operator=op=0`, `slashLevel=1` (MINOR, threshold 3),
+   `epoch=1`, `evidenceHash=0x4538e11c…da6407`, `messageHash=0x8285eeb4…af8c`.
+2. **SP submits**
+   `verifyAndExecute(8900001, 0, 1, [], [], 1, evidenceHash, proof)` →
+   `proposalSignersCommitment(8900001) = 0x8904b1b9…4f34` (A' snapshot stored).
+3. **DVT watcher** resolves `claimedSigners` at the execution block =
+   `[0x09a0ca08…, 0x6F7D30f2…, 0xb5600060…]` (uint160-ascending, reproduces the
+   commitment).
+4. **DVT assembler** builds the `fraudProof`; on-chain preflight
+   `verifier.verify(fraudProofId, guilty, fraudProof) == true`.
+5. **executeGuardianSlash** (tx
+   **`0xb870688e6c156e4e7f97cbad390e72e5900fc3384da0809d042fa023307991ba`**,
+   status 1, gas 331215): guilty = all 3 guardians.
+6. **Result:** the 3 guardians' ROLE_DVT lock **30e18 → 0**; a fresh
+   `verify(mask=0x7)` now **reverts** (`SlotValidatorStakeBelowMinimum`) —
+   **auto-eject confirmed**.
+
+**Closed loop demonstrated:** accuse a not-over-issued token → 3 guardians
+collude to pass the slash → fraud proof catches it → their stake is slashed in
+full → they are ejected from the signer set.
+
+## 4. Conclusions for the paper
+
+- **`ρ`'s detection half is now "implemented + testnet-E2E-verified"**, no
+  longer a bare modeling parameter — cite this Sepolia run for the
+  **on-chain-objective, over-issue class**.
+- **Coverage is bounded** (state honestly): `ρ` is a system property only for
+  on-chain-objective violations. **Liveness** class is gated on CC-29
+  (LivenessRegistry — no on-chain liveness signal yet); **purely off-chain
+  evidence** stays a governance assumption.
+- **Historical-state caveat:** the E2E used the _current-state_ `isOverIssued()`
+  variant (state held constant slash→proof). Trustless historical-state
+  (BLOCKHASH + EIP-1186 storage proof over the epoch block, ~256-block challenge
+  window) is Phase-3 production hardening — so `ρ` for over-issue is a system
+  property **only within a bounded challenge window**, not indefinitely.
+- Keep corrections from §1: `m = slashThresholds[level]`; gap = "different
+  asset".
+
+## 5. Reproducibility
+
+Tooling (this repo): `scripts/cc89-cosign.mjs` (3-key aggregate + on-chain
+self-verify), `scripts/cc89-e2e-finish.mjs` (resident auto-finisher: watch
+commitment → fraudProof → executeGuardianSlash → verify locks→0 + auto-eject),
+`contracts/script/DeployOverIssueVerifier.s.sol` (verifier deploy with identity
+guards), `contracts/src/mocks/MockOverIssuableToken.sol`. Verifier +
+watcher-core + assembler unit/Foundry tests are in the merged PRs
+(#221/#223/#224/#225/#226/#227/#229) with a TS↔Solidity golden vector pinning
+byte-alignment. Re-running requires re-staking the 3 guardians (their ROLE_DVT
+lock is now 0 from this run).

--- a/scripts/cc89-cosign.mjs
+++ b/scripts/cc89-cosign.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// CC-89 joint-testnet co-sign CLI — produce the 3-of-3 BLS aggregate `proof` SuperPaymaster's
+// BLSAggregator.verifyAndExecute needs for a (disputed, over-issue) slash proposal.
+//
+// This is a thin ENTRYPOINT over the SAME primitives the DVT signer service uses in production
+// (src/modules/bls + src/modules/audit/gossip-quorum-cosigner): @noble longSignatures over the
+// SP-matching DST, EIP-2537 G2 encoding, proof = abi.encode(uint256 signerMask, bytes sigG2).
+// It just signs with the 3 LOCAL guardian keys (node_dev_00{1,2,3}.json) instead of over gossip —
+// which is correct for the testnet E2E where all 3 keys are on this machine (CLAUDE.md dev nodes).
+//
+// The messageHash is SP's slash-only expectedMessageHash:
+//   keccak256(abi.encode(proposalId, operator, slashLevel, [], [], epoch, chainId, evidenceHash))
+// and each key signs hashToCurve(messageHash, DST) — byte-identical to BLSAggregator._checkSignatures.
+//
+// Usage (real run — fields from SP):
+//   PROPOSAL_ID=42 OPERATOR=0x.. SLASH_LEVEL=1 EPOCH=100 \
+//     TOKEN=0x..            (over-issue evidenceHash = keccak(TAG,token,operator,epoch))  \
+//     AGGREGATOR=0xf44E7E51..  SEPOLIA_RPC_URL=..  node scripts/cc89-cosign.mjs
+//   (or pass EVIDENCE_HASH=0x.. directly instead of TOKEN)
+// Self-test (no SP fields — proves the 3-key aggregate passes on-chain verify):
+//   AGGREGATOR=0xf44E7E51..  SEPOLIA_RPC_URL=..  node scripts/cc89-cosign.mjs --selftest
+//
+// Output: the `proof` bytes to hand SP, after a staticcall to aggregator.verify(...) returns true.
+import { bls12_381 as bls } from "@noble/curves/bls12-381.js";
+import { ethers } from "ethers";
+import { readFileSync, existsSync } from "fs";
+
+const sigs = bls.longSignatures;
+// MUST equal SP BLSAggregator BLS.sol hashToG2 DST + src/utils/bls.util.ts BLS_DST.
+const BLS_DST = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
+const OVERISSUE_EVIDENCE_TAG = "DVT_OVERISSUE_EVIDENCE_V1"; // cross-repo, must match verifier
+const coder = ethers.AbiCoder.defaultAbiCoder();
+const die = m => {
+  console.error("✗ " + m);
+  process.exit(1);
+};
+
+// EIP-2537 G2 (256B) — identical layout to src/utils/bls.util.ts encodeG2Point.
+const _fp = x => {
+  const b = new Uint8Array(48);
+  const s = x.toString(16).padStart(96, "0");
+  for (let i = 0; i < 48; i++) b[i] = parseInt(s.substr(i * 2, 2), 16);
+  return b;
+};
+const eip2537G2 = point => {
+  const a = point.toAffine();
+  const r = new Uint8Array(256);
+  r.set(_fp(a.x.c0), 16);
+  r.set(_fp(a.x.c1), 80);
+  r.set(_fp(a.y.c0), 144);
+  r.set(_fp(a.y.c1), 208);
+  return "0x" + Buffer.from(r).toString("hex");
+};
+
+function loadKey(slot) {
+  const f = `node_dev_00${slot}.json`;
+  if (!existsSync(f)) die(`${f} not found — generate the 3 guardian keys first`);
+  const s = JSON.parse(readFileSync(f, "utf8"));
+  if (!s.privateKey) die(`${f} has no privateKey`);
+  return Buffer.from(s.privateKey.replace(/^0x/, ""), "hex");
+}
+
+const selftest = process.argv.includes("--selftest");
+const chainId = BigInt(process.env.CHAIN_ID || "11155111");
+const aggregator = process.env.AGGREGATOR || die("AGGREGATOR required");
+const rpc = process.env.SEPOLIA_RPC_URL || process.env.ETH_RPC_URL || die("SEPOLIA_RPC_URL required");
+
+// ---- 1. messageHash ---------------------------------------------------------
+let messageHash;
+if (selftest) {
+  messageHash = ethers.keccak256(ethers.toUtf8Bytes("cc89-cosign-selftest"));
+  console.log("SELF-TEST mode: signing a dummy messageHash to prove the 3-key aggregate verifies.");
+} else {
+  const proposalId = BigInt(process.env.PROPOSAL_ID || die("PROPOSAL_ID required"));
+  const operator = ethers.getAddress(process.env.OPERATOR || die("OPERATOR required"));
+  const slashLevel = parseInt(process.env.SLASH_LEVEL || die("SLASH_LEVEL required"), 10);
+  const epoch = BigInt(process.env.EPOCH || die("EPOCH required"));
+  let evidenceHash = process.env.EVIDENCE_HASH;
+  if (!evidenceHash) {
+    const token = ethers.getAddress(process.env.TOKEN || die("TOKEN or EVIDENCE_HASH required"));
+    evidenceHash = ethers.keccak256(
+      coder.encode(
+        ["string", "address", "address", "uint256"],
+        [OVERISSUE_EVIDENCE_TAG, token, operator, epoch]
+      )
+    );
+    console.log(`over-issue evidenceHash(${token}, ${operator}, ${epoch}) = ${evidenceHash}`);
+  }
+  // SP slash-only expectedMessageHash (repUsers/newScores empty).
+  messageHash = ethers.keccak256(
+    coder.encode(
+      ["uint256", "address", "uint8", "address[]", "uint256[]", "uint256", "uint256", "bytes32"],
+      [proposalId, operator, slashLevel, [], [], epoch, chainId, evidenceHash]
+    )
+  );
+}
+console.log("messageHash:", messageHash);
+
+// ---- 2. sign with the 3 local guardian keys + aggregate ---------------------
+const msgG2 = bls.G2.hashToCurve(ethers.getBytes(messageHash), { DST: BLS_DST });
+const perSig = [1, 2, 3].map(slot => sigs.sign(msgG2, loadKey(slot)));
+const aggregate = sigs.aggregateSignatures(perSig);
+const sigG2 = eip2537G2(aggregate);
+const signerMask = 0x7n; // slots 1,2,3
+const proof = coder.encode(["uint256", "bytes"], [signerMask, sigG2]);
+
+// ---- 3. on-chain self-verify (definitive: passes ⇒ verifyAndExecute will accept) -----
+const provider = new ethers.JsonRpcProvider(rpc);
+const agg = new ethers.Contract(
+  aggregator,
+  ["function verify(bytes32,uint256,uint256,bytes) view returns (bool)"],
+  provider
+);
+const ok = await agg.verify(messageHash, signerMask, 3n, sigG2);
+console.log("\n=== aggregator.verify(messageHash, mask=0x7, threshold=3, sigG2) =", ok, "===");
+if (!ok) die("on-chain verify returned FALSE — aggregate/encoding/keys mismatch, DO NOT submit");
+
+console.log("\n✓ 3-of-3 aggregate VALID on-chain. Hand SP this proof for verifyAndExecute:");
+console.log("signerMask:", "0x" + signerMask.toString(16));
+console.log("sigG2 (EIP-2537 256B):", sigG2);
+console.log("proof (abi.encode(uint256,bytes)):", proof);

--- a/scripts/cc89-cosign.mjs
+++ b/scripts/cc89-cosign.mjs
@@ -63,7 +63,8 @@ function loadKey(slot) {
 const selftest = process.argv.includes("--selftest");
 const chainId = BigInt(process.env.CHAIN_ID || "11155111");
 const aggregator = process.env.AGGREGATOR || die("AGGREGATOR required");
-const rpc = process.env.SEPOLIA_RPC_URL || process.env.ETH_RPC_URL || die("SEPOLIA_RPC_URL required");
+const rpc =
+  process.env.SEPOLIA_RPC_URL || process.env.ETH_RPC_URL || die("SEPOLIA_RPC_URL required");
 
 // ---- 1. messageHash ---------------------------------------------------------
 let messageHash;

--- a/scripts/cc89-e2e-finish.mjs
+++ b/scripts/cc89-e2e-finish.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// CC-89 joint-testnet RESIDENT auto-finisher (DVT half).
+// Arms once, waits for SP to submit verifyAndExecute (proposalSignersCommitment[pid] != 0), then
+// auto-runs the entire DVT finish and verifies the outcome — no per-step human/polling handshake:
+//   1. resolveClaimedSigners = sorted validatorAtSlot(slots in mask)  (watcher-core derivation)
+//   2. assemble fraudProof + fraudProofId  (assembler logic)
+//   3. preflight: verifier.verify(...) must be true
+//   4. broadcast BLSAggregator.executeGuardianSlash(fraudProofId, guilty, fraudProof)  [jason key]
+//   5. verify: each guilty guardian's ROLE_DVT lock -> 0, and a fresh verify(mask) now REVERTS
+//      (auto-eject: _reconstructPkAgg rejects the slashed slot below minStake)
+//
+//   AGGREGATOR=.. VERIFIER=.. STAKING=.. TOKEN=.. PROPOSAL_ID=.. SEPOLIA_RPC_URL=.. \
+//     node scripts/cc89-e2e-finish.mjs
+import { ethers } from "ethers";
+import { readFileSync } from "fs";
+
+const RPC = process.env.SEPOLIA_RPC_URL;
+const AGG = process.env.AGGREGATOR;
+const VERIFIER = process.env.VERIFIER;
+const STAKING = process.env.STAKING;
+const TOKEN = process.env.TOKEN;
+const PID = BigInt(process.env.PROPOSAL_ID);
+const OPERATOR = ethers.ZeroAddress; // operator = op = 0 (verifier couples both)
+const SLASH_LEVEL = 1;
+const EPOCH = 1n;
+const MASK = 0x7n;
+const ROLE_DVT = ethers.keccak256(ethers.toUtf8Bytes("DVT"));
+const FRAUD_ID_TAG = "GUARDIAN_FRAUD_V1";
+const coder = ethers.AbiCoder.defaultAbiCoder();
+const provider = new ethers.JsonRpcProvider(RPC);
+const die = m => {
+  console.error("✗ " + m);
+  process.exit(1);
+};
+
+const PK = (() => {
+  for (const line of readFileSync(".env.sepolia", "utf8").split("\n")) {
+    const m = line.match(/^PRIVATE_KEY_JASON=(.*)$/);
+    if (m) return m[1].replace(/#.*/, "").trim().replace(/^["']|["']$/g, "");
+  }
+  die("PRIVATE_KEY_JASON not in .env.sepolia");
+})();
+const wallet = new ethers.Wallet(PK, provider);
+
+const agg = new ethers.Contract(
+  AGG,
+  [
+    "function proposalSignersCommitment(uint256) view returns (bytes32)",
+    "function validatorAtSlot(uint8) view returns (address)",
+    "function verify(bytes32,uint256,uint256,bytes) view returns (bool)",
+    "function executeGuardianSlash(uint256,address[],bytes)",
+  ],
+  wallet
+);
+const verifier = new ethers.Contract(
+  VERIFIER,
+  ["function verify(uint256,address[],bytes) view returns (bool)"],
+  provider
+);
+const staking = new ethers.Contract(
+  STAKING,
+  ["function roleLocks(address,bytes32) view returns (uint128,uint128,uint48,bytes32,bytes)"],
+  provider
+);
+
+const lockOf = async g => (await staking.roleLocks(g, ROLE_DVT))[0];
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+console.log(`CC-89 resident finisher armed — waiting for SP verifyAndExecute on proposal ${PID}...`);
+
+// ---- 1. wait for SP's verifyAndExecute (commitment set) ---------------------
+let commitment = ethers.ZeroHash;
+const deadline = Date.now() + 60 * 60 * 1000; // 1h
+while (Date.now() < deadline) {
+  commitment = await agg.proposalSignersCommitment(PID);
+  if (commitment !== ethers.ZeroHash) break;
+  await sleep(20000);
+}
+if (commitment === ethers.ZeroHash) die("timed out waiting for verifyAndExecute (commitment still 0)");
+console.log(`\n✓ SP submitted — proposalSignersCommitment(${PID}) = ${commitment}`);
+
+// ---- 2. resolveClaimedSigners = sorted validatorAtSlot over the mask --------
+const slots = [];
+for (let s = 1n; s <= 13n; s++) if ((MASK >> (s - 1n)) & 1n) slots.push(Number(s));
+const raw = [];
+for (const s of slots) raw.push(ethers.getAddress(await agg.validatorAtSlot(s)));
+const claimedSigners = [...raw].sort((a, b) => (BigInt(a) < BigInt(b) ? -1 : BigInt(a) > BigInt(b) ? 1 : 0));
+console.log("claimedSigners (sorted):", claimedSigners);
+
+// ---- 3. assemble fraudProof + fraudProofId ---------------------------------
+const fraudProof = coder.encode(
+  ["uint256", "address", "uint8", "uint256", "address", "uint256", "address[]"],
+  [PID, OPERATOR, SLASH_LEVEL, EPOCH, TOKEN, MASK, claimedSigners]
+);
+const fraudProofId = BigInt(
+  ethers.keccak256(coder.encode(["string", "uint256"], [FRAUD_ID_TAG, PID]))
+);
+const guilty = claimedSigners; // E2E: slash all 3 colluders (ascending, ⊆ claimedSigners)
+
+// ---- 4. preflight ----------------------------------------------------------
+const ok = await verifier.verify(fraudProofId, guilty, fraudProof);
+console.log(`\nverifier.verify(fraudProofId, guilty, fraudProof) = ${ok}`);
+if (!ok) die("verifier rejected the fraudProof — NOT submitting executeGuardianSlash");
+
+// ---- 5. locks BEFORE -------------------------------------------------------
+const before = {};
+for (const g of guilty) before[g] = await lockOf(g);
+console.log("ROLE_DVT locks BEFORE:", Object.fromEntries(guilty.map(g => [g, before[g].toString()])));
+
+// ---- 6. broadcast executeGuardianSlash -------------------------------------
+console.log("\nbroadcasting executeGuardianSlash...");
+const tx = await agg.executeGuardianSlash(fraudProofId, guilty, fraudProof);
+const rcpt = await tx.wait();
+console.log(`✓ executeGuardianSlash mined: ${rcpt.hash} (status ${rcpt.status}, gas ${rcpt.gasUsed})`);
+
+// ---- 7. locks AFTER (expect 0) ---------------------------------------------
+const after = {};
+for (const g of guilty) after[g] = await lockOf(g);
+console.log("ROLE_DVT locks AFTER: ", Object.fromEntries(guilty.map(g => [g, after[g].toString()])));
+const allZero = guilty.every(g => after[g] === 0n);
+
+// ---- 8. auto-eject: a fresh verify(mask) must now REVERT --------------------
+let autoEject = false;
+try {
+  await agg.verify(ethers.keccak256(ethers.toUtf8Bytes("auto-eject-probe")), MASK, 3n, "0x" + "00".repeat(256));
+  autoEject = false; // did NOT revert
+} catch {
+  autoEject = true; // reverted (SlotValidatorStakeBelowMinimum) → slashed slots ejected
+}
+
+console.log("\n=== CC-89 over-issue guardian-slash E2E RESULT ===");
+console.log("executeGuardianSlash tx:", rcpt.hash);
+console.log("all 3 guardian ROLE_DVT locks -> 0:", allZero);
+console.log("auto-eject (verify(mask) now reverts):", autoEject);
+console.log(allZero && autoEject ? "✅ E2E PASSED" : "⚠️ E2E INCOMPLETE — review above");

--- a/scripts/cc89-e2e-finish.mjs
+++ b/scripts/cc89-e2e-finish.mjs
@@ -36,7 +36,11 @@ const die = m => {
 const PK = (() => {
   for (const line of readFileSync(".env.sepolia", "utf8").split("\n")) {
     const m = line.match(/^PRIVATE_KEY_JASON=(.*)$/);
-    if (m) return m[1].replace(/#.*/, "").trim().replace(/^["']|["']$/g, "");
+    if (m)
+      return m[1]
+        .replace(/#.*/, "")
+        .trim()
+        .replace(/^["']|["']$/g, "");
   }
   die("PRIVATE_KEY_JASON not in .env.sepolia");
 })();
@@ -66,7 +70,9 @@ const staking = new ethers.Contract(
 const lockOf = async g => (await staking.roleLocks(g, ROLE_DVT))[0];
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 
-console.log(`CC-89 resident finisher armed — waiting for SP verifyAndExecute on proposal ${PID}...`);
+console.log(
+  `CC-89 resident finisher armed — waiting for SP verifyAndExecute on proposal ${PID}...`
+);
 
 // ---- 1. wait for SP's verifyAndExecute (commitment set) ---------------------
 let commitment = ethers.ZeroHash;
@@ -76,7 +82,8 @@ while (Date.now() < deadline) {
   if (commitment !== ethers.ZeroHash) break;
   await sleep(20000);
 }
-if (commitment === ethers.ZeroHash) die("timed out waiting for verifyAndExecute (commitment still 0)");
+if (commitment === ethers.ZeroHash)
+  die("timed out waiting for verifyAndExecute (commitment still 0)");
 console.log(`\n✓ SP submitted — proposalSignersCommitment(${PID}) = ${commitment}`);
 
 // ---- 2. resolveClaimedSigners = sorted validatorAtSlot over the mask --------
@@ -84,7 +91,9 @@ const slots = [];
 for (let s = 1n; s <= 13n; s++) if ((MASK >> (s - 1n)) & 1n) slots.push(Number(s));
 const raw = [];
 for (const s of slots) raw.push(ethers.getAddress(await agg.validatorAtSlot(s)));
-const claimedSigners = [...raw].sort((a, b) => (BigInt(a) < BigInt(b) ? -1 : BigInt(a) > BigInt(b) ? 1 : 0));
+const claimedSigners = [...raw].sort((a, b) =>
+  BigInt(a) < BigInt(b) ? -1 : BigInt(a) > BigInt(b) ? 1 : 0
+);
 console.log("claimedSigners (sorted):", claimedSigners);
 
 // ---- 3. assemble fraudProof + fraudProofId ---------------------------------
@@ -105,24 +114,37 @@ if (!ok) die("verifier rejected the fraudProof — NOT submitting executeGuardia
 // ---- 5. locks BEFORE -------------------------------------------------------
 const before = {};
 for (const g of guilty) before[g] = await lockOf(g);
-console.log("ROLE_DVT locks BEFORE:", Object.fromEntries(guilty.map(g => [g, before[g].toString()])));
+console.log(
+  "ROLE_DVT locks BEFORE:",
+  Object.fromEntries(guilty.map(g => [g, before[g].toString()]))
+);
 
 // ---- 6. broadcast executeGuardianSlash -------------------------------------
 console.log("\nbroadcasting executeGuardianSlash...");
 const tx = await agg.executeGuardianSlash(fraudProofId, guilty, fraudProof);
 const rcpt = await tx.wait();
-console.log(`✓ executeGuardianSlash mined: ${rcpt.hash} (status ${rcpt.status}, gas ${rcpt.gasUsed})`);
+console.log(
+  `✓ executeGuardianSlash mined: ${rcpt.hash} (status ${rcpt.status}, gas ${rcpt.gasUsed})`
+);
 
 // ---- 7. locks AFTER (expect 0) ---------------------------------------------
 const after = {};
 for (const g of guilty) after[g] = await lockOf(g);
-console.log("ROLE_DVT locks AFTER: ", Object.fromEntries(guilty.map(g => [g, after[g].toString()])));
+console.log(
+  "ROLE_DVT locks AFTER: ",
+  Object.fromEntries(guilty.map(g => [g, after[g].toString()]))
+);
 const allZero = guilty.every(g => after[g] === 0n);
 
 // ---- 8. auto-eject: a fresh verify(mask) must now REVERT --------------------
 let autoEject = false;
 try {
-  await agg.verify(ethers.keccak256(ethers.toUtf8Bytes("auto-eject-probe")), MASK, 3n, "0x" + "00".repeat(256));
+  await agg.verify(
+    ethers.keccak256(ethers.toUtf8Bytes("auto-eject-probe")),
+    MASK,
+    3n,
+    "0x" + "00".repeat(256)
+  );
   autoEject = false; // did NOT revert
 } catch {
   autoEject = true; // reverted (SlotValidatorStakeBelowMinimum) → slashed slots ejected


### PR DESCRIPTION
## What (CC-89 Sepolia joint-run tool)

`scripts/cc89-cosign.mjs` — produces the 3-of-3 BLS aggregate `proof` SP's `BLSAggregator.verifyAndExecute` needs for the disputed over-issue slash in the joint E2E. Thin entrypoint over the **production** BLS primitives (`src/modules/bls`, `gossip-quorum-cosigner`): signs SP's slash-only `expectedMessageHash` with the 3 local guardian keys (`node_dev_00{1,2,3}.json`), aggregates, EIP-2537-encodes, emits `proof = abi.encode(uint256 signerMask, bytes sigG2)`. Same DST (`BLS_SIG_…_POP_`) + G2 encoding as the service.

Local-key signing (not gossip) is the right shape for the testnet E2E where all 3 guardian keys live on one machine (CLAUDE.md dev-nodes convention).

## Verification — proven on-chain, not just reviewed
The CLI staticcalls the **deployed Sepolia** aggregator `verify(messageHash, mask=0x7, threshold=3, sigG2)` and refuses to emit a proof unless it returns `true`. Ran the self-test live:
```
aggregator(0xf44E7E51…A285).verify(...) = true ✅
```
→ the aggregate passes SP's real `_checkSignatures`; also cross-proves the 3 registered slot pubkeys == our keys (pairing holds). This on-chain check is stronger than a static review for correctness.

## Note
Testnet joint-run tooling; correctness is self-proving via the on-chain `verify` gate. No production/mainnet path. `node_dev_*.json` are git-ignored (private keys never committed — see #228).

Refs: Seeder CC-89.