### PR TITLE
chore(release): v1.13.1 — CC-89 follow-up (aggregator-default alignment + audit/watcher bootstrap fail-closure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to YetAnotherAA-Validator (the DVT BLS signer node) are
 documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow SemVer.
 
+## [1.13.1] — 2026-08-15 — CC-89 follow-up: aggregator-default alignment + audit/watcher bootstrap fail-closure
+
+Backward-compatible hardening patch (raised on CC-90 by the KMS工兵: the DVT
+code default `AUDIT_BLS_AGGREGATOR_ADDRESS` was a stale pre-CC-89 address).
+Every touched path is opt-in (offline audit + guardian watcher, both default
+off) — no change to default runtime behaviour, no breaking change. SP / SDK /
+airaccount / paper need no changes; KMS only updates the watcher env example.
+
+### Changed
+
+- **Aggregator default aligned** `0xF51c0298…` (stale, SP's pre-CC-89 canonical)
+  → `0x174b60bB462b00550F0EC7Bc35Fe39dDB6310158` (SP production A' 4.3.0).
+  Tracks the real aggregator rotation that shipped with CC-89.
+
+### Added (fail-closed hardening)
+
+- **`aggregator-bootstrap-guard.ts`** (pure, shared) — one fail-closed policy
+  for both audit consumers: reject a provider chain ≠ `AUDIT_CHAIN_ID`, and
+  reject the Sepolia default silently inherited **off-Sepolia** unless
+  `AUDIT_BLS_AGGREGATOR_ADDRESS` is set explicitly (a non-empty default
+  otherwise masks the unset case).
+- **`auditBlsAggregatorAddressFromEnv`** (`configuration.ts`) — tracks whether
+  the aggregator address was set explicitly (not the resolved value).
+- **Interface probe at bootstrap** — the offline rule (`getBLSPublicKey` +
+  `validatorAtSlot`) and the guardian watcher (`validatorAtSlot` +
+  `proposalSignersCommitment`) each statically exercise the exact methods they
+  call at runtime, so a wrong-but-deployed address fails-closed at startup
+  instead of fail-open per tick. New `BlockchainService.getChainId()` /
+  `probeBlsAggregator()`.
+- `.gitignore`: `guardian-operators.json` (production guardian EOA keys).
+
+### Notes
+
+- Codex Tier-1: 5 rounds, final verdict CLEAN (0 Critical/High/Medium/Low). One
+  Medium (a hard canonical-identity address/codehash pin) deferred with
+  rationale — it would false-disable on legitimate SP aggregator redeploys; the
+  silent-default footgun this patch closes is the real issue.
+- docs `cc89-e2e-record.md`: distinguishes the E2E throwaway aggregator from
+  production.
+
 ## [1.13.0] — 2026-08-15 — CC-89 stage-2: over-issue guardian-collusion slash (testnet-E2E proven)
 
 Production release. Adds the DVT half of the CC-89 guardian-collusion slashing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yetanotheraa-validator",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yetanotheraa-validator",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "license": "MIT",
       "dependencies": {
         "@nestjs/common": "^11.1.27",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yetanotheraa-validator",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Production-ready BLS signature validation infrastructure for ERC-4337 account abstraction",
   "main": "dist/main.js",
   "type": "module",


### PR DESCRIPTION
Release **v1.13.1** — the CC-89 hardening follow-up merged in #231.

**Backward-compatible patch.** Every touched path is opt-in (offline audit + guardian watcher, both default off) → no default-behaviour change, no breaking change. **SP / SDK / airaccount / paper need no changes**; KMS only updates the watcher env example to `0x174b60bB…` (being notified on CC-90).

Contents (see CHANGELOG [1.13.1]):
- Aggregator default `0xF51c0298` → `0x174b60bB` (SP production A' 4.3.0) — tracks the real rotation shipped with CC-89.
- Shared fail-closed bootstrap guard (chain mismatch + off-Sepolia-explicit) + per-consumer interface probe, so a wrong/stale/off-chain aggregator fails-closed at startup, not fail-open per tick.

Code was Codex Tier-1 reviewed across 5 rounds (final CLEAN) and merged as #231. This PR is bump + CHANGELOG only. Tag v1.13.1 + GH release follow after merge.

Refs: CC-89, CC-90.