### PR TITLE
chore(release): v1.13.0 — CC-89 stage-2 over-issue guardian-slash (production)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to YetAnotherAA-Validator (the DVT BLS signer node) are
 documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow SemVer.
 
+## [1.13.0] — 2026-08-15 — CC-89 stage-2: over-issue guardian-collusion slash (testnet-E2E proven)
+
+Production release. Adds the DVT half of the CC-89 guardian-collusion slashing
+mechanism — the fraud-proof path that punishes ≥m colluding guardians who pass a
+fraudulent over-issue slash — and proves the whole chain end-to-end on Sepolia
+with SuperPaymaster.
+
+### Added
+
+- **`OverIssueFraudProofVerifier`** (`contracts/`, #223) + `IFraudProofVerifier`
+  — the on-chain `verify()` (fail-closed view) that
+  `BLSAggregator.executeGuardianSlash` calls: 5 checks (fraudProofId
+  content-binding, canonical claimedSigners, A'-commitment reconstruction
+  binding the disputed token, `guiltyGuardians ⊆ claimedSigners`,
+  `isOverIssued(token)==false`). 16 Foundry tests + TS↔Solidity golden vector.
+- **Guardian-slash watcher** (`src/modules/audit/guardian-slash-watcher.*`,
+  #224) — in-process, opt-in (`AUDIT_GUARDIAN_WATCH_ENABLED`, default off),
+  fail-closed: captures each `SlashExecuted`'s signer address set at the
+  execution block into a 3-area durable store (verified / quarantine /
+  dead-letter), the irreversible-A' data-availability layer. Restart-safe
+  cursor.
+- **Fraud-proof assembler** (`guardian-fraud-proof-assembler.ts`, #225) — builds
+  the `(fraudProofId, guiltyGuardians, fraudProof)` the verifier accepts;
+  refuses doomed/harmful inputs.
+- **Stage-0 design + E2E runbook + shipping plan + E2E record** (docs/design/,
+  #221/#226 + this release) — threat model, A' spec, cross-repo evidence
+  convention, and the authoritative Sepolia E2E record for the RepCredit paper.
+- **Joint-testnet tooling** — `DeployOverIssueVerifier.s.sol` (#227),
+  `cc89-cosign.mjs` + `cc89-e2e-finish.mjs` + `MockOverIssuableToken.sol`
+  (#229), `/goal` shipping-pipeline command.
+
+### Verified
+
+- **Testnet E2E PASSED on Sepolia** (CC-89): SP `verifyAndExecute` → A'
+  commitment → DVT fraud proof → `executeGuardianSlash` (tx `0xb870688e…91ba`) →
+  3 guardians' ROLE_DVT stake 30e18 → 0 → auto-eject. The paper's `ρ` detection
+  half is now "implemented + testnet-verified" for the on-chain-objective
+  (over-issue) class.
+
+### Fixed (security)
+
+- **`.gitignore`** (#228) — drop the stale `!node_dev_001.json` un-ignore that
+  force-included a BLS private-key filename; all `node_dev_*.json` now ignored.
+
+### Deferred (Phase-3 / gated)
+
+- Trustless historical-state over-issue proof (BLOCKHASH + storage proof,
+  bounded challenge window); watcher wrapped-call trace resolution; liveness
+  class (gated on CC-29); production arming of an on-chain-objective slash rule.
+
 ## [1.3.0] — 2026-06-16 — node hardening + dependency pinning
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yetanotheraa-validator",
-  "version": "1.11.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yetanotheraa-validator",
-      "version": "1.11.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@nestjs/common": "^11.1.27",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yetanotheraa-validator",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Production-ready BLS signature validation infrastructure for ERC-4337 account abstraction",
   "main": "dist/main.js",
   "type": "module",


### PR DESCRIPTION
## v1.13.0 — DVT production release

Cuts the production release for the **CC-89 stage-2 over-issue guardian-collusion slash** mechanism, proven end-to-end on Sepolia with SuperPaymaster.

**This PR:** version bump `1.12.0 → 1.13.0` (package.json + lock) + CHANGELOG `[1.13.0]` entry. All feature code already merged (#221/#223/#224/#225/#226/#227/#228/#229).

### What ships in 1.13.0
- `OverIssueFraudProofVerifier` + `IFraudProofVerifier` (#223) — 5-check fail-closed fraud-proof verifier.
- Guardian-slash watcher (#224) — captures the signer set (3-area durable store) for attribution.
- Fraud-proof assembler (#225) — builds verifier-accepted proofs; refuses harmful inputs.
- Stage-0 design + E2E runbook + shipping plan + **E2E record** (`docs/design/cc89-e2e-record.md`).
- Joint-testnet tooling: `DeployOverIssueVerifier.s.sol` (#227), `cc89-cosign.mjs` + `cc89-e2e-finish.mjs` + `MockOverIssuableToken.sol` (#229).
- Security: `.gitignore` node_dev key footgun fix (#228).

### Verified
- **Testnet E2E PASSED on Sepolia**: SP `verifyAndExecute` → A' commitment → DVT fraud proof → `executeGuardianSlash` (tx `0xb870688e…91ba`) → 3 guardians' ROLE_DVT 30e18→0 → auto-eject. Paper `ρ` detection half now "implemented + testnet-verified" (on-chain-objective / over-issue class).
- Full suite green: `jest` 446, `forge` 75, type-check/lint/format clean.

### Deferred (Phase-3 / gated)
Historical-state trustless proof; watcher wrapped-call trace; liveness class (CC-29); production arming.

After merge → tag `v1.13.0` + GitHub release. **This becomes the DVT production version.**

Refs CC-89.