### PR TITLE
fix(CC-89): fail-close audit/watcher aggregator bootstrap + align default to production aggregator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ deploy/.drill-archive-backup/
 
 # Foundry broadcast logs (auto-generated per deploy; addresses recorded in docs)
 contracts/broadcast/
+
+# CC-89 production guardian operator EOA keys (NEVER commit)
+guardian-operators.json

--- a/docs/design/cc89-e2e-record.md
+++ b/docs/design/cc89-e2e-record.md
@@ -61,6 +61,16 @@ between the messageHash field and the evidence op — for a no-real-victim demo,
 | GTokenStaking                                      | `0x472297B557c1d0F030f281a5Bb8A535f6c5AB65e` |
 | MockOverIssuableToken (`isOverIssued()==false`)    | `0x8dE1b6585Bdf5a3e6F13B3125B2d40CC34fc005b` |
 
+> **⚠️ These are the E2E throwaway deployment addresses — NOT production.** The
+> aggregator `0xf44E7E51…` above was a single-run fixture (its 3 guardians are
+> now slashed to 0 and ejected). The **production** Sepolia SuperPaymaster
+> BLSAggregator (A' 4.3.0) is **`0x174b60bB462b00550F0EC7Bc35Fe39dDB6310158`**
+> (the config default; see `src/config/configuration.ts`
+> `auditBlsAggregatorAddress`), with production verifier `0x128847cF…` and 3
+> persistent guardians (CC-89 comment `b26903ec`). Guardian nodes must set
+> `AUDIT_BLS_AGGREGATOR_ADDRESS` to the **production** aggregator; do not copy
+> the E2E address from this record.
+
 3 guardians registered at slots 1/2/3, each with **30e18 ROLE_DVT** locked
 (`ROLE_DVT = keccak256("DVT")`): `0xb5600060…` (slot1), `0x6F7D30f2…F96E`
 (slot2), `0x09a0ca08…5c93` (slot3).

--- a/src/config/configuration.spec.ts
+++ b/src/config/configuration.spec.ts
@@ -4,6 +4,31 @@ import configuration from "./configuration.js";
  * Config-floor tests (Codex round-2 LOW): AUDIT_FINALITY_CONFIRMATIONS must be floored to a
  * POSITIVE value so the finalized-block fallback never resolves to the unconfirmed head (latest − 0).
  */
+describe("configuration: auditBlsAggregatorAddressFromEnv (CC-89 explicit-presence flag)", () => {
+  const saved = { ...process.env };
+  beforeEach(() => {
+    process.env.ETH_RPC_URL = "http://localhost:8545";
+    process.env.VALIDATOR_CONTRACT_ADDRESS = "0x" + "12".repeat(20);
+    delete process.env.AUDIT_BLS_AGGREGATOR_ADDRESS;
+  });
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  it("unset env → resolved value carries the built-in default, but fromEnv is FALSE", () => {
+    const c = configuration();
+    expect(c.auditBlsAggregatorAddress).toBe("0x174b60bB462b00550F0EC7Bc35Fe39dDB6310158");
+    expect(c.auditBlsAggregatorAddressFromEnv).toBe(false);
+  });
+
+  it("explicit env → fromEnv is TRUE and the value is the env value", () => {
+    process.env.AUDIT_BLS_AGGREGATOR_ADDRESS = "0x" + "cd".repeat(20);
+    const c = configuration();
+    expect(c.auditBlsAggregatorAddress).toBe("0x" + "cd".repeat(20));
+    expect(c.auditBlsAggregatorAddressFromEnv).toBe(true);
+  });
+});
+
 describe("configuration: auditFinalityConfirmations floor", () => {
   const saved = { ...process.env };
 

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -231,11 +231,18 @@ export default () => {
     // DVTValidator (SP #329 finalized interface). Default is the Sepolia deployment.
     auditDvtValidatorAddress:
       process.env.AUDIT_DVT_VALIDATOR_ADDRESS || "0x568b1486BFE036e603eA11f0D03Dc47fa62c9E0e",
-    // BLSAggregator (SP #329). Currently informational — the on-chain queue/execute writes go
-    // through DVTValidator; the aggregator address is recorded for the future live gossip
-    // co-sign that will aggregate peer BLS signatures by SP-assigned validator slot.
+    // SP BLSAggregator (A' 4.3.0) — the aggregator the guardian-slash watcher (CC-89) reads
+    // proposalSignersCommitment/validatorAtSlot from, and the offline-audit rule resolves
+    // operator→BLS key through. Default is the Sepolia PRODUCTION deployment (CC-89 0fe793f2;
+    // supersedes the pre-migration 0xF51c0298… which was stale/informational). ALWAYS set
+    // AUDIT_BLS_AGGREGATOR_ADDRESS explicitly per network — never rely on the default off-Sepolia.
     auditBlsAggregatorAddress:
-      process.env.AUDIT_BLS_AGGREGATOR_ADDRESS || "0xF51c029879685Ced8fbCfa4b647c2eAe50Cd8B13",
+      process.env.AUDIT_BLS_AGGREGATOR_ADDRESS || "0x174b60bB462b00550F0EC7Bc35Fe39dDB6310158",
+    // Whether the aggregator address was set EXPLICITLY (not the resolved value — the resolved value
+    // always carries the Sepolia default above, which would mask the unset case). Consumed by the
+    // fail-closed off-Sepolia guard so the Sepolia default is never silently inherited on another
+    // chain. See aggregator-bootstrap-guard.ts.
+    auditBlsAggregatorAddressFromEnv: Boolean(process.env.AUDIT_BLS_AGGREGATOR_ADDRESS),
     auditGtokenStakingAddress: process.env.AUDIT_GTOKEN_STAKING_ADDRESS || undefined,
     // SECOND safety gate (increment 2). AUDIT_ENABLED alone only FILES slash proposals; the
     // two-step on-chain slash (queueSlashWithProof → executeWithProof, each quorum co-signed)

--- a/src/modules/audit/aggregator-bootstrap-guard.spec.ts
+++ b/src/modules/audit/aggregator-bootstrap-guard.spec.ts
@@ -1,0 +1,59 @@
+import { checkAggregatorChainPolicy, SEPOLIA_CHAIN_ID } from "./aggregator-bootstrap-guard.js";
+
+describe("checkAggregatorChainPolicy (CC-89 shared fail-closed guard)", () => {
+  it("rejects a provider chain that differs from AUDIT_CHAIN_ID (always, regardless of required)", () => {
+    const r = checkAggregatorChainPolicy({
+      expectedChainId: SEPOLIA_CHAIN_ID,
+      providerChainId: 1,
+      aggregatorFromEnv: true,
+      aggregatorRequired: false,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain("!= AUDIT_CHAIN_ID");
+  });
+
+  it("rejects the Sepolia default silently inherited off-Sepolia when the aggregator IS required", () => {
+    const r = checkAggregatorChainPolicy({
+      expectedChainId: 10, // OP-mainnet, matches provider
+      providerChainId: 10,
+      aggregatorFromEnv: false, // never set explicitly → would inherit the Sepolia default
+      aggregatorRequired: true,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain("not set explicitly");
+  });
+
+  it("allows off-Sepolia when the aggregator was set explicitly", () => {
+    expect(
+      checkAggregatorChainPolicy({
+        expectedChainId: 10,
+        providerChainId: 10,
+        aggregatorFromEnv: true,
+        aggregatorRequired: true,
+      }).ok
+    ).toBe(true);
+  });
+
+  it("allows off-Sepolia with an unset aggregator when it is NOT required (chain matches)", () => {
+    // e.g. the audit runs with offline disabled — the aggregator is never consumed.
+    expect(
+      checkAggregatorChainPolicy({
+        expectedChainId: 10,
+        providerChainId: 10,
+        aggregatorFromEnv: false,
+        aggregatorRequired: false,
+      }).ok
+    ).toBe(true);
+  });
+
+  it("allows the Sepolia default on Sepolia even when not set explicitly", () => {
+    expect(
+      checkAggregatorChainPolicy({
+        expectedChainId: SEPOLIA_CHAIN_ID,
+        providerChainId: SEPOLIA_CHAIN_ID,
+        aggregatorFromEnv: false,
+        aggregatorRequired: true,
+      }).ok
+    ).toBe(true);
+  });
+});

--- a/src/modules/audit/aggregator-bootstrap-guard.ts
+++ b/src/modules/audit/aggregator-bootstrap-guard.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared fail-closed policy for the SP BLS aggregator address, used by BOTH audit consumers
+ * (the offline-audit rule in `audit.service.ts` and the CC-89 guardian-slash watcher). Centralizing
+ * it here prevents the two bootstraps from drifting (Codex CC-89 round-2: the watcher originally had
+ * no chain guard at all while the offline rule did).
+ *
+ * The built-in `auditBlsAggregatorAddress` default in `configuration.ts` is a Sepolia PRODUCTION
+ * address. Two silent-inheritance footguns it must never enable:
+ *   1. wrong chain — the RPC actually points at a chain other than AUDIT_CHAIN_ID; the default (or
+ *      any Sepolia address) is then garbage.
+ *   2. off-Sepolia default — even when the RPC matches AUDIT_CHAIN_ID, if that chain is NOT Sepolia
+ *      and the operator never explicitly set AUDIT_BLS_AGGREGATOR_ADDRESS, they are unknowingly
+ *      polling a Sepolia address on a non-Sepolia chain. `getCode != 0x` cannot catch this (a
+ *      wrong-but-deployed address passes it); requiring an explicit env value does.
+ */
+export const SEPOLIA_CHAIN_ID = 11155111;
+
+export interface AggregatorChainPolicyInput {
+  /** AUDIT_CHAIN_ID (the chain the audit is configured for). */
+  expectedChainId: number;
+  /** The RPC provider's actual chainId (from getNetwork). */
+  providerChainId: number;
+  /** Whether AUDIT_BLS_AGGREGATOR_ADDRESS was set explicitly in the env (NOT the resolved value —
+   *  the resolved value always carries the built-in default, which masks the unset case). */
+  aggregatorFromEnv: boolean;
+  /** Whether this consumer actually uses the aggregator (offline-audit rule / guardian watcher). The
+   *  chain-mismatch guard applies regardless (all default addresses are Sepolia); the
+   *  off-Sepolia-explicit guard only when the aggregator is genuinely consumed. */
+  aggregatorRequired: boolean;
+}
+
+/** Pure fail-closed policy check. Returns `{ ok: false, reason }` when the audit/watcher must
+ *  refuse to start rather than trust a possibly-wrong-chain aggregator address. */
+export function checkAggregatorChainPolicy(input: AggregatorChainPolicyInput): {
+  ok: boolean;
+  reason?: string;
+} {
+  const { expectedChainId, providerChainId, aggregatorFromEnv, aggregatorRequired } = input;
+  if (providerChainId !== expectedChainId) {
+    return {
+      ok: false,
+      reason:
+        `RPC chainId ${providerChainId} != AUDIT_CHAIN_ID ${expectedChainId} — refusing to ` +
+        `poll network-specific default addresses on the wrong chain`,
+    };
+  }
+  if (aggregatorRequired && expectedChainId !== SEPOLIA_CHAIN_ID && !aggregatorFromEnv) {
+    return {
+      ok: false,
+      reason:
+        `AUDIT_CHAIN_ID ${expectedChainId} is not Sepolia but AUDIT_BLS_AGGREGATOR_ADDRESS was not ` +
+        `set explicitly — the built-in default is a Sepolia-only address; set it explicitly`,
+    };
+  }
+  return { ok: true };
+}

--- a/src/modules/audit/audit.service.spec.ts
+++ b/src/modules/audit/audit.service.spec.ts
@@ -45,6 +45,8 @@ function makeBlockchain(
       fromBlock: number
     ) => Promise<boolean | null>;
     getCode: (addr: string) => Promise<string>;
+    getChainId: () => Promise<number>;
+    probeBlsAggregator: (addr: string) => Promise<void>;
     getCreditLimit: (addr: string, op: string, bt?: number) => Promise<bigint>;
     getAvailableCredit: (addr: string, op: string, token: string, bt?: number) => Promise<bigint>;
     getDebt: (tokenAddr: string, op: string, bt?: number) => Promise<bigint | null>;
@@ -89,6 +91,11 @@ function makeBlockchain(
     // No prior slash by default → the durable on-chain over-slash guard reports "not slashed".
     getRecentSlashExecuted: overrides.getRecentSlashExecuted ?? (async () => false),
     getCode: overrides.getCode ?? (async () => "0x60006000fd"),
+    // Provider chainId matches the default auditChainId (11155111) so the bootstrap chain guard
+    // passes; the invalid-chainId test bails earlier (auditChainId<=0) before this is read.
+    getChainId: overrides.getChainId ?? (async () => 11155111),
+    // Aggregator interface probe succeeds by default (validatorAtSlot(1) did not revert).
+    probeBlsAggregator: overrides.probeBlsAggregator ?? (async () => {}),
     getCreditLimit: overrides.getCreditLimit ?? (async () => 1000n),
     getAvailableCredit: overrides.getAvailableCredit ?? (async () => 1000n),
     getDebt: overrides.getDebt ?? (async () => 0n),
@@ -251,6 +258,75 @@ describe("AuditService", () => {
     await svc.onApplicationBootstrap();
     expect((svc as any).startupTimer).toBeNull();
     expect((await svc.getStatus()).enabled).toBe(false);
+  });
+
+  it("fail-closed: RPC chainId != AUDIT_CHAIN_ID → DISABLED (wrong-chain default addresses)", async () => {
+    // Provider is actually on mainnet (1) while AUDIT_CHAIN_ID declares Sepolia (11155111) — the
+    // Sepolia default addresses would be garbage, so the audit must refuse to start.
+    const blockchain = makeBlockchain({ getChainId: async () => 1 });
+    const svc = makeService(blockchain, makeConfig(), makeArchive());
+    await svc.onApplicationBootstrap();
+    expect((svc as any).startupTimer).toBeNull();
+    expect((await svc.getStatus()).enabled).toBe(false);
+  });
+
+  it("fail-closed: offline audit ON but AUDIT_BLS_AGGREGATOR_ADDRESS empty → DISABLED", async () => {
+    const svc = makeService(
+      makeBlockchain(),
+      makeConfig({ auditOfflineEnabled: true, auditBlsAggregatorAddress: "" }),
+      makeArchive()
+    );
+    await svc.onApplicationBootstrap();
+    expect((svc as any).startupTimer).toBeNull();
+    expect((await svc.getStatus()).enabled).toBe(false);
+  });
+
+  it("fail-closed: offline audit ON + aggregator set but no on-chain code → DISABLED", async () => {
+    // Aggregator address is set but the only address returning empty code is the aggregator; every
+    // other required address has code. This proves the aggregator is in the existence check.
+    const AGG = "0x" + "ab".repeat(20);
+    const blockchain = makeBlockchain({
+      getCode: async (addr: string) => (addr.toLowerCase() === AGG ? "0x" : "0x60006000fd"),
+    });
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditOfflineEnabled: true, auditBlsAggregatorAddress: AGG }),
+      makeArchive()
+    );
+    await svc.onApplicationBootstrap();
+    expect((svc as any).startupTimer).toBeNull();
+    expect((await svc.getStatus()).enabled).toBe(false);
+  });
+
+  it("fail-closed: offline audit ON + aggregator has code but is not a BLSAggregator → DISABLED", async () => {
+    // getCode passes (bytecode exists) but the interface probe (validatorAtSlot(1)) reverts — a
+    // wrong-but-deployed address. Must fail-closed rather than trust it.
+    const AGG = "0x" + "ac".repeat(20);
+    const blockchain = makeBlockchain({
+      probeBlsAggregator: async () => {
+        throw new Error("execution reverted (not a BLSAggregator)");
+      },
+    });
+    const svc = makeService(
+      blockchain,
+      makeConfig({ auditOfflineEnabled: true, auditBlsAggregatorAddress: AGG }),
+      makeArchive()
+    );
+    await svc.onApplicationBootstrap();
+    expect((svc as any).startupTimer).toBeNull();
+    expect((await svc.getStatus()).enabled).toBe(false);
+  });
+
+  it("offline audit ON + aggregator set + code + probe OK + chain matches → ENABLED", async () => {
+    // Positive path: proves the new fail-closed guards do NOT false-disable a correct offline setup.
+    const AGG = "0x" + "ad".repeat(20);
+    const svc = makeService(
+      makeBlockchain(),
+      makeConfig({ auditOfflineEnabled: true, auditBlsAggregatorAddress: AGG }),
+      makeArchive()
+    );
+    await svc.onApplicationBootstrap();
+    expect((await svc.getStatus()).enabled).toBe(true);
   });
 
   it("computeJitterMs stays within [0, intervalMs)", () => {

--- a/src/modules/audit/audit.service.ts
+++ b/src/modules/audit/audit.service.ts
@@ -13,6 +13,7 @@ import { GossipService } from "../gossip/gossip.service.js";
 import { CapabilityRegistry } from "../capability/capability-registry.service.js";
 import type { IProofArchive, SlashProof, EvidenceSource, ProofIdentity } from "./proof-archive.js";
 import { LocalProofArchive, computeProofHash, PROOF_SCHEMA_VERSION } from "./proof-archive.js";
+import { checkAggregatorChainPolicy } from "./aggregator-bootstrap-guard.js";
 import type { IQuorumCoSigner } from "./slash-consensus.js";
 import {
   SlashLevel,
@@ -94,6 +95,8 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
   private readonly superPaymasterAddress: string;
   private readonly dvtValidatorAddress: string;
   private readonly blsAggregatorAddress: string;
+  /** Whether AUDIT_BLS_AGGREGATOR_ADDRESS was set explicitly (see aggregator-bootstrap-guard.ts). */
+  private readonly blsAggregatorAddressFromEnv: boolean;
   private readonly gtokenStakingAddress: string;
   /**
    * SECOND safety gate (increment 2). When false (default) a violation only FILES + ARCHIVES a
@@ -280,6 +283,8 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     this.superPaymasterAddress = config.get<string>("auditSuperPaymasterAddress") ?? "";
     this.dvtValidatorAddress = config.get<string>("auditDvtValidatorAddress") ?? "";
     this.blsAggregatorAddress = config.get<string>("auditBlsAggregatorAddress") ?? "";
+    this.blsAggregatorAddressFromEnv =
+      config.get<boolean>("auditBlsAggregatorAddressFromEnv") === true;
     this.gtokenStakingAddress = config.get<string>("auditGtokenStakingAddress") ?? "";
     this.executeSlash = config.get<boolean>("auditExecuteSlash") === true;
     this.dryRun = config.get<boolean>("auditDryRun") === true;
@@ -332,6 +337,12 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
     if (!this.registryAddress) missing.push("AUDIT_REGISTRY_ADDRESS");
     if (!this.superPaymasterAddress) missing.push("AUDIT_SUPER_PAYMASTER_ADDRESS");
     if (!this.dvtValidatorAddress) missing.push("AUDIT_DVT_VALIDATOR_ADDRESS");
+    // The offline rule resolves operator→nodeId through the BLS aggregator (getOperatorNodeId).
+    // With a built-in network-specific default it would otherwise fail lazily per tick (silently
+    // fail-OPEN on offline detection). Require it explicitly whenever offline audit is on.
+    if (this.offlineEnabled && !this.blsAggregatorAddress) {
+      missing.push("AUDIT_BLS_AGGREGATOR_ADDRESS");
+    }
     if (missing.length > 0) {
       this.enabled = false;
       this.logger.error(
@@ -344,12 +355,40 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
       this.logger.error(`Audit: invalid AUDIT_CHAIN_ID=${this.chainId} — DISABLED (fail-closed)`);
       return;
     }
+    // Chain guard: the config carries network-specific default addresses (Sepolia BLS aggregator /
+    // DVTValidator). If the RPC points at a different chain than AUDIT_CHAIN_ID, or the Sepolia
+    // aggregator default is silently inherited off-Sepolia, those addresses are garbage. Shared
+    // fail-closed policy (aggregator-bootstrap-guard.ts) — mirrored by the guardian watcher.
+    let providerChainId: number;
+    try {
+      providerChainId = await this.blockchainService.getChainId();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.enabled = false;
+      this.logger.error(`Audit: could not read provider chainId (${msg}) — DISABLED (fail-closed)`);
+      return;
+    }
+    const policy = checkAggregatorChainPolicy({
+      expectedChainId: this.chainId,
+      providerChainId,
+      aggregatorFromEnv: this.blsAggregatorAddressFromEnv,
+      aggregatorRequired: this.offlineEnabled,
+    });
+    if (!policy.ok) {
+      this.enabled = false;
+      this.logger.error(`Audit: ${policy.reason} — DISABLED (fail-closed)`);
+      return;
+    }
     // On-chain existence check: reject any address with no deployed code (wrong chain / typo).
     const toCheck: Array<[string, string]> = [
       ["AUDIT_REGISTRY_ADDRESS", this.registryAddress],
       ["AUDIT_SUPER_PAYMASTER_ADDRESS", this.superPaymasterAddress],
       ["AUDIT_DVT_VALIDATOR_ADDRESS", this.dvtValidatorAddress],
     ];
+    // When offline audit is on, the aggregator must also exist on-chain (it's required above).
+    if (this.offlineEnabled && this.blsAggregatorAddress) {
+      toCheck.push(["AUDIT_BLS_AGGREGATOR_ADDRESS", this.blsAggregatorAddress]);
+    }
     if (this.gtokenStakingAddress) {
       toCheck.push(["AUDIT_GTOKEN_STAKING_ADDRESS", this.gtokenStakingAddress]);
     }
@@ -369,6 +408,21 @@ export class AuditService implements OnApplicationBootstrap, OnApplicationShutdo
         this.enabled = false;
         this.logger.error(
           `Audit: ${name}=${addr} has no on-chain code on chainId ${this.chainId} — DISABLED (fail-closed)`
+        );
+        return;
+      }
+    }
+    // Interface sanity-probe for the aggregator (offline rule only): getCode proves bytecode exists,
+    // not that it's a BLSAggregator. A static validatorAtSlot(1) catches a wrong-but-deployed address.
+    if (this.offlineEnabled && this.blsAggregatorAddress) {
+      try {
+        await this.blockchainService.probeBlsAggregator(this.blsAggregatorAddress);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.enabled = false;
+        this.logger.error(
+          `Audit: AUDIT_BLS_AGGREGATOR_ADDRESS=${this.blsAggregatorAddress} did not respond to ` +
+            `validatorAtSlot(1) (${msg}) — not a BLSAggregator? DISABLED (fail-closed)`
         );
         return;
       }

--- a/src/modules/audit/guardian-slash-watcher.service.spec.ts
+++ b/src/modules/audit/guardian-slash-watcher.service.spec.ts
@@ -249,4 +249,33 @@ describe("GuardianSlashWatcherService (CC-89 stage-2 durability)", () => {
     await svc.tick();
     expect(await store.readCursor()).toBeNull();
   });
+
+  it("bootstrap fail-closed: aggregator answers validatorAtSlot but REVERTS proposalSignersCommitment → DISABLED", async () => {
+    // Proves the watcher's bootstrap probe exercises proposalSignersCommitment INDEPENDENTLY — a
+    // wrong-but-deployed contract implementing only validatorAtSlot must not start the poller.
+    let sawCommitmentProbe = false;
+    const bootProvider: any = {
+      getCode: async () => "0x60006000fd",
+      getNetwork: async () => ({ chainId: CHAIN_ID }),
+      call: async (tx: { data: string }) => {
+        const sel = tx.data.slice(0, 10);
+        if (sel === va.getFunction("validatorAtSlot")!.selector) {
+          return va.encodeFunctionResult("validatorAtSlot", [ethers.ZeroAddress]);
+        }
+        sawCommitmentProbe = true;
+        throw new Error("execution reverted (no proposalSignersCommitment)");
+      },
+    };
+    const svc = new GuardianSlashWatcherService(undefined, undefined, store);
+    (svc as any).provider = bootProvider;
+    (svc as any).aggregatorAddress = AGG;
+    (svc as any).expectedChainId = Number(CHAIN_ID);
+    (svc as any).aggregatorFromEnv = true;
+
+    await (svc as any).bootstrapAndPoll();
+
+    expect(sawCommitmentProbe).toBe(true); // the second probe method actually fired
+    expect((svc as any).timer).toBeNull(); // poller NOT started (fail-closed)
+    expect((svc as any).chainId).toBeNull(); // never advanced past the probe
+  });
 });

--- a/src/modules/audit/guardian-slash-watcher.service.ts
+++ b/src/modules/audit/guardian-slash-watcher.service.ts
@@ -11,6 +11,7 @@ import { OpsAlertService } from "../ops-alert/ops-alert.service.js";
 import type { IGuardianSignerStore } from "./guardian-signer-store.js";
 import { LocalGuardianSignerStore } from "./guardian-signer-store.js";
 import { SLASH_EXECUTED_EVENT, buildGuardianSignerRecord } from "./guardian-slash-watcher.core.js";
+import { checkAggregatorChainPolicy } from "./aggregator-bootstrap-guard.js";
 
 /**
  * CC-89 stage-2 — guardian-slash WATCHER (the off-chain data-availability half).
@@ -54,6 +55,10 @@ export class GuardianSlashWatcherService implements OnApplicationBootstrap, OnAp
   private readonly logger = new Logger(GuardianSlashWatcherService.name);
   private readonly enabled: boolean;
   private readonly aggregatorAddress: string;
+  /** AUDIT_CHAIN_ID — cross-checked against the RPC's actual chain (shared fail-closed policy). */
+  private readonly expectedChainId: number;
+  /** Whether AUDIT_BLS_AGGREGATOR_ADDRESS was set explicitly (guards the Sepolia default). */
+  private readonly aggregatorFromEnv: boolean;
   private readonly rpcUrl: string;
   private readonly intervalMs: number;
   private readonly fromBlock: number;
@@ -75,6 +80,8 @@ export class GuardianSlashWatcherService implements OnApplicationBootstrap, OnAp
   ) {
     this.enabled = this.config?.get<boolean>("auditGuardianWatchEnabled") === true;
     this.aggregatorAddress = this.config?.get<string>("auditBlsAggregatorAddress") ?? "";
+    this.expectedChainId = this.config?.get<number>("auditChainId") ?? 0;
+    this.aggregatorFromEnv = this.config?.get<boolean>("auditBlsAggregatorAddressFromEnv") === true;
     this.rpcUrl = this.config?.get<string>("ethRpcUrl") ?? "";
     this.intervalMs = this.config?.get<number>("auditGuardianWatchIntervalMs") ?? 60_000;
     this.fromBlock = this.config?.get<number>("auditGuardianWatchFromBlock") ?? 0;
@@ -144,6 +151,31 @@ export class GuardianSlashWatcherService implements OnApplicationBootstrap, OnAp
         return;
       }
       const net = await this.provider!.getNetwork();
+      // Shared fail-closed policy (mirrors AuditService): reject a wrong-chain RPC or a Sepolia
+      // aggregator default silently inherited off-Sepolia. getCode above only proves bytecode exists.
+      const policy = checkAggregatorChainPolicy({
+        expectedChainId: this.expectedChainId,
+        providerChainId: Number(net.chainId),
+        aggregatorFromEnv: this.aggregatorFromEnv,
+        aggregatorRequired: true,
+      });
+      if (!policy.ok) {
+        this.logger.warn(`${policy.reason} — watcher DISABLED`);
+        return;
+      }
+      // Interface sanity-probe: statically exercise the EXACT methods this watcher calls at runtime
+      // (validatorAtSlot + proposalSignersCommitment). A wrong-but-deployed address passes getCode
+      // but reverts / fails to decode here → fail-closed at bootstrap, not at runtime.
+      const probe = new ethers.Contract(
+        this.aggregatorAddress,
+        [
+          "function validatorAtSlot(uint8) view returns (address)",
+          "function proposalSignersCommitment(uint256) view returns (bytes32)",
+        ],
+        this.provider!
+      );
+      await probe.validatorAtSlot(1);
+      await probe.proposalSignersCommitment(0);
       this.chainId = net.chainId;
     } catch (e: any) {
       this.logger.warn(`watcher bootstrap read failed — DISABLED: ${e?.message ?? String(e)}`);

--- a/src/modules/blockchain/blockchain.service.spec.ts
+++ b/src/modules/blockchain/blockchain.service.spec.ts
@@ -580,3 +580,64 @@ describe("BlockchainService.getRegisteredSlot (finding-3 O(1) own-slot)", () => 
     expect(calls).toBe(0);
   });
 });
+
+describe("BlockchainService.probeBlsAggregator (CC-89 interface probe)", () => {
+  const BLS_AGG = ethers.getAddress("0x" + "aa".repeat(20));
+  const iface = new ethers.Interface([
+    "function validatorAtSlot(uint8) view returns (address)",
+    "function getBLSPublicKey(address validator) view returns (tuple(bytes32 x_a, bytes32 x_b, bytes32 y_a, bytes32 y_b) publicKey, uint8 slot, bool isActive)",
+  ]);
+  const SLOT_SEL = iface.getFunction("validatorAtSlot")!.selector;
+  const PK_SEL = iface.getFunction("getBLSPublicKey")!.selector;
+  const okSlot = () => iface.encodeFunctionResult("validatorAtSlot", [ethers.ZeroAddress]);
+  const okPk = () =>
+    iface.encodeFunctionResult("getBLSPublicKey", [
+      [
+        "0x" + "00".repeat(32),
+        "0x" + "00".repeat(32),
+        "0x" + "00".repeat(32),
+        "0x" + "00".repeat(32),
+      ],
+      0,
+      false,
+    ]);
+
+  function makeService(call: (tx: { data: string }) => Promise<string>): BlockchainService {
+    const svc = new BlockchainService({ get: (_k: string) => undefined } as any);
+    (svc as any).provider = { call };
+    return svc;
+  }
+
+  it("exercises BOTH validatorAtSlot(1) AND getBLSPublicKey(0) — resolves when both succeed", async () => {
+    const hit = { slot: false, pk: false };
+    const svc = makeService(async tx => {
+      const sel = tx.data.slice(0, 10);
+      if (sel === SLOT_SEL) {
+        hit.slot = true;
+        return okSlot();
+      }
+      if (sel === PK_SEL) {
+        hit.pk = true;
+        return okPk();
+      }
+      throw new Error("unexpected selector");
+    });
+    await expect(svc.probeBlsAggregator(BLS_AGG)).resolves.toBeUndefined();
+    expect(hit).toEqual({ slot: true, pk: true }); // proves each method actually fires
+  });
+
+  it("fails-closed (throws) when getBLSPublicKey reverts even though validatorAtSlot works", async () => {
+    const svc = makeService(async tx => {
+      if (tx.data.slice(0, 10) === SLOT_SEL) return okSlot();
+      throw new Error("execution reverted (no getBLSPublicKey)");
+    });
+    await expect(svc.probeBlsAggregator(BLS_AGG)).rejects.toThrow();
+  });
+
+  it("fails-closed (throws) when validatorAtSlot reverts", async () => {
+    const svc = makeService(async () => {
+      throw new Error("execution reverted (not an aggregator)");
+    });
+    await expect(svc.probeBlsAggregator(BLS_AGG)).rejects.toThrow();
+  });
+});

--- a/src/modules/blockchain/blockchain.service.ts
+++ b/src/modules/blockchain/blockchain.service.ts
@@ -1385,6 +1385,34 @@ export class BlockchainService {
     return this.provider.getCode(address, blockTag);
   }
 
+  /** The RPC provider's actual chainId. Used for a fail-closed bootstrap guard so the audit never
+   *  inherits a network-specific default address (e.g. the Sepolia BLS aggregator) on the wrong
+   *  chain. */
+  async getChainId(): Promise<number> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+    return Number((await this.provider.getNetwork()).chainId);
+  }
+
+  /** Interface sanity-probe for the OFFLINE-audit consumer's BLS aggregator surface. `getCode != 0x`
+   *  only proves *some* bytecode exists; this statically exercises the exact methods the offline rule
+   *  calls at runtime — `validatorAtSlot(1)` and `getBLSPublicKey(address(0))` (the latter is what
+   *  `getOperatorNodeId` uses) — so a wrong-but-deployed contract that implements one but not the
+   *  other still fails-closed at bootstrap instead of at runtime. Throws on any failure. */
+  async probeBlsAggregator(aggregatorAddress: string): Promise<void> {
+    if (!this.provider) {
+      throw new Error("Blockchain provider not configured");
+    }
+    const abi = [
+      "function validatorAtSlot(uint8) view returns (address)",
+      "function getBLSPublicKey(address validator) view returns (tuple(bytes32 x_a, bytes32 x_b, bytes32 y_a, bytes32 y_b) publicKey, uint8 slot, bool isActive)",
+    ];
+    const contract = new ethers.Contract(aggregatorAddress, abi, this.provider);
+    await contract.validatorAtSlot(1);
+    await contract.getBLSPublicKey(ethers.ZeroAddress);
+  }
+
   /** Registry.getCreditLimit(operator) — the operator's on-chain credit ceiling (wei-scaled). */
   async getCreditLimit(
     registryAddress: string,


### PR DESCRIPTION
## What
Follow-up hardening to CC-89 (raised on **CC-90** by the KMS工兵: the DVT code default `AUDIT_BLS_AGGREGATOR_ADDRESS` was the stale `0xF51c0298…`, not the production aggregator).

- **Align default** `0xF51c0298` (stale, SP's pre-CC-89 canonical) → **`0x174b60bB462b00550F0EC7Bc35Fe39dDB6310158`** (SP production A' 4.3.0, CC-89).
- Because a non-empty default **masks the unset case**, harden BOTH audit consumers (offline rule + guardian watcher) against silently inheriting a wrong/stale/off-chain aggregator:
  - `configuration.ts`: `auditBlsAggregatorAddressFromEnv` tracks **explicit** env presence (not the resolved value).
  - **`aggregator-bootstrap-guard.ts` (new, pure)**: shared fail-closed policy — reject provider chain ≠ AUDIT_CHAIN_ID; reject the Sepolia default inherited **off-Sepolia** unless set explicitly. Called by both consumers.
  - `audit.service.ts` + `guardian-slash-watcher.service.ts`: chain guard + **interface probe** (validatorAtSlot + getBLSPublicKey / proposalSignersCommitment) → a wrong-but-deployed address fails-closed at **bootstrap**, not fail-open at runtime.
  - `blockchain.service.ts`: `getChainId()` + `probeBlsAggregator()`.
- `.gitignore`: `guardian-operators.json` (production guardian EOA keys — never commit).
- docs/cc89-e2e-record: distinguish the E2E throwaway aggregator from production.

## Impact
**Zero breaking change** — every touched path is opt-in (offline audit + guardian watcher, both default off). SP / SDK / airaccount / paper need **no** changes; KMS only updates the watcher env example to `0x174b60bB…` (already communicated on CC-90).

## Review
Codex Tier-1: **5 rounds, final verdict CLEAN (0 Critical/High/Medium/Low)**. One Medium (hard canonical-identity pin) explicitly **deferred with rationale** — a hard address/codehash pin would false-disable on legitimate SP aggregator redeploys; the silent-default footgun this PR closes is the real issue.

## Tests
462 pass (new: aggregator-bootstrap-guard policy cases, per-selector probe assertions for both consumers, config fromEnv flag, offline bootstrap fail-closed/positive). type-check + build + lint(0 errors) + format green.

Refs: CC-89, CC-90, issue #222.