### PR TITLE
feat(CC-98): production per-proposal committee BLS validator

### DIFF
--- a/contracts/src/AAStarCommitteeValidator.sol
+++ b/contracts/src/AAStarCommitteeValidator.sol
@@ -94,11 +94,13 @@ contract AAStarCommitteeValidator is AAStarValidator {
     uint256[] public freeSlots;
     /// @dev Count of currently active leaves (slots occupied). Feeds the m_e curve.
     uint256 public activeCount;
-    /// @dev Block of the most recent set mutation (activate/deactivate). snapshotEpoch requires this to
-    ///      be strictly in the past, so a keeper cannot atomically evict nodes (syncNode is permissionless
-    ///      and owner-free) and freeze the shrunken count in the SAME tx to depress m/quorum (pr-daemon
-    ///      Medium — this manipulation feeds the B1 forgery budget).
+    /// @dev Block of the current block's first set mutation, plus the root/count captured just BEFORE it.
+    ///      snapshotEpoch freezes these block-start values when the set was mutated in its own block, so a
+    ///      permissionless syncNode eviction cannot be atomically composed with the freeze to depress
+    ///      epochSetCount — without snapshotEpoch reverting (pr-daemon round-2 High). See _latchBlockStart.
     uint256 public lastSetMutationBlock;
+    bytes32 public rootAtBlockStart;
+    uint256 public countAtBlockStart;
 
     /// @dev SMT internal nodes: node[level][index]. Level 0 = leaves (leaf = nodeId, or 0 if empty).
     ///      Unset entries read as the empty-subtree hash `zeros[level]`.
@@ -149,12 +151,12 @@ contract AAStarCommitteeValidator is AAStarValidator {
             zeros[i + 1] = keccak256(abi.encode(zeros[i], zeros[i]));
         }
         runningRoot = zeros[TREE_DEPTH];
-        // oversample = 1.0: DSR's B1 security calc assumes E[committee] = m_e (λ = β*m_e). Any value > 1
-        // inflates the attacker's expected selections and breaks the N>=430 β=1/3 guarantee, so the
-        // default matches the security model exactly. setOversample can raise it (trading the DSR margin
-        // for honest-liveness headroom) but that is an explicit, configVersion-bumping deviation.
-        oversampleNum = 1;
-        oversampleDen = 1;
+        // oversample = 1.25 (pr-daemon B5): raises E[committee] to 1.25*m_e so the actual committee clears
+        // requiredQuorum with margin (liveness tail <=1.65e-4), while floor 30's forgery headroom keeps
+        // P(forge) <= ~4.4e-9 @ β=10%. This is the two-tail operating point; it gives up the old β=1/3
+        // "free gift" (out of scope under the β<=10% assumption). Pinned by test_constructor_oversample.
+        oversampleNum = 5;
+        oversampleDen = 4;
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -205,6 +207,7 @@ contract AAStarCommitteeValidator is AAStarValidator {
     function _onNodeActivated(bytes32 nodeId) internal override {
         // base already guaranteed !isRegistered before this; defensively no-op on a double-activate.
         if (slotPlusOne[nodeId] != 0) return;
+        _latchBlockStart();
         uint256 slot;
         uint256 free = freeSlots.length;
         if (free != 0) {
@@ -217,7 +220,6 @@ contract AAStarCommitteeValidator is AAStarValidator {
         }
         slotPlusOne[nodeId] = slot + 1;
         activeCount += 1;
-        lastSetMutationBlock = block.number;
         _smtSet(slot, nodeId);
         emit SlotAssigned(nodeId, slot);
     }
@@ -225,13 +227,27 @@ contract AAStarCommitteeValidator is AAStarValidator {
     function _onNodeDeactivated(bytes32 nodeId) internal override {
         uint256 sp = slotPlusOne[nodeId];
         if (sp == 0) return; // defensive: never activated in committee accounting
+        _latchBlockStart();
         uint256 slot = sp - 1;
         delete slotPlusOne[nodeId];
         freeSlots.push(slot);
         activeCount -= 1;
-        lastSetMutationBlock = block.number;
         _smtSet(slot, bytes32(0));
         emit SlotCleared(nodeId, slot);
+    }
+
+    /// @dev On the FIRST set mutation of a block, capture the pre-mutation (block-start) root + count.
+    ///      snapshotEpoch freezes those when the set was mutated in its own block, so an atomic
+    ///      "evict-then-freeze" cannot depress epochSetCount, WITHOUT snapshotEpoch having to revert
+    ///      (the revert was a zero-capital migration-boundary DoS: setRequireStake(true) makes every
+    ///      bootstrap node permissionlessly syncNode-able, and a forced same-block collision could block
+    ///      pinning for a whole epoch — pr-daemon round-2 High). This keeps snapshotEpoch unconditional.
+    function _latchBlockStart() internal {
+        if (block.number != lastSetMutationBlock) {
+            rootAtBlockStart = runningRoot;
+            countAtBlockStart = activeCount;
+            lastSetMutationBlock = block.number;
+        }
     }
 
     /// @dev Set leaf `slot` to `leaf` and fold the change up to the root: O(TREE_DEPTH) hashes + SSTOREs.
@@ -272,17 +288,19 @@ contract AAStarCommitteeValidator is AAStarValidator {
         require(block.number <= startBlock + 256, "pin window elapsed");
         bytes32 bh = blockhash(startBlock);
         require(bh != bytes32(0), "blockhash unavailable");
-        // No set mutation in THIS block: forces any set change (esp. permissionless syncNode evictions)
-        // to land in an earlier block than the freeze, turning an atomic "evict-then-freeze" depression
-        // of epochSetCount into a race an honest keeper can win (pr-daemon Medium).
-        require(lastSetMutationBlock < block.number, "set mutated this block");
+        // Freeze the block-START set state: if the set was mutated in THIS block, use the pre-mutation
+        // root/count so a permissionless syncNode eviction cannot be atomically composed with the freeze
+        // to depress epochSetCount. Unconditional (no revert) → no forced-collision DoS (round-2 High).
+        bool mutatedThisBlock = lastSetMutationBlock == block.number;
+        bytes32 setRoot = mutatedThisBlock ? rootAtBlockStart : runningRoot;
+        uint256 setCount = mutatedThisBlock ? countAtBlockStart : activeCount;
 
         epochSeed[e] = bh;
-        epochSetRoot[e] = runningRoot;
-        epochSetCount[e] = activeCount;
+        epochSetRoot[e] = setRoot;
+        epochSetCount[e] = setCount;
         epochConfigVersion[e] = configVersion;
         epochPinned[e] = true;
-        emit EpochSnapshotted(e, bh, runningRoot, activeCount);
+        emit EpochSnapshotted(e, bh, setRoot, setCount);
     }
 
     function currentEpoch() public view returns (uint256) {
@@ -306,7 +324,10 @@ contract AAStarCommitteeValidator is AAStarValidator {
         emit AccountEnrolled(msg.sender);
     }
 
-    /// @notice Un-enroll the caller (e.g. before migrating away). Only the account itself can.
+    /// @notice Un-enroll the caller. Only the account itself can. WARNING: while this validator is the
+    ///         mounted one and committee mode is on, an account has to pass validate() to send ANY tx, and
+    ///         validate() requires enrollment — so unenrolling first is self-bricking. Un-enroll only
+    ///         AFTER unmounting this validator (or via owner disabling committee mode).
     function unenroll() external {
         enrolledAccount[msg.sender] = false;
         emit AccountUnenrolled(msg.sender);
@@ -318,20 +339,26 @@ contract AAStarCommitteeValidator is AAStarValidator {
 
     /// @dev DSR expected-committee curve over committed pool size n:
     ///      n ≤ 8 → whole set (bootstrap); else m_e = min(110, max(16, n/5)).
-    ///      DSR-locked curve (CC-98 comment 9a9f47c9, Jason-adjudicated target): m_e(N) = N for N<=8
-    ///      (bootstrap whole set); else clamp(ceil(N/5), 17, 86). Security target: forgery probability
-    ///      ε = P(Poisson(β*m_e) >= ceil(2*m_e/3)) <= 1e-6 per (account, epoch) under the explicit
-    ///      assumption β <= 10% malicious stake. floor 17 hits ε=2.6e-7 @ β=10% (floor 16 was 1.02e-6,
-    ///      just over); cap 86 is the β=1/3 1e-6 point, so pools of N>=430 meet 1e-6 even at worst-case
-    ///      β=1/3 for free. This methodology REQUIRES E[committee] = m_e, i.e. oversample = 1.0 (see the
-    ///      constructor) — any oversample > 1 inflates λ and breaks the N>=430 worst-case guarantee.
-    ///      CAPPED AT n keeps requiredQuorum = ceil(2*m_e/3) <= n for the 9..16 bootstrap band (where the
-    ///      floor 17 would otherwise exceed the pool); airaccount gates committee mode on N >= N0 to keep
-    ///      such small pools off the sampling path (bootstrap-cliff avoidance).
+    ///      Curve: m_e(N) = N for N<=8 (bootstrap whole set); else clamp(ceil(N/5), 30, 86).
+    ///
+    ///      TWO tails must both hold (pr-daemon round-2 B5 — B1's original single-tail floor-17/o-1.0
+    ///      curve left a 6.3% honest-liveness failure). With committee K ~ Binom(n, oversample*m_e/n) and
+    ///      requiredQuorum = ceil(2*m_e/3):
+    ///        - forgery : P(Poisson(β*oversample*m_e) >= requiredQuorum) <= 1e-6, β <= 10% (unchanged).
+    ///        - liveness: P(K < requiredQuorum) <= 1e-3 (LOOSER target, Jason-adjudicated) — a liveness
+    ///          miss is a retryable one-epoch stall (seed re-draws each epoch: two-in-a-row ~5.9e-7),
+    ///          not fund loss, so it is not held to the 1e-6 forgery bar.
+    ///      floor 30 (up from 17) gives the forgery tail enough headroom (~4.4e-9 @ β=10% in the sampling
+    ///      regime) to afford oversample = 1.25 (see constructor), which pulls the liveness tail to
+    ///      <=1.65e-4 (100% online) / <=5.9e-4 (95% online) — verified by an exact Binom/Poisson scan over
+    ///      n in [9,20000]. floor 17 could NOT afford any oversample (its forgery tail was 4.6e-7, razor
+    ///      thin). Cost: requiredQuorum in [20,58], ~10KB (typical N<=150) to ~29KB (N>=430) calldata/op.
+    ///      CAPPED AT n keeps requiredQuorum <= n in the bootstrap band; airaccount gates committee mode
+    ///      on N >= N0 (>= ~39, where sampling begins) to keep small pools off the sampling path.
     function expectedCommittee(uint256 n) public pure returns (uint256) {
         if (n <= 8) return n;
         uint256 m = (n + 4) / 5; // ceil(n/5)
-        if (m < 17) m = 17;
+        if (m < 30) m = 30;
         if (m > 86) m = 86;
         if (m > n) m = n; // never sample more than the pool
         return m;

--- a/contracts/src/AAStarCommitteeValidator.sol
+++ b/contracts/src/AAStarCommitteeValidator.sol
@@ -131,12 +131,13 @@ contract AAStarCommitteeValidator is AAStarValidator {
     /// @dev Accounts that have self-enrolled for committee validation. validate() fails closed unless the
     ///      injected accountId maps to an enrolled account. This is DEFENSE-IN-DEPTH for the accountId
     ///      trust (pr-daemon B2, agreed with airaccount f444db89): the MANDATORY fix is the account
-    ///      injecting address(this), but enrollment (a) blocks the flip-order shape collision — a
-    ///      legacy-shaped payload's fabricated accountId prefix maps to a non-enrolled address → reject
-    ///      — and (b) turns a FREE offline grind over 2^256 accountIds into a gas-metered grind over
-    ///      addresses the attacker had to enroll (enroll self-proves via msg.sender). It does NOT
-    ///      replace injection: an attacker can still enroll its own accounts, so accountId==address(this)
-    ///      at the account remains the primary guarantee.
+    ///      injecting address(this). Enrollment blocks the flip-order shape collision — a legacy-shaped
+    ///      payload's fabricated accountId maps to a non-enrolled address → reject. Combined with the
+    ///      canonical-accountId check in validate() (high 96 bits must be zero, pr-daemon B4), the value
+    ///      the gate reads (low 160) equals the value the draw consumes (all 256), so an enrolled
+    ///      address's committee cannot be shifted by grinding unused bits. It does NOT replace injection:
+    ///      an attacker can still enroll its own accounts, so accountId==address(this) at the account
+    ///      remains the primary guarantee.
     mapping(address => bool) public enrolledAccount;
 
     event AccountEnrolled(address indexed account);
@@ -407,9 +408,15 @@ contract AAStarCommitteeValidator is AAStarValidator {
         uint256 T = _thresholdOf(committedCount, m);
 
         bytes32 accountId = bytes32(signature[0:32]);
+        // accountId MUST be the canonical zero-extension of a 160-bit address. The enrollment gate below
+        // reads the low 160 bits, but the sortition draw consumes all 256 — so a set high bit is a free
+        // offline grind surface on committee membership (pr-daemon B4). Reject non-canonical, symmetric
+        // to the canonical-slot check below. (The account injecting address(this) always has zero high
+        // bits, so this never rejects an honest op.)
+        if (uint256(accountId) >> 160 != 0) return 1;
         // Defense-in-depth for the account-injected accountId (pr-daemon B2): the account must have
-        // self-enrolled. A flip-order legacy-shaped payload whose fabricated accountId prefix maps to a
-        // non-enrolled address fails closed here, and grinding accountId now costs an enroll tx per try.
+        // self-enrolled. A flip-order legacy-shaped payload whose fabricated accountId maps to a
+        // non-enrolled address fails closed here.
         if (!enrolledAccount[address(uint160(uint256(accountId)))]) return 1;
 
         bytes32[] memory nodeIds = new bytes32[](k);

--- a/contracts/src/AAStarCommitteeValidator.sol
+++ b/contracts/src/AAStarCommitteeValidator.sol
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.19;
+
+import "./AAStarValidator.sol";
+
+/// @title AAStarCommitteeValidator — CC-98 per-proposal random-committee BLS validator (production)
+/// @notice Replaces CC-97's global ⌈2N/3⌉ (which does not scale: registry unbounded ⇒ quorum exceeds
+///         the single-call node cap ⇒ network-wide fail-close). Each operation is validated against a
+///         PER-PROPOSAL committee the submitter cannot choose:
+///
+///           node ∈ committee(account A, epoch e)  ⟺  H("CMT_SELECT", seed[e], A, nodeId) < T
+///
+///         Security rests on THREE inputs, each un-choosable by the submitter:
+///           1. seed[e]     = blockhash(firstBlockOf(e)), pinned by a permissionless keeper.
+///           2. the SET     the node must belong to is committed by an on-chain incremental Merkle root
+///                          FROZEN ONE EPOCH AHEAD of the seed reveal (look-ahead) — see below.
+///           3. accountId A = the account injects address(this); never taken from submitter calldata.
+///
+///         LOOK-AHEAD (the register-to-order fix, dvt CC-98 comment 7322c647): a committee used DURING
+///         epoch e samples over setRoot[e-1] (frozen while e-1 was current, strictly BEFORE seed[e]
+///         became knowable) with seed[e] (revealed at the start of e). An attacker cannot grind a
+///         pubkey → nodeId into a victim's committee: during e-1 they don't know seed[e]; during e the
+///         set is already frozen. This reduces the attack to holding a β-fraction of ALL stake (the
+///         honest-majority assumption the DSR tail bound is built on).
+///
+///         Per signer, validate() does zero extra pairings: a Merkle proof that nodeId ∈ setRoot[e-1]
+///         (O(depth) keccak) + the sortition inequality (1 keccak) + the existing registration/stake
+///         gate, then the SAME aggregate BLS verify as the base contract. Committee membership is NOT
+///         transmitted; it is recomputed. Threshold ⌈2·m_e/3⌉ is computed by the validator (never
+///         accepted from calldata), m_e follows the DSR curve over the committed node count.
+///
+///         Wire format of `signature` (the account prepends accountId; the submitter provides the rest):
+///           [ accountId(32) ] [ per signer: nodeId(32) ‖ merkleProof(TREE_DEPTH×32) ]... [ blsSig(256) ]
+contract AAStarCommitteeValidator is AAStarValidator {
+    // Base declares these as private constants; re-declare the two lengths the committee path needs.
+    uint256 private constant G1_LEN = 128;
+    uint256 private constant G2_LEN = 256;
+    /// @dev Mirrors the base's private MAX_NODE_COUNT: upper bound on signers parsed in one validate().
+    uint256 private constant MAX_NODE_COUNT = 100;
+
+    /// @dev Sortition domain separator (DSR: distinct keccak domain, disjoint from any BLS DST).
+    bytes32 private constant CMT_DOMAIN = keccak256("CMT_SELECT");
+
+    /// @dev Incremental sparse-Merkle-tree depth over slot indices. 2^14 = 16,384 concurrent nodes.
+    ///      Slots are reused on deactivation (free list), so this bounds CONCURRENT nodes, not lifetime.
+    uint256 public constant TREE_DEPTH = 14;
+
+    // ---------------------------------------------------------------------------------------------
+    //                          COMMITTEE / EPOCH CONFIGURATION (owner-set)
+    // ---------------------------------------------------------------------------------------------
+
+    /// @dev Blocks per epoch. 0 ⇒ committee mode OFF (validate() falls back to the base whole-set path).
+    uint256 public epochLength;
+    /// @dev Oversampling numerator/denominator applied to the expected committee size m_e when deriving
+    ///      the sortition threshold T (DSR: E[selected] ≈ 1.15·m_e buys liveness margin). Default 115/100.
+    uint256 public oversampleNum;
+    uint256 public oversampleDen;
+
+    event EpochSnapshotted(uint256 indexed epoch, bytes32 seed, bytes32 setRoot, uint256 setCount);
+    event EpochLengthSet(uint256 epochLength);
+    event OversampleSet(uint256 num, uint256 den);
+
+    // ---------------------------------------------------------------------------------------------
+    //                          INCREMENTAL SPARSE MERKLE TREE (active-set commitment)
+    // ---------------------------------------------------------------------------------------------
+
+    /// @dev nodeId → (slot + 1). 0 means "no slot" (unregistered). Stored +1 so slot 0 is representable.
+    mapping(bytes32 => uint256) public slotPlusOne;
+    /// @dev Monotonic slot allocator; `freeSlots` recycles slots freed on deactivation to stay compact.
+    uint256 public nextSlot;
+    uint256[] public freeSlots;
+    /// @dev Count of currently active leaves (slots occupied). Feeds the m_e curve.
+    uint256 public activeCount;
+
+    /// @dev SMT internal nodes: node[level][index]. Level 0 = leaves (leaf = nodeId, or 0 if empty).
+    ///      Unset entries read as the empty-subtree hash `zeros[level]`.
+    mapping(uint256 => mapping(uint256 => bytes32)) internal smt;
+    /// @dev Precomputed empty-subtree hashes per level (zeros[0]=0, zeros[l]=H(zeros[l-1],zeros[l-1])).
+    bytes32[TREE_DEPTH + 1] public zeros;
+    /// @dev Current Merkle root of the active set (level TREE_DEPTH). Updated O(depth) per mutation.
+    bytes32 public runningRoot;
+
+    // ---------------------------------------------------------------------------------------------
+    //                          PER-EPOCH SNAPSHOTS (double-snapshot, look-ahead)
+    // ---------------------------------------------------------------------------------------------
+
+    /// @dev epoch → pinned seed = blockhash(firstBlockOf(epoch)). Used by committees DURING this epoch.
+    mapping(uint256 => bytes32) public epochSeed;
+    /// @dev epoch → active-set Merkle root frozen while this epoch was current. Used by committees
+    ///      DURING epoch+1 (the look-ahead: set frozen strictly before the next seed is revealed).
+    mapping(uint256 => bytes32) public epochSetRoot;
+    /// @dev epoch → active node count at the freeze. Feeds requiredQuorum for epoch+1.
+    mapping(uint256 => uint256) public epochSetCount;
+    /// @dev epoch → whether snapshotEpoch() has run for it (both seed and setRoot are then final).
+    mapping(uint256 => bool) public epochPinned;
+
+    constructor() AAStarValidator() {
+        // Empty-subtree hashes + empty-tree root.
+        for (uint256 i = 0; i < TREE_DEPTH; i++) {
+            zeros[i + 1] = keccak256(abi.encode(zeros[i], zeros[i]));
+        }
+        runningRoot = zeros[TREE_DEPTH];
+        oversampleNum = 115;
+        oversampleDen = 100;
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    //                          ADMIN
+    // ---------------------------------------------------------------------------------------------
+
+    function setEpochLength(uint256 _epochLength) external onlyOwner {
+        epochLength = _epochLength;
+        emit EpochLengthSet(_epochLength);
+    }
+
+    function setOversample(uint256 num, uint256 den) external onlyOwner {
+        require(den != 0 && num >= den, "oversample must be >= 1");
+        oversampleNum = num;
+        oversampleDen = den;
+        emit OversampleSet(num, den);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    //                          SET-MUTATION HOOKS (maintain the SMT in lock-step with isRegistered[])
+    // ---------------------------------------------------------------------------------------------
+
+    function _onNodeActivated(bytes32 nodeId) internal override {
+        // base already guaranteed !isRegistered before this; defensively no-op on a double-activate.
+        if (slotPlusOne[nodeId] != 0) return;
+        uint256 slot;
+        uint256 free = freeSlots.length;
+        if (free != 0) {
+            slot = freeSlots[free - 1];
+            freeSlots.pop();
+        } else {
+            slot = nextSlot;
+            require(slot < (1 << TREE_DEPTH), "committee tree full");
+            nextSlot = slot + 1;
+        }
+        slotPlusOne[nodeId] = slot + 1;
+        activeCount += 1;
+        _smtSet(slot, nodeId);
+    }
+
+    function _onNodeDeactivated(bytes32 nodeId) internal override {
+        uint256 sp = slotPlusOne[nodeId];
+        if (sp == 0) return; // defensive: never activated in committee accounting
+        uint256 slot = sp - 1;
+        delete slotPlusOne[nodeId];
+        freeSlots.push(slot);
+        activeCount -= 1;
+        _smtSet(slot, bytes32(0));
+    }
+
+    /// @dev Set leaf `slot` to `leaf` and fold the change up to the root: O(TREE_DEPTH) hashes + SSTOREs.
+    function _smtSet(uint256 slot, bytes32 leaf) internal {
+        uint256 idx = slot;
+        smt[0][idx] = leaf;
+        bytes32 cur = leaf;
+        for (uint256 level = 0; level < TREE_DEPTH; level++) {
+            uint256 sibIdx = idx ^ 1;
+            bytes32 sib = smt[level][sibIdx];
+            if (sib == bytes32(0)) sib = zeros[level]; // unset ⇒ empty subtree
+            cur = (idx & 1) == 0 ? keccak256(abi.encode(cur, sib)) : keccak256(abi.encode(sib, cur));
+            idx >>= 1;
+            smt[level + 1][idx] = cur;
+        }
+        runningRoot = cur;
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    //                          EPOCH SNAPSHOT (permissionless keeper)
+    // ---------------------------------------------------------------------------------------------
+
+    /// @notice Pin epoch `e`: seed[e] = blockhash(firstBlockOf(e)) (used by committees during e) and
+    ///         setRoot[e] = current active-set root (used by committees during e+1). Callable by anyone
+    ///         within the 256-block window after the epoch's first block (blockhash availability), once.
+    /// @dev The seed source is a FIXED past block (the epoch's first block), so no caller can grind it by
+    ///      choosing when to call — only the block proposer has the standard bounded ~1-bit RANDAO bias.
+    function snapshotEpoch() external {
+        require(epochLength != 0, "committee mode off");
+        uint256 e = block.number / epochLength;
+        require(!epochPinned[e], "epoch already pinned");
+        uint256 startBlock = e * epochLength;
+        require(block.number > startBlock, "wait for epoch start block");
+        require(block.number <= startBlock + 256, "pin window elapsed");
+        bytes32 bh = blockhash(startBlock);
+        require(bh != bytes32(0), "blockhash unavailable");
+
+        epochSeed[e] = bh;
+        epochSetRoot[e] = runningRoot;
+        epochSetCount[e] = activeCount;
+        epochPinned[e] = true;
+        emit EpochSnapshotted(e, bh, runningRoot, activeCount);
+    }
+
+    function currentEpoch() public view returns (uint256) {
+        require(epochLength != 0, "committee mode off");
+        return block.number / epochLength;
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    //                          COMMITTEE MATH (m_e curve + threshold)
+    // ---------------------------------------------------------------------------------------------
+
+    /// @dev DSR expected-committee curve over committed pool size n:
+    ///      n ≤ 8 → whole set (bootstrap); else m_e = min(110, max(16, n/5)).
+    ///      CAPPED AT n: the expected committee can never exceed the pool. Without this, a pool of
+    ///      9..15 nodes gets m_e = 16 (the floor) and requiredQuorum = ceil(2*16/3) = 11 > n, making
+    ///      every op unsatisfiable (liveness DoS). Capping degrades such pools to the whole set, so
+    ///      requiredQuorum = ceil(2n/3) <= n always holds.
+    function expectedCommittee(uint256 n) public pure returns (uint256) {
+        if (n <= 8) return n;
+        uint256 m = n / 5;
+        if (m < 16) m = 16;
+        if (m > 110) m = 110;
+        if (m > n) m = n; // never sample more than the pool
+        return m;
+    }
+
+    /// @dev ⌈2·m/3⌉ with m ≥ 1 (base of the whole scheme). Division-free ceil.
+    function _quorumOf(uint256 m) internal pure returns (uint256) {
+        return (2 * m + 2) / 3;
+    }
+
+    /// @dev Sortition threshold T for pool n, expected committee m: a node is selected iff its 256-bit
+    ///      draw < T. Target selection probability = oversample·m/n, capped at "whole set" (T = max).
+    function _thresholdOf(uint256 n, uint256 m) internal view returns (uint256) {
+        if (n == 0) return 0;
+        uint256 target = (oversampleNum * m + oversampleDen - 1) / oversampleDen; // ceil(over·m)
+        if (target >= n) return type(uint256).max; // whole set (bootstrap / tiny pool)
+        return (type(uint256).max / n) * target;
+    }
+
+    /// @notice Required signer count ⌈2·m_e/3⌉ for committees active in `e`, i.e. over setRoot[e-1].
+    ///         Returns type(uint256).max when the prerequisite snapshot is missing (nothing can satisfy
+    ///         it — the account's mirror check then fails closed too).
+    function requiredQuorum() public view returns (uint256) {
+        uint256 e = currentEpoch();
+        if (e == 0 || !epochPinned[e - 1]) return type(uint256).max;
+        uint256 m = expectedCommittee(epochSetCount[e - 1]);
+        return _quorumOf(m);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    //                          VALIDATE (committee path; overrides the base whole-set path)
+    // ---------------------------------------------------------------------------------------------
+
+    function validate(bytes32 hash, bytes calldata signature) external view override returns (uint256) {
+        // Committee mode disabled → behave exactly like the base contract (whole-set aggregate verify).
+        if (epochLength == 0) return _validateWholeSet(hash, signature);
+
+        uint256 e = block.number / epochLength;
+        // Need seed[e] (this epoch) and setRoot[e-1] (frozen last epoch, the look-ahead set). Fail-closed
+        // if either is missing: the permissionless keeper must snapshot each epoch inside its window.
+        if (e == 0 || !epochPinned[e] || !epochPinned[e - 1]) return 1;
+        bytes32 seed = epochSeed[e];
+        bytes32 setRoot = epochSetRoot[e - 1];
+        uint256 committedCount = epochSetCount[e - 1];
+
+        // ---- parse layout: accountId(32) ‖ k×(nodeId(32) ‖ proof(TREE_DEPTH*32)) ‖ blsSig(256) ----
+        uint256 perSigner = 32 + TREE_DEPTH * 32;
+        if (signature.length < 32 + G2_LEN) return 1;
+        uint256 body = signature.length - 32 - G2_LEN;
+        if (body == 0 || body % perSigner != 0) return 1;
+        uint256 k = body / perSigner;
+        if (k > MAX_NODE_COUNT) return 1; // gas-griefing bound (shared with the base cap)
+
+        // requiredQuorum for THIS epoch (over the look-ahead set).
+        uint256 m = expectedCommittee(committedCount);
+        uint256 required = _quorumOf(m);
+        if (k < required) return 1;
+        uint256 T = _thresholdOf(committedCount, m);
+
+        bytes32 accountId = bytes32(signature[0:32]);
+
+        bytes32[] memory nodeIds = new bytes32[](k);
+        bytes32 prevId = bytes32(0);
+        uint256 off = 32;
+        for (uint256 i = 0; i < k; i++) {
+            bytes32 nid = bytes32(signature[off:off + 32]);
+            off += 32;
+            // Distinct, strictly-increasing signers (blocks self-repetition inflating the aggregate).
+            if (i != 0 && nid <= prevId) return 1;
+            prevId = nid;
+            // Still-active + economically backed (rejects retired bootstrap in staked mode).
+            if (!isRegistered[nid]) return 1;
+            if (requireStake && isBootstrap[nid]) return 1;
+            // (a) Membership in the look-ahead set: Merkle proof at the node's slot against setRoot[e-1].
+            uint256 sp = slotPlusOne[nid];
+            if (sp == 0) return 1;
+            if (!_verifyMerkle(setRoot, sp - 1, nid, signature[off:off + TREE_DEPTH * 32])) return 1;
+            off += TREE_DEPTH * 32;
+            // (b) Sortition: the committee membership the submitter cannot choose. When T == max the
+            //     pool degrades to the whole set (bootstrap/tiny pool) — skip the draw so membership is
+            //     truly universal (a draw == max, prob 2^-256, must not spuriously exclude a node).
+            if (T != type(uint256).max) {
+                uint256 draw = uint256(keccak256(abi.encode(CMT_DOMAIN, seed, accountId, nid)));
+                if (draw >= T) return 1;
+            }
+            nodeIds[i] = nid;
+        }
+
+        bytes calldata blsSignature = signature[off:off + G2_LEN];
+        if (_isG2InfinityCalldata(blsSignature)) return 1;
+
+        bytes memory messagePoint = _hashToG2(hash);
+        if (_isG2InfinityMemory(messagePoint)) return 1;
+
+        bytes memory blsSigMem = blsSignature;
+        bool valid = _validateBLSSignatureMem(nodeIds, blsSigMem, messagePoint);
+        return valid ? 0 : 1;
+    }
+
+    /// @dev The base whole-set parse+verify, inlined for the epochLength==0 fallback. Kept byte-identical
+    ///      to AAStarValidator.validate() so mounting this contract with committee mode off is a no-op
+    ///      change vs. the legacy validator.
+    function _validateWholeSet(bytes32 hash, bytes calldata signature) internal view returns (uint256) {
+        if (signature.length <= G2_LEN) return 1;
+        uint256 nodeIdsBytes = signature.length - G2_LEN;
+        if (nodeIdsBytes == 0 || nodeIdsBytes % 32 != 0) return 1;
+        uint256 nodeCount = nodeIdsBytes / 32;
+        if (nodeCount > MAX_NODE_COUNT) return 1;
+
+        bytes32[] memory nodeIds = new bytes32[](nodeCount);
+        bytes32 prevId = bytes32(0);
+        for (uint256 i = 0; i < nodeCount; i++) {
+            bytes32 nid = bytes32(signature[i * 32:(i + 1) * 32]);
+            if (i != 0 && nid <= prevId) return 1;
+            prevId = nid;
+            if (!isRegistered[nid]) return 1;
+            if (requireStake && isBootstrap[nid]) return 1;
+            nodeIds[i] = nid;
+        }
+        bytes calldata blsSignature = signature[nodeIdsBytes:nodeIdsBytes + G2_LEN];
+        if (_isG2InfinityCalldata(blsSignature)) return 1;
+        bytes memory messagePoint = _hashToG2(hash);
+        if (_isG2InfinityMemory(messagePoint)) return 1;
+        bytes memory blsSigMem = blsSignature;
+        return _validateBLSSignatureMem(nodeIds, blsSigMem, messagePoint) ? 0 : 1;
+    }
+
+    /// @notice Build a Merkle proof for `nodeId` against the CURRENT active-set root. Convenience view
+    ///         for off-chain aggregators (and tests). NOTE: production proofs must target the FROZEN
+    ///         setRoot[e-1]; this returns a current-state proof, valid only while the set is unchanged
+    ///         since that snapshot (aggregators otherwise reconstruct the frozen tree from events).
+    /// @return slot The node's leaf slot. @return proof TREE_DEPTH sibling hashes (leaf→root order).
+    function getMerkleProof(bytes32 nodeId) external view returns (uint256 slot, bytes32[] memory proof) {
+        uint256 sp = slotPlusOne[nodeId];
+        require(sp != 0, "node not active");
+        slot = sp - 1;
+        proof = new bytes32[](TREE_DEPTH);
+        uint256 idx = slot;
+        for (uint256 level = 0; level < TREE_DEPTH; level++) {
+            bytes32 sib = smt[level][idx ^ 1];
+            proof[level] = sib == bytes32(0) ? zeros[level] : sib;
+            idx >>= 1;
+        }
+    }
+
+    /// @dev Verify a fixed-depth Merkle proof: fold `leaf` at position `slot` up through `proof`
+    ///      (TREE_DEPTH sibling words) and compare to `root`. Bit i of `slot` selects left/right.
+    function _verifyMerkle(
+        bytes32 root,
+        uint256 slot,
+        bytes32 leaf,
+        bytes calldata proof
+    ) internal pure returns (bool) {
+        if (proof.length != TREE_DEPTH * 32) return false;
+        bytes32 cur = leaf;
+        uint256 idx = slot;
+        for (uint256 level = 0; level < TREE_DEPTH; level++) {
+            bytes32 sib = bytes32(proof[level * 32:level * 32 + 32]);
+            cur = (idx & 1) == 0 ? keccak256(abi.encode(cur, sib)) : keccak256(abi.encode(sib, cur));
+            idx >>= 1;
+        }
+        return cur == root;
+    }
+}

--- a/contracts/src/AAStarCommitteeValidator.sol
+++ b/contracts/src/AAStarCommitteeValidator.sol
@@ -128,6 +128,20 @@ contract AAStarCommitteeValidator is AAStarValidator {
     /// @dev Bumped on every epochLength change; namespaces all epoch snapshots to their schedule.
     uint256 public configVersion;
 
+    /// @dev Accounts that have self-enrolled for committee validation. validate() fails closed unless the
+    ///      injected accountId maps to an enrolled account. This is DEFENSE-IN-DEPTH for the accountId
+    ///      trust (pr-daemon B2, agreed with airaccount f444db89): the MANDATORY fix is the account
+    ///      injecting address(this), but enrollment (a) blocks the flip-order shape collision — a
+    ///      legacy-shaped payload's fabricated accountId prefix maps to a non-enrolled address → reject
+    ///      — and (b) turns a FREE offline grind over 2^256 accountIds into a gas-metered grind over
+    ///      addresses the attacker had to enroll (enroll self-proves via msg.sender). It does NOT
+    ///      replace injection: an attacker can still enroll its own accounts, so accountId==address(this)
+    ///      at the account remains the primary guarantee.
+    mapping(address => bool) public enrolledAccount;
+
+    event AccountEnrolled(address indexed account);
+    event AccountUnenrolled(address indexed account);
+
     constructor() AAStarValidator() {
         // Empty-subtree hashes + empty-tree root.
         for (uint256 i = 0; i < TREE_DEPTH; i++) {
@@ -150,6 +164,12 @@ contract AAStarCommitteeValidator is AAStarValidator {
     ///      blocks (blockhash availability vs epoch span), so epochLength == 1 is unpinnable and tiny
     ///      values leave a window too small for a keeper; 64 keeps a usable window (pr-daemon Low).
     ///      Bumps configVersion so snapshots taken under a previous schedule are not reused (Codex Low).
+    ///      MIGRATION INTERLOCK (pr-daemon B2, airaccount f444db89): committee mode MUST NOT be enabled
+    ///      before the accountId-injecting v0.30.0 accounts are deployed, mounted, and (defense-in-depth)
+    ///      enrolled. Flipping this on early would fail-close honest legacy traffic while an attacker's
+    ///      legacy-shaped payload parses as a committee op — but enrollment blocks that path on-chain
+    ///      (non-enrolled accountId => reject), so the residual is an owner/Safe process ordering:
+    ///      deploy+mount+enroll accounts first, THEN setEpochLength.
     function setEpochLength(uint256 _epochLength) external onlyOwner {
         require(_epochLength == 0 || _epochLength >= 64, "epochLength must be 0 or >= 64");
         epochLength = _epochLength;
@@ -265,6 +285,28 @@ contract AAStarCommitteeValidator is AAStarValidator {
         return block.number / epochLength;
     }
 
+    /// @notice Whether committee mode is active. The ACCOUNT reads this to choose its signature framing
+    ///         (inject accountId + committee layout) rather than guessing from the payload shape — the
+    ///         shape-collision root of the flip-order attack (pr-daemon B2, airaccount f444db89). Same
+    ///         validator state drives both the validator's parse and the account's framing → no desync.
+    function committeeActive() external view returns (bool) {
+        return epochLength != 0;
+    }
+
+    /// @notice Self-enroll the caller for committee validation. msg.sender IS the account, so enrollment
+    ///         is self-proving — no trusted external input. Required before an account's committee ops
+    ///         validate (defense-in-depth for accountId; see enrolledAccount).
+    function enroll() external {
+        enrolledAccount[msg.sender] = true;
+        emit AccountEnrolled(msg.sender);
+    }
+
+    /// @notice Un-enroll the caller (e.g. before migrating away). Only the account itself can.
+    function unenroll() external {
+        enrolledAccount[msg.sender] = false;
+        emit AccountUnenrolled(msg.sender);
+    }
+
     // ---------------------------------------------------------------------------------------------
     //                          COMMITTEE MATH (m_e curve + threshold)
     // ---------------------------------------------------------------------------------------------
@@ -355,6 +397,10 @@ contract AAStarCommitteeValidator is AAStarValidator {
         uint256 T = _thresholdOf(committedCount, m);
 
         bytes32 accountId = bytes32(signature[0:32]);
+        // Defense-in-depth for the account-injected accountId (pr-daemon B2): the account must have
+        // self-enrolled. A flip-order legacy-shaped payload whose fabricated accountId prefix maps to a
+        // non-enrolled address fails closed here, and grinding accountId now costs an enroll tx per try.
+        if (!enrolledAccount[address(uint160(uint256(accountId)))]) return 1;
 
         bytes32[] memory nodeIds = new bytes32[](k);
         bytes32 prevId = bytes32(0);

--- a/contracts/src/AAStarCommitteeValidator.sol
+++ b/contracts/src/AAStarCommitteeValidator.sol
@@ -70,8 +70,9 @@ contract AAStarCommitteeValidator is AAStarValidator {
 
     /// @dev Blocks per epoch. 0 ⇒ committee mode OFF (validate() falls back to the base whole-set path).
     uint256 public epochLength;
-    /// @dev Oversampling numerator/denominator applied to the expected committee size m_e when deriving
-    ///      the sortition threshold T (DSR: E[selected] ≈ 1.15·m_e buys liveness margin). Default 115/100.
+    /// @dev Oversampling numerator/denominator applied to m_e when deriving the sortition threshold T:
+    ///      E[committee] = oversample·m_e, which pulls the liveness tail below its 1e-3 target. Default
+    ///      5/4 = 1.25 (pr-daemon B5 two-tail operating point; see the constructor).
     uint256 public oversampleNum;
     uint256 public oversampleDen;
 
@@ -407,32 +408,19 @@ contract AAStarCommitteeValidator is AAStarValidator {
         // Committee mode disabled → behave exactly like the base contract (whole-set aggregate verify).
         if (epochLength == 0) return _validateWholeSet(hash, signature);
 
-        uint256 e = block.number / epochLength;
-        // Need seed[e] (this epoch) and setRoot[e-1] (frozen last epoch, the look-ahead set), both under
-        // the current epoch schedule. Fail-closed if either is missing/stale: the permissionless keeper
-        // must snapshot each epoch inside its window.
-        if (e == 0 || !_epochUsable(e) || !_epochUsable(e - 1)) return 1;
-        bytes32 seed = epochSeed[e];
-        bytes32 setRoot = epochSetRoot[e - 1];
-        uint256 committedCount = epochSetCount[e - 1];
-
-        // ---- parse layout: accountId(32) || k×(nodeId(32) || slot(32) || proof(TREE_DEPTH*32)) || blsSig(256)
-        //      The slot is submitter-provided and authenticated by the Merkle proof against setRoot[e-1]:
-        //      each nodeId sits at exactly one slot in the frozen tree, so a wrong slot cannot verify. This
-        //      binds membership to the node's HISTORICAL slot in the frozen set, so a node whose live slot
-        //      was recycled+reassigned after the snapshot is still provable (Codex Medium: slot-reuse).
-        uint256 perSigner = 64 + TREE_DEPTH * 32;
-        if (signature.length < 32 + G2_LEN) return 1;
-        uint256 body = signature.length - 32 - G2_LEN;
-        if (body == 0 || body % perSigner != 0) return 1;
-        uint256 k = body / perSigner;
-        if (k > MAX_NODE_COUNT) return 1; // gas-griefing bound (shared with the base cap)
-
-        // requiredQuorum for THIS epoch (over the look-ahead set).
-        uint256 m = expectedCommittee(committedCount);
-        uint256 required = _quorumOf(m);
-        if (k < required) return 1;
-        uint256 T = _thresholdOf(committedCount, m);
+        bytes32 seed;
+        bytes32 setRoot;
+        uint256 committedCount;
+        {
+            uint256 e = block.number / epochLength;
+            // Need seed[e] (this epoch) and setRoot[e-1] (frozen last epoch, the look-ahead set), both
+            // under the current epoch schedule. Fail-closed if either is missing/stale (keeper must
+            // snapshot each epoch inside its window).
+            if (e == 0 || !_epochUsable(e) || !_epochUsable(e - 1)) return 1;
+            seed = epochSeed[e];
+            setRoot = epochSetRoot[e - 1];
+            committedCount = epochSetCount[e - 1];
+        }
 
         bytes32 accountId = bytes32(signature[0:32]);
         // accountId MUST be the canonical zero-extension of a 160-bit address. The enrollment gate below
@@ -446,6 +434,60 @@ contract AAStarCommitteeValidator is AAStarValidator {
         // non-enrolled address fails closed here.
         if (!enrolledAccount[address(uint160(uint256(accountId)))]) return 1;
 
+        // ---- parse layout: accountId(32) || k×(nodeId(32) || slot(32) || proof(TREE_DEPTH*32)) || blsSig
+        //      The slot is submitter-provided and authenticated by the Merkle proof against setRoot[e-1];
+        //      a wrong slot cannot verify, so membership binds to the node's HISTORICAL slot (Codex Medium).
+        //      Intermediate parse/quorum locals are block-scoped so validate()'s live stack stays within
+        //      the non-via-IR limit that `forge coverage` compiles under.
+        uint256 k;
+        uint256 T;
+        {
+            uint256 perSigner = 64 + TREE_DEPTH * 32;
+            if (signature.length < 32 + G2_LEN) return 1;
+            uint256 body = signature.length - 32 - G2_LEN;
+            if (body == 0 || body % perSigner != 0) return 1;
+            k = body / perSigner;
+            if (k > MAX_NODE_COUNT) return 1; // gas-griefing bound (shared with the base cap)
+            uint256 m = expectedCommittee(committedCount);
+            if (k < _quorumOf(m)) return 1; // requiredQuorum for THIS epoch (over the look-ahead set)
+            T = _thresholdOf(committedCount, m);
+        }
+
+        // Per-signer membership + sortition is factored into a helper (params packed into a memory struct
+        // = one stack slot) so validate()'s own stack stays within the non-via-IR limit `forge coverage`
+        // compiles under. ok=false means some check failed (fail-closed).
+        (bool ok, bytes32[] memory nodeIds) = _verifyCommitteeSigners(signature, k, _Ctx(seed, setRoot, accountId, T));
+        if (!ok) return 1;
+
+        // blsSig is the trailing G2_LEN bytes: off after k signers is exactly signature.length - G2_LEN.
+        bytes calldata blsSignature = signature[signature.length - G2_LEN:];
+        if (_isG2InfinityCalldata(blsSignature)) return 1;
+
+        bytes memory messagePoint = _hashToG2(hash);
+        if (_isG2InfinityMemory(messagePoint)) return 1;
+
+        bytes memory blsSigMem = blsSignature;
+        return _validateBLSSignatureMem(nodeIds, blsSigMem, messagePoint) ? 0 : 1;
+    }
+
+    /// @dev Parse and verify the k committee signers: canonical slot, strictly-increasing distinct
+    ///      nodeIds, still-registered + staked, Merkle membership in the look-ahead setRoot, and the
+    ///      sortition draw. Returns (true, nodeIds) on full success; (false, []) the moment any check
+    ///      fails. Split out of validate() to keep that frame within the non-via-IR stack limit.
+    /// @dev Committee-verification parameters, packed so the helper takes one memory pointer instead of
+    ///      four stack words (keeps both frames within the non-via-IR limit for `forge coverage`).
+    struct _Ctx {
+        bytes32 seed;
+        bytes32 setRoot;
+        bytes32 accountId;
+        uint256 T;
+    }
+
+    function _verifyCommitteeSigners(bytes calldata signature, uint256 k, _Ctx memory ctx)
+        internal
+        view
+        returns (bool, bytes32[] memory)
+    {
         bytes32[] memory nodeIds = new bytes32[](k);
         bytes32 prevId = bytes32(0);
         uint256 off = 32;
@@ -455,35 +497,28 @@ contract AAStarCommitteeValidator is AAStarValidator {
             off += 64;
             // Canonical slot only: _verifyMerkle folds just the low TREE_DEPTH bits, so slot and
             // slot + q*2^TREE_DEPTH would share a path. Reject non-canonical aliases (Codex round-2 Low).
-            if (slot >= (1 << TREE_DEPTH)) return 1;
+            if (slot >= (1 << TREE_DEPTH)) return (false, nodeIds);
             // Distinct, strictly-increasing signers (blocks self-repetition inflating the aggregate).
-            if (i != 0 && nid <= prevId) return 1;
+            if (i != 0 && nid <= prevId) return (false, nodeIds);
             prevId = nid;
             // Still-active + economically backed (rejects retired bootstrap in staked mode).
-            if (!isRegistered[nid]) return 1;
-            if (requireStake && isBootstrap[nid]) return 1;
+            if (!isRegistered[nid]) return (false, nodeIds);
+            if (requireStake && isBootstrap[nid]) return (false, nodeIds);
             // (a) Membership in the look-ahead set: Merkle proof at the submitted (authenticated) slot.
-            if (!_verifyMerkle(setRoot, slot, nid, signature[off:off + TREE_DEPTH * 32])) return 1;
+            if (!_verifyMerkle(ctx.setRoot, slot, nid, signature[off:off + TREE_DEPTH * 32])) {
+                return (false, nodeIds);
+            }
             off += TREE_DEPTH * 32;
-            // (b) Sortition: the committee membership the submitter cannot choose. When T == max the
-            //     pool degrades to the whole set (bootstrap/tiny pool) — skip the draw so membership is
-            //     truly universal (a draw == max, prob 2^-256, must not spuriously exclude a node).
-            if (T != type(uint256).max) {
-                uint256 draw = uint256(keccak256(abi.encode(CMT_DOMAIN, seed, accountId, nid)));
-                if (draw >= T) return 1;
+            // (b) Sortition: the committee membership the submitter cannot choose. When T == max the pool
+            //     degrades to the whole set — skip the draw so membership is truly universal.
+            if (ctx.T != type(uint256).max) {
+                if (uint256(keccak256(abi.encode(CMT_DOMAIN, ctx.seed, ctx.accountId, nid))) >= ctx.T) {
+                    return (false, nodeIds);
+                }
             }
             nodeIds[i] = nid;
         }
-
-        bytes calldata blsSignature = signature[off:off + G2_LEN];
-        if (_isG2InfinityCalldata(blsSignature)) return 1;
-
-        bytes memory messagePoint = _hashToG2(hash);
-        if (_isG2InfinityMemory(messagePoint)) return 1;
-
-        bytes memory blsSigMem = blsSignature;
-        bool valid = _validateBLSSignatureMem(nodeIds, blsSigMem, messagePoint);
-        return valid ? 0 : 1;
+        return (true, nodeIds);
     }
 
     /// @dev The base whole-set parse+verify, inlined for the epochLength==0 fallback. Kept byte-identical

--- a/contracts/src/AAStarCommitteeValidator.sol
+++ b/contracts/src/AAStarCommitteeValidator.sol
@@ -52,8 +52,7 @@ import "./AAStarValidator.sol";
 ///           reopen register-to-order (seed still unknowable at freeze) but lets a griefer exclude
 ///           registrations made between the epoch boundary and the pin. Minor fairness, not safety.
 contract AAStarCommitteeValidator is AAStarValidator {
-    // Base declares these as private constants; re-declare the two lengths the committee path needs.
-    uint256 private constant G1_LEN = 128;
+    // Base declares these as private constants; re-declare the length the committee path needs.
     uint256 private constant G2_LEN = 256;
     /// @dev Mirrors the base's private MAX_NODE_COUNT: upper bound on signers parsed in one validate().
     uint256 private constant MAX_NODE_COUNT = 100;
@@ -79,6 +78,10 @@ contract AAStarCommitteeValidator is AAStarValidator {
     event EpochSnapshotted(uint256 indexed epoch, bytes32 seed, bytes32 setRoot, uint256 setCount);
     event EpochLengthSet(uint256 epochLength);
     event OversampleSet(uint256 num, uint256 den);
+    /// @dev Emitted on every SMT leaf mutation so off-chain aggregators can reconstruct any historical
+    ///      (frozen) tree from logs alone, without re-deriving the slot allocator (pr-daemon Low).
+    event SlotAssigned(bytes32 indexed nodeId, uint256 slot);
+    event SlotCleared(bytes32 indexed nodeId, uint256 slot);
 
     // ---------------------------------------------------------------------------------------------
     //                          INCREMENTAL SPARSE MERKLE TREE (active-set commitment)
@@ -91,6 +94,11 @@ contract AAStarCommitteeValidator is AAStarValidator {
     uint256[] public freeSlots;
     /// @dev Count of currently active leaves (slots occupied). Feeds the m_e curve.
     uint256 public activeCount;
+    /// @dev Block of the most recent set mutation (activate/deactivate). snapshotEpoch requires this to
+    ///      be strictly in the past, so a keeper cannot atomically evict nodes (syncNode is permissionless
+    ///      and owner-free) and freeze the shrunken count in the SAME tx to depress m/quorum (pr-daemon
+    ///      Medium — this manipulation feeds the B1 forgery budget).
+    uint256 public lastSetMutationBlock;
 
     /// @dev SMT internal nodes: node[level][index]. Level 0 = leaves (leaf = nodeId, or 0 if empty).
     ///      Unset entries read as the empty-subtree hash `zeros[level]`.
@@ -138,20 +146,30 @@ contract AAStarCommitteeValidator is AAStarValidator {
     ///      for every block, so `block.number > startBlock` in snapshotEpoch is never true and committee
     ///      mode is permanently unpinnable (Codex High). Bumps configVersion so snapshots taken under a
     ///      previous schedule are not reused under the new one (Codex Low).
+    /// @dev 0 disables committee mode; otherwise >= 64. The real pin window is min(256, epochLength-1)
+    ///      blocks (blockhash availability vs epoch span), so epochLength == 1 is unpinnable and tiny
+    ///      values leave a window too small for a keeper; 64 keeps a usable window (pr-daemon Low).
+    ///      Bumps configVersion so snapshots taken under a previous schedule are not reused (Codex Low).
     function setEpochLength(uint256 _epochLength) external onlyOwner {
-        require(_epochLength == 0 || _epochLength >= 2, "epochLength must be 0 or >= 2");
+        require(_epochLength == 0 || _epochLength >= 64, "epochLength must be 0 or >= 64");
         epochLength = _epochLength;
         configVersion += 1;
         emit EpochLengthSet(_epochLength);
     }
 
-    /// @dev Bounded so `oversampleNum * m` in _thresholdOf cannot overflow and turn a fail-closed
-    ///      `return 1` into a revert (Codex Medium). num/den in [1, 8], den in [1, 1e9].
+    /// @dev The threshold `oversample` scales the OTHER half of the committee definition, so — exactly
+    ///      like setEpochLength — it bumps configVersion. Without this, setOversample RETROACTIVELY
+    ///      relaxes the sortition gate on ALREADY-PINNED epochs (e.g. setOversample(5,1) collapses
+    ///      _thresholdOf to type(uint256).max, admitting nodes that were out of committee), which is a
+    ///      committee-definition mutation on a frozen epoch (pr-daemon B3). Bumping fails those epochs
+    ///      closed until re-pinned. Bounds also keep `oversampleNum * m` from overflowing (num/den in
+    ///      [1,8], den in [1,1e9]).
     function setOversample(uint256 num, uint256 den) external onlyOwner {
         require(den != 0 && den <= 1e9, "den out of range");
         require(num >= den && num <= 8 * den, "oversample must be in [1, 8]");
         oversampleNum = num;
         oversampleDen = den;
+        configVersion += 1;
         emit OversampleSet(num, den);
     }
 
@@ -174,7 +192,9 @@ contract AAStarCommitteeValidator is AAStarValidator {
         }
         slotPlusOne[nodeId] = slot + 1;
         activeCount += 1;
+        lastSetMutationBlock = block.number;
         _smtSet(slot, nodeId);
+        emit SlotAssigned(nodeId, slot);
     }
 
     function _onNodeDeactivated(bytes32 nodeId) internal override {
@@ -184,7 +204,9 @@ contract AAStarCommitteeValidator is AAStarValidator {
         delete slotPlusOne[nodeId];
         freeSlots.push(slot);
         activeCount -= 1;
+        lastSetMutationBlock = block.number;
         _smtSet(slot, bytes32(0));
+        emit SlotCleared(nodeId, slot);
     }
 
     /// @dev Set leaf `slot` to `leaf` and fold the change up to the root: O(TREE_DEPTH) hashes + SSTOREs.
@@ -225,6 +247,10 @@ contract AAStarCommitteeValidator is AAStarValidator {
         require(block.number <= startBlock + 256, "pin window elapsed");
         bytes32 bh = blockhash(startBlock);
         require(bh != bytes32(0), "blockhash unavailable");
+        // No set mutation in THIS block: forces any set change (esp. permissionless syncNode evictions)
+        // to land in an earlier block than the freeze, turning an atomic "evict-then-freeze" depression
+        // of epochSetCount into a race an honest keeper can win (pr-daemon Medium).
+        require(lastSetMutationBlock < block.number, "set mutated this block");
 
         epochSeed[e] = bh;
         epochSetRoot[e] = runningRoot;
@@ -276,7 +302,11 @@ contract AAStarCommitteeValidator is AAStarValidator {
     ///         Returns type(uint256).max when the prerequisite snapshot is missing (nothing can satisfy
     ///         it — the account's mirror check then fails closed too).
     function requiredQuorum() public view returns (uint256) {
-        uint256 e = currentEpoch();
+        // Read epochLength directly — do NOT go through currentEpoch(), which reverts when epochLength
+        // == 0 (the DEFAULT/committee-off config). Returning the sentinel keeps this view fail-closed
+        // and consistent with validate()'s "return 1" for the same state (pr-daemon Medium).
+        if (epochLength == 0) return type(uint256).max;
+        uint256 e = block.number / epochLength;
         if (e == 0 || !_epochUsable(e - 1)) return type(uint256).max;
         uint256 m = expectedCommittee(epochSetCount[e - 1]);
         return _quorumOf(m);

--- a/contracts/src/AAStarCommitteeValidator.sol
+++ b/contracts/src/AAStarCommitteeValidator.sol
@@ -408,6 +408,11 @@ contract AAStarCommitteeValidator is AAStarValidator {
         // Committee mode disabled → behave exactly like the base contract (whole-set aggregate verify).
         if (epochLength == 0) return _validateWholeSet(hash, signature);
 
+        // Length guard FIRST — before any calldata slice — so a short signature fails closed (return 1)
+        // instead of reverting on an out-of-bounds slice. Uniform fail-closed is the base contract's
+        // contract (pr-daemon round-3 regression: an earlier accountId slice moved ahead of this check).
+        if (signature.length < 32 + G2_LEN) return 1;
+
         bytes32 seed;
         bytes32 setRoot;
         uint256 committedCount;
@@ -443,8 +448,7 @@ contract AAStarCommitteeValidator is AAStarValidator {
         uint256 T;
         {
             uint256 perSigner = 64 + TREE_DEPTH * 32;
-            if (signature.length < 32 + G2_LEN) return 1;
-            uint256 body = signature.length - 32 - G2_LEN;
+            uint256 body = signature.length - 32 - G2_LEN; // safe: length >= 32 + G2_LEN checked above
             if (body == 0 || body % perSigner != 0) return 1;
             k = body / perSigner;
             if (k > MAX_NODE_COUNT) return 1; // gas-griefing bound (shared with the base cap)

--- a/contracts/src/AAStarCommitteeValidator.sol
+++ b/contracts/src/AAStarCommitteeValidator.sol
@@ -30,7 +30,27 @@ import "./AAStarValidator.sol";
 ///         accepted from calldata), m_e follows the DSR curve over the committed node count.
 ///
 ///         Wire format of `signature` (the account prepends accountId; the submitter provides the rest):
-///           [ accountId(32) ] [ per signer: nodeId(32) ‖ merkleProof(TREE_DEPTH×32) ]... [ blsSig(256) ]
+///           [ accountId(32) ] [ per signer: nodeId(32) | slot(32) | merkleProof(TREE_DEPTH*32) ]... [ blsSig(256) ]
+///         (slot is the node's leaf index in the FROZEN setRoot[e-1]; it is authenticated by the proof.)
+///
+///         SECURITY ASSUMPTIONS (residuals from adversarial review — read before mounting):
+///         - accountId is SECURITY-CRITICAL, not formatting. This contract cannot bind it to msg.sender
+///           because a ValidatorRouter sits between account and validator. The account MUST inject its own
+///           address(this) and MUST NOT forward any submitter-supplied accountId. If that account-side rule
+///           is violated/bypassed, a submitter can shop accountId after seed[e] is known and place its own
+///           nodes into the committee -> forgery. Enforcement is the account's responsibility (airaccount).
+///         - LIVENESS (not safety): quorum is over the frozen count epochSetCount[e-1] but signers must be
+///           currently registered. If more than ~1/3 of an account's frozen committee unregisters mid-epoch
+///           (unstake/syncNode/revoke), ops for that account fail until the next epoch's fresh set. This is
+///           the standard BFT liveness bound; mitigated by DSR oversampling (E[selected] ~ 1.15*m), the SP
+///           unbonding delay (bounds mass-exit), and per-epoch retry. Lowering quorum on churn would break
+///           safety, so it is intentionally NOT done.
+///         - LIVENESS: if a keeper misses the 256-block pin window for an epoch, committee ops fail for that
+///           epoch (no seed) and the next (no setRoot), then self-heal. No late seed fallback exists because
+///           a caller-chosen late seed would be grindable. Run redundant permissionless keepers.
+///         - The active-set freeze time within the pin window is caller-chosen (first call wins); this cannot
+///           reopen register-to-order (seed still unknowable at freeze) but lets a griefer exclude
+///           registrations made between the epoch boundary and the pin. Minor fairness, not safety.
 contract AAStarCommitteeValidator is AAStarValidator {
     // Base declares these as private constants; re-declare the two lengths the committee path needs.
     uint256 private constant G1_LEN = 128;
@@ -93,6 +113,12 @@ contract AAStarCommitteeValidator is AAStarValidator {
     mapping(uint256 => uint256) public epochSetCount;
     /// @dev epoch → whether snapshotEpoch() has run for it (both seed and setRoot are then final).
     mapping(uint256 => bool) public epochPinned;
+    /// @dev epoch → the config version in force when it was pinned. A snapshot is only usable while it
+    ///      matches the CURRENT configVersion, so changing epochLength cannot silently reuse a seed/root
+    ///      that belonged to a different epoch schedule (Codex Low: reconfiguration provenance).
+    mapping(uint256 => uint256) public epochConfigVersion;
+    /// @dev Bumped on every epochLength change; namespaces all epoch snapshots to their schedule.
+    uint256 public configVersion;
 
     constructor() AAStarValidator() {
         // Empty-subtree hashes + empty-tree root.
@@ -108,13 +134,22 @@ contract AAStarCommitteeValidator is AAStarValidator {
     //                          ADMIN
     // ---------------------------------------------------------------------------------------------
 
+    /// @dev 0 disables committee mode. Must be >= 2: with epochLength == 1, startBlock == block.number
+    ///      for every block, so `block.number > startBlock` in snapshotEpoch is never true and committee
+    ///      mode is permanently unpinnable (Codex High). Bumps configVersion so snapshots taken under a
+    ///      previous schedule are not reused under the new one (Codex Low).
     function setEpochLength(uint256 _epochLength) external onlyOwner {
+        require(_epochLength == 0 || _epochLength >= 2, "epochLength must be 0 or >= 2");
         epochLength = _epochLength;
+        configVersion += 1;
         emit EpochLengthSet(_epochLength);
     }
 
+    /// @dev Bounded so `oversampleNum * m` in _thresholdOf cannot overflow and turn a fail-closed
+    ///      `return 1` into a revert (Codex Medium). num/den in [1, 8], den in [1, 1e9].
     function setOversample(uint256 num, uint256 den) external onlyOwner {
-        require(den != 0 && num >= den, "oversample must be >= 1");
+        require(den != 0 && den <= 1e9, "den out of range");
+        require(num >= den && num <= 8 * den, "oversample must be in [1, 8]");
         oversampleNum = num;
         oversampleDen = den;
         emit OversampleSet(num, den);
@@ -190,6 +225,7 @@ contract AAStarCommitteeValidator is AAStarValidator {
         epochSeed[e] = bh;
         epochSetRoot[e] = runningRoot;
         epochSetCount[e] = activeCount;
+        epochConfigVersion[e] = configVersion;
         epochPinned[e] = true;
         emit EpochSnapshotted(e, bh, runningRoot, activeCount);
     }
@@ -237,9 +273,16 @@ contract AAStarCommitteeValidator is AAStarValidator {
     ///         it — the account's mirror check then fails closed too).
     function requiredQuorum() public view returns (uint256) {
         uint256 e = currentEpoch();
-        if (e == 0 || !epochPinned[e - 1]) return type(uint256).max;
+        if (e == 0 || !_epochUsable(e - 1)) return type(uint256).max;
         uint256 m = expectedCommittee(epochSetCount[e - 1]);
         return _quorumOf(m);
+    }
+
+    /// @dev An epoch's snapshot is usable only if it was pinned AND under the current epoch schedule
+    ///      (configVersion). This makes a post-reconfiguration seed/root fail-closed rather than being
+    ///      combined across incompatible schedules.
+    function _epochUsable(uint256 e) internal view returns (bool) {
+        return epochPinned[e] && epochConfigVersion[e] == configVersion;
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -251,15 +294,20 @@ contract AAStarCommitteeValidator is AAStarValidator {
         if (epochLength == 0) return _validateWholeSet(hash, signature);
 
         uint256 e = block.number / epochLength;
-        // Need seed[e] (this epoch) and setRoot[e-1] (frozen last epoch, the look-ahead set). Fail-closed
-        // if either is missing: the permissionless keeper must snapshot each epoch inside its window.
-        if (e == 0 || !epochPinned[e] || !epochPinned[e - 1]) return 1;
+        // Need seed[e] (this epoch) and setRoot[e-1] (frozen last epoch, the look-ahead set), both under
+        // the current epoch schedule. Fail-closed if either is missing/stale: the permissionless keeper
+        // must snapshot each epoch inside its window.
+        if (e == 0 || !_epochUsable(e) || !_epochUsable(e - 1)) return 1;
         bytes32 seed = epochSeed[e];
         bytes32 setRoot = epochSetRoot[e - 1];
         uint256 committedCount = epochSetCount[e - 1];
 
-        // ---- parse layout: accountId(32) ‖ k×(nodeId(32) ‖ proof(TREE_DEPTH*32)) ‖ blsSig(256) ----
-        uint256 perSigner = 32 + TREE_DEPTH * 32;
+        // ---- parse layout: accountId(32) || k×(nodeId(32) || slot(32) || proof(TREE_DEPTH*32)) || blsSig(256)
+        //      The slot is submitter-provided and authenticated by the Merkle proof against setRoot[e-1]:
+        //      each nodeId sits at exactly one slot in the frozen tree, so a wrong slot cannot verify. This
+        //      binds membership to the node's HISTORICAL slot in the frozen set, so a node whose live slot
+        //      was recycled+reassigned after the snapshot is still provable (Codex Medium: slot-reuse).
+        uint256 perSigner = 64 + TREE_DEPTH * 32;
         if (signature.length < 32 + G2_LEN) return 1;
         uint256 body = signature.length - 32 - G2_LEN;
         if (body == 0 || body % perSigner != 0) return 1;
@@ -279,17 +327,16 @@ contract AAStarCommitteeValidator is AAStarValidator {
         uint256 off = 32;
         for (uint256 i = 0; i < k; i++) {
             bytes32 nid = bytes32(signature[off:off + 32]);
-            off += 32;
+            uint256 slot = uint256(bytes32(signature[off + 32:off + 64]));
+            off += 64;
             // Distinct, strictly-increasing signers (blocks self-repetition inflating the aggregate).
             if (i != 0 && nid <= prevId) return 1;
             prevId = nid;
             // Still-active + economically backed (rejects retired bootstrap in staked mode).
             if (!isRegistered[nid]) return 1;
             if (requireStake && isBootstrap[nid]) return 1;
-            // (a) Membership in the look-ahead set: Merkle proof at the node's slot against setRoot[e-1].
-            uint256 sp = slotPlusOne[nid];
-            if (sp == 0) return 1;
-            if (!_verifyMerkle(setRoot, sp - 1, nid, signature[off:off + TREE_DEPTH * 32])) return 1;
+            // (a) Membership in the look-ahead set: Merkle proof at the submitted (authenticated) slot.
+            if (!_verifyMerkle(setRoot, slot, nid, signature[off:off + TREE_DEPTH * 32])) return 1;
             off += TREE_DEPTH * 32;
             // (b) Sortition: the committee membership the submitter cannot choose. When T == max the
             //     pool degrades to the whole set (bootstrap/tiny pool) — skip the draw so membership is

--- a/contracts/src/AAStarCommitteeValidator.sol
+++ b/contracts/src/AAStarCommitteeValidator.sol
@@ -360,12 +360,11 @@ contract AAStarCommitteeValidator is AAStarValidator {
 
     /// @dev Verify a fixed-depth Merkle proof: fold `leaf` at position `slot` up through `proof`
     ///      (TREE_DEPTH sibling words) and compare to `root`. Bit i of `slot` selects left/right.
-    function _verifyMerkle(
-        bytes32 root,
-        uint256 slot,
-        bytes32 leaf,
-        bytes calldata proof
-    ) internal pure returns (bool) {
+    function _verifyMerkle(bytes32 root, uint256 slot, bytes32 leaf, bytes calldata proof)
+        internal
+        pure
+        returns (bool)
+    {
         if (proof.length != TREE_DEPTH * 32) return false;
         bytes32 cur = leaf;
         uint256 idx = slot;

--- a/contracts/src/AAStarCommitteeValidator.sol
+++ b/contracts/src/AAStarCommitteeValidator.sol
@@ -148,8 +148,12 @@ contract AAStarCommitteeValidator is AAStarValidator {
             zeros[i + 1] = keccak256(abi.encode(zeros[i], zeros[i]));
         }
         runningRoot = zeros[TREE_DEPTH];
-        oversampleNum = 115;
-        oversampleDen = 100;
+        // oversample = 1.0: DSR's B1 security calc assumes E[committee] = m_e (λ = β*m_e). Any value > 1
+        // inflates the attacker's expected selections and breaks the N>=430 β=1/3 guarantee, so the
+        // default matches the security model exactly. setOversample can raise it (trading the DSR margin
+        // for honest-liveness headroom) but that is an explicit, configVersion-bumping deviation.
+        oversampleNum = 1;
+        oversampleDen = 1;
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -313,15 +317,21 @@ contract AAStarCommitteeValidator is AAStarValidator {
 
     /// @dev DSR expected-committee curve over committed pool size n:
     ///      n ≤ 8 → whole set (bootstrap); else m_e = min(110, max(16, n/5)).
-    ///      CAPPED AT n: the expected committee can never exceed the pool. Without this, a pool of
-    ///      9..15 nodes gets m_e = 16 (the floor) and requiredQuorum = ceil(2*16/3) = 11 > n, making
-    ///      every op unsatisfiable (liveness DoS). Capping degrades such pools to the whole set, so
-    ///      requiredQuorum = ceil(2n/3) <= n always holds.
+    ///      DSR-locked curve (CC-98 comment 9a9f47c9, Jason-adjudicated target): m_e(N) = N for N<=8
+    ///      (bootstrap whole set); else clamp(ceil(N/5), 17, 86). Security target: forgery probability
+    ///      ε = P(Poisson(β*m_e) >= ceil(2*m_e/3)) <= 1e-6 per (account, epoch) under the explicit
+    ///      assumption β <= 10% malicious stake. floor 17 hits ε=2.6e-7 @ β=10% (floor 16 was 1.02e-6,
+    ///      just over); cap 86 is the β=1/3 1e-6 point, so pools of N>=430 meet 1e-6 even at worst-case
+    ///      β=1/3 for free. This methodology REQUIRES E[committee] = m_e, i.e. oversample = 1.0 (see the
+    ///      constructor) — any oversample > 1 inflates λ and breaks the N>=430 worst-case guarantee.
+    ///      CAPPED AT n keeps requiredQuorum = ceil(2*m_e/3) <= n for the 9..16 bootstrap band (where the
+    ///      floor 17 would otherwise exceed the pool); airaccount gates committee mode on N >= N0 to keep
+    ///      such small pools off the sampling path (bootstrap-cliff avoidance).
     function expectedCommittee(uint256 n) public pure returns (uint256) {
         if (n <= 8) return n;
-        uint256 m = n / 5;
-        if (m < 16) m = 16;
-        if (m > 110) m = 110;
+        uint256 m = (n + 4) / 5; // ceil(n/5)
+        if (m < 17) m = 17;
+        if (m > 86) m = 86;
         if (m > n) m = n; // never sample more than the pool
         return m;
     }

--- a/contracts/src/AAStarCommitteeValidator.sol
+++ b/contracts/src/AAStarCommitteeValidator.sol
@@ -215,7 +215,11 @@ contract AAStarCommitteeValidator is AAStarValidator {
     function snapshotEpoch() external {
         require(epochLength != 0, "committee mode off");
         uint256 e = block.number / epochLength;
-        require(!epochPinned[e], "epoch already pinned");
+        // Re-pinning is allowed only when the existing pin belongs to a PREVIOUS epoch schedule
+        // (configVersion). Otherwise, after an epochLength change, new-schedule epoch numbers that
+        // collide with old pinned IDs could never be re-snapshotted under the current version, stranding
+        // committee mode until the epoch counter passed every colliding old ID (Codex round-2 High).
+        require(!epochPinned[e] || epochConfigVersion[e] != configVersion, "epoch already pinned");
         uint256 startBlock = e * epochLength;
         require(block.number > startBlock, "wait for epoch start block");
         require(block.number <= startBlock + 256, "pin window elapsed");
@@ -329,6 +333,9 @@ contract AAStarCommitteeValidator is AAStarValidator {
             bytes32 nid = bytes32(signature[off:off + 32]);
             uint256 slot = uint256(bytes32(signature[off + 32:off + 64]));
             off += 64;
+            // Canonical slot only: _verifyMerkle folds just the low TREE_DEPTH bits, so slot and
+            // slot + q*2^TREE_DEPTH would share a path. Reject non-canonical aliases (Codex round-2 Low).
+            if (slot >= (1 << TREE_DEPTH)) return 1;
             // Distinct, strictly-increasing signers (blocks self-repetition inflating the aggregate).
             if (i != 0 && nid <= prevId) return 1;
             prevId = nid;

--- a/contracts/src/AAStarValidator.sol
+++ b/contracts/src/AAStarValidator.sol
@@ -218,7 +218,7 @@ contract AAStarValidator is IAAStarAlgorithm {
     ///      fail-closed: EVERY malformed / unregistered / retired-bootstrap / non-quorum input
     ///      returns 1 rather than reverting (the account calls it under try/catch, treating a
     ///      revert as fail; returning 1 keeps the failure signal uniform).
-    function validate(bytes32 hash, bytes calldata signature) external view override returns (uint256) {
+    function validate(bytes32 hash, bytes calldata signature) external view virtual override returns (uint256) {
         // Parse: variable-length nodeIds + 256-byte BLS sig (messagePoint dropped — see above).
         uint256 fixedLen = G2_POINT_LENGTH; // 256
         if (signature.length <= fixedLen) return 1;
@@ -432,7 +432,7 @@ contract AAStarValidator is IAAStarAlgorithm {
         bytes32[] memory nodeIds,
         bytes memory signature,
         bytes memory messagePoint
-    ) internal view returns (bool isValid) {
+    ) internal view virtual returns (bool isValid) {
         bytes[] memory publicKeys = _getPublicKeysByNodesMem(nodeIds);
         bytes memory aggregatedKey = _aggregatePublicKeysFromMemory(publicKeys);
         bytes memory negatedAggregatedKey = _negateG1Point(aggregatedKey);
@@ -823,7 +823,7 @@ contract AAStarValidator is IAAStarAlgorithm {
      * @param nodeId Unique node identifier
      * @param publicKey G1 public key (128 bytes)
      */
-    function registerPublicKey(bytes32 nodeId, bytes calldata publicKey) external {
+    function registerPublicKey(bytes32 nodeId, bytes calldata publicKey) external virtual {
         require(nodeId != bytes32(0), "Invalid node ID");
         require(publicKey.length == G1_POINT_LENGTH, "Invalid public key length");
         require(!_isInfinity(publicKey), "pubkey is infinity");
@@ -840,6 +840,7 @@ contract AAStarValidator is IAAStarAlgorithm {
         registeredKeys[nodeId] = publicKey;
         isRegistered[nodeId] = true;
         registeredNodes.push(nodeId);
+        _onNodeActivated(nodeId);
 
         emit PublicKeyRegistered(nodeId, publicKey);
     }
@@ -862,7 +863,7 @@ contract AAStarValidator is IAAStarAlgorithm {
         bytes calldata publicKey,
         bytes calldata popPoint,
         bytes calldata popSig
-    ) external {
+    ) external virtual {
         require(requireStake, "Staked registration disabled");
         require(publicKey.length == G1_POINT_LENGTH, "Invalid public key length");
         // Reject the point-at-infinity encoding (all-zero). e(_, infinity)=1, so an
@@ -881,6 +882,7 @@ contract AAStarValidator is IAAStarAlgorithm {
         registeredKeys[nodeId] = publicKey;
         isRegistered[nodeId] = true;
         registeredNodes.push(nodeId);
+        _onNodeActivated(nodeId);
 
         emit NodeBound(nodeId, msg.sender);
         emit PublicKeyRegistered(nodeId, publicKey);
@@ -936,7 +938,7 @@ contract AAStarValidator is IAAStarAlgorithm {
     }
 
     /// @dev Remove a node from the active set + clear its operator binding.
-    function _deactivate(bytes32 nodeId) internal {
+    function _deactivate(bytes32 nodeId) internal virtual {
         address op = nodeOperator[nodeId];
         isRegistered[nodeId] = false;
         delete registeredKeys[nodeId];
@@ -945,7 +947,14 @@ contract AAStarValidator is IAAStarAlgorithm {
         if (op != address(0) && operatorNode[op] == nodeId) delete operatorNode[op];
         // registeredNodes[] is an unordered enumeration; leave the stale id (isRegistered
         // gates all reads). Compaction is a gas trade-off deferred to a later pass.
+        _onNodeDeactivated(nodeId);
     }
+
+    // --- CC-98 committee subsystem hooks (no-op in the base; overridden by the committee validator
+    //     to maintain an incremental Merkle commitment of the active set). Called at EVERY set
+    //     mutation so a subclass's commitment can never drift from isRegistered[]. ---
+    function _onNodeActivated(bytes32 nodeId) internal virtual {}
+    function _onNodeDeactivated(bytes32 nodeId) internal virtual {}
 
     // --- Owner/Safe governance (transfer owner to a Gnosis Safe after init) --------
     function setRegistry(address _registry) external onlyOwner {
@@ -992,7 +1001,7 @@ contract AAStarValidator is IAAStarAlgorithm {
      *
      * @param nodeId Unique node identifier
      */
-    function revokePublicKey(bytes32 nodeId) external onlyOwner {
+    function revokePublicKey(bytes32 nodeId) external virtual onlyOwner {
         require(isRegistered[nodeId], "Node not registered");
 
         // Clear the operator binding too, or operatorNode[op] would stay pointing at a
@@ -1004,6 +1013,7 @@ contract AAStarValidator is IAAStarAlgorithm {
         delete isBootstrap[nodeId];
         delete registeredKeys[nodeId];
         isRegistered[nodeId] = false;
+        _onNodeDeactivated(nodeId);
 
         // Remove node ID from array
         for (uint256 i = 0; i < registeredNodes.length; i++) {
@@ -1023,7 +1033,7 @@ contract AAStarValidator is IAAStarAlgorithm {
      * @param nodeIds Array of node identifiers
      * @param publicKeys Corresponding public key array
      */
-    function batchRegisterPublicKeys(bytes32[] calldata nodeIds, bytes[] calldata publicKeys) external onlyOwner {
+    function batchRegisterPublicKeys(bytes32[] calldata nodeIds, bytes[] calldata publicKeys) external virtual onlyOwner {
         // Bootstrap-only, same as registerPublicKey: once staking is mandatory this owner
         // path would let stake-less/PoP-less nodes into the active set.
         require(!requireStake, "Staking on: use registerWithProof");
@@ -1043,6 +1053,7 @@ contract AAStarValidator is IAAStarAlgorithm {
             registeredKeys[nodeIds[i]] = publicKeys[i];
             isRegistered[nodeIds[i]] = true;
             registeredNodes.push(nodeIds[i]);
+            _onNodeActivated(nodeIds[i]);
 
             emit PublicKeyRegistered(nodeIds[i], publicKeys[i]);
         }

--- a/contracts/test/AAStarCommitteeValidator.t.sol
+++ b/contracts/test/AAStarCommitteeValidator.t.sol
@@ -93,8 +93,8 @@ contract AAStarCommitteeValidatorTest is Test {
     function _payload(address account, bytes32[] memory signers) internal view returns (bytes memory out) {
         out = abi.encodePacked(bytes32(uint256(uint160(account))));
         for (uint256 i = 0; i < signers.length; i++) {
-            (, bytes32[] memory proof) = v.getMerkleProof(signers[i]);
-            out = abi.encodePacked(out, signers[i]);
+            (uint256 slot, bytes32[] memory proof) = v.getMerkleProof(signers[i]);
+            out = abi.encodePacked(out, signers[i], bytes32(slot));
             for (uint256 j = 0; j < proof.length; j++) {
                 out = abi.encodePacked(out, proof[j]);
             }
@@ -274,8 +274,8 @@ contract AAStarCommitteeValidatorTest is Test {
         signers[0] = ids[0];
         signers[1] = ids[1];
         bytes memory payload = _payload(ACCOUNT, signers);
-        // Corrupt one byte inside the first signer's Merkle proof (offset: 32 accountId + 32 nodeId).
-        payload[64] = bytes1(uint8(payload[64]) ^ 0xFF);
+        // Corrupt one byte inside the first signer's Merkle proof (offset: 32 accountId + 32 nodeId + 32 slot).
+        payload[96] = bytes1(uint8(payload[96]) ^ 0xFF);
         assertEq(v.validate(keccak256("op"), payload), 1, "tampered proof must fail");
     }
 
@@ -341,5 +341,58 @@ contract AAStarCommitteeValidatorTest is Test {
         // legacy format: [nodeId][blsSig]
         bytes memory legacy = abi.encodePacked(nid, DUMMY_SIG);
         assertEq(w.validate(keccak256("op"), legacy), 0, "epochLength=0 => whole-set path validates");
+    }
+
+    // ---- Codex-round fixes ---------------------------------------------------------------------
+
+    // High: epochLength == 1 is permanently unpinnable, so the setter must reject it.
+    function test_setEpochLength_rejects_one() public {
+        MockCommitteeValidator w = new MockCommitteeValidator();
+        vm.expectRevert("epochLength must be 0 or >= 2");
+        w.setEpochLength(1);
+        w.setEpochLength(0); // 0 (disable) allowed
+        w.setEpochLength(2); // >= 2 allowed
+    }
+
+    // Medium: unbounded oversample would overflow _thresholdOf and turn fail-closed into a revert.
+    function test_setOversample_bounds() public {
+        vm.expectRevert("oversample must be in [1, 8]");
+        v.setOversample(type(uint256).max, 1);
+        vm.expectRevert("oversample must be in [1, 8]");
+        v.setOversample(1, 2); // num < den
+        vm.expectRevert("den out of range");
+        v.setOversample(2e9, 2e9);
+        v.setOversample(2, 1); // ok (2x)
+    }
+
+    // Medium: the submitted slot is authenticated by the proof — a wrong slot must fail.
+    function test_validate_rejects_wrong_slot() public {
+        bytes32[] memory ids = _registerNodes(3);
+        _rollAndSnapshot(1, bytes32(uint256(0xAA)));
+        _rollAndSnapshot(2, bytes32(uint256(0xBB)));
+        bytes32[] memory signers = new bytes32[](2);
+        signers[0] = ids[0];
+        signers[1] = ids[1];
+        bytes memory payload = _payload(ACCOUNT, signers);
+        // Slot word for signer 0 is at offset 32(accountId)+32(nodeId) = 64; flip its low byte.
+        payload[95] = bytes1(uint8(payload[95]) ^ 0x01);
+        assertEq(v.validate(keccak256("op"), payload), 1, "wrong slot must fail Merkle");
+    }
+
+    // Low: changing epochLength must invalidate snapshots taken under the old schedule (fail-closed).
+    function test_configVersion_invalidates_snapshots() public {
+        bytes32[] memory ids = _registerNodes(3);
+        _rollAndSnapshot(1, bytes32(uint256(0xAA)));
+        _rollAndSnapshot(2, bytes32(uint256(0xBB)));
+        bytes32[] memory signers = new bytes32[](2);
+        signers[0] = ids[0];
+        signers[1] = ids[1];
+        bytes memory payload = _payload(ACCOUNT, signers);
+        assertEq(v.validate(keccak256("op"), payload), 0, "valid before reconfig");
+
+        // Reconfigure epoch schedule -> configVersion bumps -> old snapshots become stale.
+        v.setEpochLength(EPOCH_LEN);
+        assertEq(v.validate(keccak256("op"), payload), 1, "stale snapshots => fail-closed after reconfig");
+        assertEq(v.requiredQuorum(), type(uint256).max, "requiredQuorum unusable until re-pinned");
     }
 }

--- a/contracts/test/AAStarCommitteeValidator.t.sol
+++ b/contracts/test/AAStarCommitteeValidator.t.sol
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+import "../src/AAStarCommitteeValidator.sol";
+
+/// @dev Test seam: mock the aggregate BLS verify (real pairing tested elsewhere) so these tests
+///      isolate the CC-98 committee gate -- SMT membership, sortition, quorum, snapshot/look-ahead.
+///      Also exposes the internal pure helpers for direct unit assertions.
+contract MockCommitteeValidator is AAStarCommitteeValidator {
+    bool public blsResult = true;
+
+    function setBlsResult(bool v) external {
+        blsResult = v;
+    }
+
+    function _validateBLSSignatureMem(
+        bytes32[] memory,
+        bytes memory,
+        bytes memory
+    ) internal view override returns (bool) {
+        return blsResult;
+    }
+
+    function exposedVerifyMerkle(
+        bytes32 root,
+        uint256 slot,
+        bytes32 leaf,
+        bytes calldata proof
+    ) external pure returns (bool) {
+        return _verifyMerkle(root, slot, leaf, proof);
+    }
+
+    function exposedThreshold(uint256 n, uint256 m) external view returns (uint256) {
+        return _thresholdOf(n, m);
+    }
+}
+
+contract AAStarCommitteeValidatorTest is Test {
+    MockCommitteeValidator v;
+
+    uint256 constant EPOCH_LEN = 100;
+    address constant ACCOUNT = address(0xA11CE);
+
+    // A valid-length, non-infinity G1 key / G2 sig (content irrelevant -- BLS verify is mocked).
+    bytes DUMMY_KEY;
+    bytes DUMMY_SIG;
+
+    function setUp() public {
+        v = new MockCommitteeValidator();
+        v.setEpochLength(EPOCH_LEN);
+
+        DUMMY_KEY = new bytes(128);
+        DUMMY_SIG = new bytes(256);
+        for (uint256 i = 0; i < 128; i++) DUMMY_KEY[i] = bytes1(uint8(1 + (i % 250)));
+        for (uint256 i = 0; i < 256; i++) DUMMY_SIG[i] = bytes1(uint8(1 + (i % 250)));
+    }
+
+    // ---- helpers -------------------------------------------------------------------------------
+
+    /// @dev Register n bootstrap nodes with distinct, ascending nodeIds. Returns them sorted.
+    function _registerNodes(uint256 n) internal returns (bytes32[] memory ids) {
+        ids = new bytes32[](n);
+        for (uint256 i = 0; i < n; i++) {
+            bytes32 nid = keccak256(abi.encode("node", i));
+            v.registerPublicKey(nid, DUMMY_KEY);
+            ids[i] = nid;
+        }
+        _sortAsc(ids);
+    }
+
+    function _sortAsc(bytes32[] memory a) internal pure {
+        for (uint256 i = 0; i < a.length; i++) {
+            for (uint256 j = i + 1; j < a.length; j++) {
+                if (a[j] < a[i]) (a[i], a[j]) = (a[j], a[i]);
+            }
+        }
+    }
+
+    /// @dev Advance to the first block of `epoch`, set its blockhash, and pin it.
+    function _rollAndSnapshot(uint256 epoch, bytes32 bh) internal {
+        uint256 startBlock = epoch * EPOCH_LEN;
+        vm.roll(startBlock + 1);
+        vm.setBlockhash(startBlock, bh);
+        v.snapshotEpoch();
+    }
+
+    /// @dev Build the committee payload: accountId || [nodeId || proof]... || blsSig.
+    function _payload(
+        address account,
+        bytes32[] memory signers
+    ) internal view returns (bytes memory out) {
+        out = abi.encodePacked(bytes32(uint256(uint160(account))));
+        for (uint256 i = 0; i < signers.length; i++) {
+            (, bytes32[] memory proof) = v.getMerkleProof(signers[i]);
+            out = abi.encodePacked(out, signers[i]);
+            for (uint256 j = 0; j < proof.length; j++) out = abi.encodePacked(out, proof[j]);
+        }
+        out = abi.encodePacked(out, DUMMY_SIG);
+    }
+
+    // ---- SMT / Merkle --------------------------------------------------------------------------
+
+    function test_smt_proof_verifies_against_running_root() public {
+        bytes32[] memory ids = _registerNodes(5);
+        for (uint256 i = 0; i < ids.length; i++) {
+            (uint256 slot, bytes32[] memory proof) = v.getMerkleProof(ids[i]);
+            bytes memory flat;
+            for (uint256 j = 0; j < proof.length; j++) flat = abi.encodePacked(flat, proof[j]);
+            assertTrue(
+                v.exposedVerifyMerkle(v.runningRoot(), slot, ids[i], flat),
+                "proof must verify against current root"
+            );
+            // A wrong leaf must NOT verify.
+            assertFalse(
+                v.exposedVerifyMerkle(v.runningRoot(), slot, keccak256("wrong"), flat),
+                "wrong leaf must fail"
+            );
+        }
+    }
+
+    function test_smt_slot_reuse_on_deactivation() public {
+        bytes32[] memory ids = _registerNodes(3);
+        assertEq(v.activeCount(), 3);
+        uint256 slot1 = v.slotPlusOne(ids[1]) - 1;
+        v.revokePublicKey(ids[1]);
+        assertEq(v.activeCount(), 2);
+        assertEq(v.slotPlusOne(ids[1]), 0, "revoked node loses its slot");
+        // New registration reuses the freed slot.
+        bytes32 fresh = keccak256("fresh");
+        v.registerPublicKey(fresh, DUMMY_KEY);
+        assertEq(v.slotPlusOne(fresh) - 1, slot1, "freed slot is recycled");
+        assertEq(v.activeCount(), 3);
+    }
+
+    // ---- snapshot / epoch ----------------------------------------------------------------------
+
+    function test_snapshot_pins_seed_setroot_count() public {
+        _registerNodes(4);
+        bytes32 root = v.runningRoot();
+        _rollAndSnapshot(1, bytes32(uint256(0xBEEF)));
+        assertTrue(v.epochPinned(1));
+        assertEq(v.epochSeed(1), bytes32(uint256(0xBEEF)));
+        assertEq(v.epochSetRoot(1), root);
+        assertEq(v.epochSetCount(1), 4);
+    }
+
+    function test_snapshot_rejects_double_pin() public {
+        _rollAndSnapshot(1, bytes32(uint256(1)));
+        vm.setBlockhash(EPOCH_LEN, bytes32(uint256(1)));
+        vm.expectRevert("epoch already pinned");
+        v.snapshotEpoch();
+    }
+
+    function test_snapshot_rejects_before_start_block() public {
+        vm.roll(EPOCH_LEN); // exactly the start block -- blockhash(startBlock) not yet available
+        vm.expectRevert("wait for epoch start block");
+        v.snapshotEpoch();
+    }
+
+    function test_snapshot_rejects_after_window() public {
+        // The blockhash(startBlock) window is 256 blocks. It is only reachable when the epoch is
+        // LONGER than 256 blocks (otherwise the whole epoch is inside the window). Use a 300-block epoch.
+        MockCommitteeValidator w = new MockCommitteeValidator();
+        w.setEpochLength(300);
+        vm.roll(300 + 257); // epoch 1, startBlock 300, block 557 > 300+256 => window elapsed
+        vm.expectRevert("pin window elapsed");
+        w.snapshotEpoch();
+    }
+
+    // ---- committee math ------------------------------------------------------------------------
+
+    function test_expectedCommittee_curve() public view {
+        assertEq(v.expectedCommittee(3), 3); // bootstrap: whole set
+        assertEq(v.expectedCommittee(8), 8);
+        assertEq(v.expectedCommittee(9), 9); // floor-16 capped at n (liveness: never sample > pool)
+        assertEq(v.expectedCommittee(15), 15); // still capped at n
+        assertEq(v.expectedCommittee(16), 16); // floor
+        assertEq(v.expectedCommittee(80), 16); // n/5=16
+        assertEq(v.expectedCommittee(100), 20); // n/5
+        assertEq(v.expectedCommittee(1000), 110); // cap
+    }
+
+    /// @dev Regression for the 9..15 pool liveness DoS: quorum must be satisfiable (<= n).
+    function test_validate_liveness_midsize_pool() public {
+        bytes32[] memory ids = _registerNodes(12); // pre-fix: m=16, quorum=11 unsatisfiable-ish; now whole set
+        _rollAndSnapshot(1, bytes32(uint256(0xAA)));
+        _rollAndSnapshot(2, bytes32(uint256(0xBB)));
+        // whole set (m=12), quorum = ceil(2*12/3) = 8. Provide 8 ascending signers.
+        assertEq(v.requiredQuorum(), 8);
+        bytes32[] memory signers = new bytes32[](8);
+        for (uint256 i = 0; i < 8; i++) signers[i] = ids[i];
+        assertEq(v.validate(keccak256("op"), _payload(ACCOUNT, signers)), 0, "12-node pool must be satisfiable");
+    }
+
+    function test_threshold_wholeset_for_small_pool() public view {
+        // n=3, m=3 -> target=ceil(1.15*3)=4 >= n => whole set (T = max).
+        assertEq(v.exposedThreshold(3, 3), type(uint256).max);
+        // n=100, m=20 -> target=23 < 100 => partial.
+        assertLt(v.exposedThreshold(100, 20), type(uint256).max);
+        assertGt(v.exposedThreshold(100, 20), 0);
+    }
+
+    // ---- validate: happy path ------------------------------------------------------------------
+
+    function test_validate_committee_happypath() public {
+        bytes32[] memory ids = _registerNodes(3); // n=3 => whole set, quorum ceil(2*3/3) = 2
+        _rollAndSnapshot(1, bytes32(uint256(0xAA))); // freeze setRoot[1]
+        _rollAndSnapshot(2, bytes32(uint256(0xBB))); // pin seed[2]; committee uses setRoot[1]
+
+        // 2 signers (meets quorum), ascending, all in the whole-set committee (T=max).
+        bytes32[] memory signers = new bytes32[](2);
+        signers[0] = ids[0];
+        signers[1] = ids[1];
+        bytes memory payload = _payload(ACCOUNT, signers);
+        assertEq(v.validate(keccak256("op"), payload), 0, "valid committee op must pass");
+    }
+
+    function test_validate_rejects_below_quorum() public {
+        bytes32[] memory ids = _registerNodes(3);
+        _rollAndSnapshot(1, bytes32(uint256(0xAA)));
+        _rollAndSnapshot(2, bytes32(uint256(0xBB)));
+
+        bytes32[] memory signers = new bytes32[](1); // 1 < quorum 2
+        signers[0] = ids[0];
+        assertEq(v.validate(keccak256("op"), _payload(ACCOUNT, signers)), 1, "below quorum must fail");
+    }
+
+    function test_validate_fails_closed_without_snapshot() public {
+        bytes32[] memory ids = _registerNodes(3);
+        // Only pin the CURRENT epoch, not the look-ahead (e-1) one.
+        _rollAndSnapshot(2, bytes32(uint256(0xBB)));
+        bytes32[] memory signers = new bytes32[](2);
+        signers[0] = ids[0];
+        signers[1] = ids[1];
+        assertEq(v.validate(keccak256("op"), _payload(ACCOUNT, signers)), 1, "missing setRoot[e-1] => fail-closed");
+    }
+
+    function test_validate_rejects_unregistered_signer() public {
+        bytes32[] memory ids = _registerNodes(3);
+        _rollAndSnapshot(1, bytes32(uint256(0xAA)));
+        _rollAndSnapshot(2, bytes32(uint256(0xBB)));
+
+        // Build a valid 2-signer payload, then revoke one signer AFTER proof generation.
+        bytes32[] memory signers = new bytes32[](2);
+        signers[0] = ids[0];
+        signers[1] = ids[1];
+        bytes memory payload = _payload(ACCOUNT, signers);
+        v.revokePublicKey(ids[0]);
+        assertEq(v.validate(keccak256("op"), payload), 1, "unregistered signer must fail");
+    }
+
+    function test_validate_rejects_non_increasing_nodeids() public {
+        bytes32[] memory ids = _registerNodes(3);
+        _rollAndSnapshot(1, bytes32(uint256(0xAA)));
+        _rollAndSnapshot(2, bytes32(uint256(0xBB)));
+
+        // Descending order (ids sorted asc => [1],[0] is descending).
+        bytes32[] memory signers = new bytes32[](2);
+        signers[0] = ids[1];
+        signers[1] = ids[0];
+        assertEq(v.validate(keccak256("op"), _payload(ACCOUNT, signers)), 1, "non-increasing ids must fail");
+    }
+
+    function test_validate_rejects_tampered_proof() public {
+        bytes32[] memory ids = _registerNodes(3);
+        _rollAndSnapshot(1, bytes32(uint256(0xAA)));
+        _rollAndSnapshot(2, bytes32(uint256(0xBB)));
+
+        bytes32[] memory signers = new bytes32[](2);
+        signers[0] = ids[0];
+        signers[1] = ids[1];
+        bytes memory payload = _payload(ACCOUNT, signers);
+        // Corrupt one byte inside the first signer's Merkle proof (offset: 32 accountId + 32 nodeId).
+        payload[64] = bytes1(uint8(payload[64]) ^ 0xFF);
+        assertEq(v.validate(keccak256("op"), payload), 1, "tampered proof must fail");
+    }
+
+    function test_validate_rejects_wrong_accountId_committee() public {
+        // With a partial-selection pool, the committee is account-specific: proofs valid but the
+        // sortition draw for a DIFFERENT account excludes these signers => fail. Demonstrates the
+        // account-binding of committee membership.
+        bytes32[] memory ids = _registerNodes(40); // n=40 => m=16, target=ceil(1.15*16)=19 < 40 => partial
+        _rollAndSnapshot(1, bytes32(uint256(0xAA)));
+        _rollAndSnapshot(2, bytes32(uint256(0xBB)));
+
+        bytes32 seed = v.epochSeed(2);
+        uint256 n = v.epochSetCount(1);
+        uint256 m = v.expectedCommittee(n);
+        uint256 T = v.exposedThreshold(n, m);
+        uint256 required = (2 * m + 2) / 3;
+
+        // Collect `required` signers that ARE in ACCOUNT's committee.
+        bytes32[] memory chosen = new bytes32[](required);
+        uint256 c;
+        for (uint256 i = 0; i < ids.length && c < required; i++) {
+            uint256 draw = uint256(keccak256(abi.encode(keccak256("CMT_SELECT"), seed, bytes32(uint256(uint160(ACCOUNT))), ids[i])));
+            if (draw < T) {
+                chosen[c++] = ids[i];
+            }
+        }
+        require(c == required, "need enough selected signers for ACCOUNT");
+        _sortAsc(chosen);
+        // Valid for ACCOUNT.
+        assertEq(v.validate(keccak256("op"), _payload(ACCOUNT, chosen)), 0, "selected committee valid for its account");
+        // Same signers, DIFFERENT account => at least one is out of that account's committee => fail.
+        address other = address(0xB0B);
+        // sanity: ensure not all `chosen` are also selected for `other` (else the test is vacuous)
+        bool someExcluded;
+        for (uint256 i = 0; i < chosen.length; i++) {
+            uint256 draw = uint256(keccak256(abi.encode(keccak256("CMT_SELECT"), seed, bytes32(uint256(uint160(other))), chosen[i])));
+            if (draw >= T) someExcluded = true;
+        }
+        if (someExcluded) {
+            assertEq(v.validate(keccak256("op"), _payload(other, chosen)), 1, "committee is account-bound");
+        }
+    }
+
+    function test_requiredQuorum_view_tracks_lookahead() public {
+        _registerNodes(3);
+        _rollAndSnapshot(1, bytes32(uint256(0xAA)));
+        _rollAndSnapshot(2, bytes32(uint256(0xBB)));
+        // epoch 2 committees use setRoot[1] (count 3) => m=3 => quorum 2.
+        assertEq(v.requiredQuorum(), 2);
+    }
+
+    function test_epochLength_zero_falls_back_to_wholeset() public {
+        MockCommitteeValidator w = new MockCommitteeValidator();
+        // epochLength stays 0 => legacy whole-set path.
+        bytes32 nid = keccak256(abi.encode("node", uint256(0)));
+        w.registerPublicKey(nid, DUMMY_KEY);
+        bytes32[] memory one = new bytes32[](1);
+        one[0] = nid;
+        // legacy format: [nodeId][blsSig]
+        bytes memory legacy = abi.encodePacked(nid, DUMMY_SIG);
+        assertEq(w.validate(keccak256("op"), legacy), 0, "epochLength=0 => whole-set path validates");
+    }
+}

--- a/contracts/test/AAStarCommitteeValidator.t.sol
+++ b/contracts/test/AAStarCommitteeValidator.t.sol
@@ -49,6 +49,8 @@ contract AAStarCommitteeValidatorTest is Test {
     function setUp() public {
         v = new MockCommitteeValidator();
         v.setEpochLength(EPOCH_LEN);
+        vm.prank(ACCOUNT);
+        v.enroll(); // committee ops require the account to have self-enrolled (B2 defense-in-depth)
 
         DUMMY_KEY = new bytes(128);
         DUMMY_SIG = new bytes(256);
@@ -331,6 +333,8 @@ contract AAStarCommitteeValidatorTest is Test {
         assertEq(v.validate(keccak256("op"), _payload(ACCOUNT, chosen)), 0, "selected committee valid for its account");
         // Same signers, DIFFERENT account => at least one is out of that account's committee => fail.
         address other = address(0xB0B);
+        vm.prank(other);
+        v.enroll(); // enroll so the rejection below is by committee sortition, not by enrollment
         // sanity: ensure not all `chosen` are also selected for `other` (else the test is vacuous)
         bool someExcluded;
         for (uint256 i = 0; i < chosen.length; i++) {
@@ -412,6 +416,37 @@ contract AAStarCommitteeValidatorTest is Test {
             1,
             "post-freeze registrant must not be a valid committee member"
         );
+    }
+
+    // pr-daemon B2 (defense-in-depth): committeeActive view + self-enroll + unenrolled fail-closed.
+    function test_committeeActive_view() public {
+        assertTrue(v.committeeActive(), "epochLength set => active");
+        MockCommitteeValidator w = new MockCommitteeValidator();
+        assertFalse(w.committeeActive(), "epochLength 0 => inactive");
+    }
+
+    function test_enroll_selfproving() public {
+        assertFalse(v.enrolledAccount(address(0xBEEF)));
+        vm.prank(address(0xBEEF));
+        v.enroll();
+        assertTrue(v.enrolledAccount(address(0xBEEF)), "enroll sets caller");
+        vm.prank(address(0xBEEF));
+        v.unenroll();
+        assertFalse(v.enrolledAccount(address(0xBEEF)), "unenroll clears caller");
+    }
+
+    function test_validate_rejects_unenrolled_account() public {
+        bytes32[] memory ids = _registerNodes(3);
+        _rollAndSnapshot(1, bytes32(uint256(0xAA)));
+        _rollAndSnapshot(2, bytes32(uint256(0xBB)));
+        bytes32[] memory signers = new bytes32[](2);
+        signers[0] = ids[0];
+        signers[1] = ids[1];
+        // ACCOUNT is enrolled (setUp) -> valid.
+        assertEq(v.validate(keccak256("op"), _payload(ACCOUNT, signers)), 0, "enrolled account valid");
+        // An un-enrolled accountId (e.g. a flip-order fabricated prefix) fails closed regardless of the
+        // committee/sortition — this blocks the B2 shape-collision path on-chain.
+        assertEq(v.validate(keccak256("op"), _payload(address(0xDEAD), signers)), 1, "unenrolled => fail-closed");
     }
 
     // pr-daemon B3: setOversample must bump configVersion so it cannot retroactively relax the

--- a/contracts/test/AAStarCommitteeValidator.t.sol
+++ b/contracts/test/AAStarCommitteeValidator.t.sol
@@ -134,6 +134,27 @@ contract AAStarCommitteeValidatorTest is Test {
         assertEq(v.activeCount(), 3);
     }
 
+    // pr-daemon Medium (coverage): _deactivate (via permissionless syncNode) must fire the SMT hook.
+    // Exercised through the syncNode path (distinct from revokePublicKey), which the mutant survives.
+    function test_syncNode_updates_smt() public {
+        bytes32[] memory ids = _registerNodes(3);
+        assertEq(v.activeCount(), 3);
+        uint256 slot = v.slotPlusOne(ids[1]) - 1;
+        bytes32 rootBefore = v.runningRoot();
+
+        v.setRequireStake(true); // now bootstrap nodes are stale -> syncNode can deactivate them
+        v.syncNode(ids[1]); // permissionless; goes through _deactivate -> _onNodeDeactivated
+
+        assertEq(v.activeCount(), 2, "syncNode must decrement activeCount via the hook");
+        assertEq(v.slotPlusOne(ids[1]), 0, "syncNode must free the slot via the hook");
+        assertTrue(v.runningRoot() != rootBefore, "syncNode must update the SMT root via the hook");
+        // Slot is recycled on the next activation.
+        v.setRequireStake(false);
+        bytes32 fresh = keccak256("fresh-after-sync");
+        v.registerPublicKey(fresh, DUMMY_KEY);
+        assertEq(v.slotPlusOne(fresh) - 1, slot, "freed slot recycled after syncNode");
+    }
+
     // ---- snapshot / epoch ----------------------------------------------------------------------
 
     function test_snapshot_pins_seed_setroot_count() public {
@@ -345,13 +366,80 @@ contract AAStarCommitteeValidatorTest is Test {
 
     // ---- Codex-round fixes ---------------------------------------------------------------------
 
-    // High: epochLength == 1 is permanently unpinnable, so the setter must reject it.
-    function test_setEpochLength_rejects_one() public {
+    // epochLength must be 0 or >= 64 (window min(256, epochLength-1) must be usable; 1 is unpinnable).
+    function test_setEpochLength_bounds() public {
         MockCommitteeValidator w = new MockCommitteeValidator();
-        vm.expectRevert("epochLength must be 0 or >= 2");
+        vm.expectRevert("epochLength must be 0 or >= 64");
         w.setEpochLength(1);
-        w.setEpochLength(0); // 0 (disable) allowed
-        w.setEpochLength(2); // >= 2 allowed
+        vm.expectRevert("epochLength must be 0 or >= 64");
+        w.setEpochLength(63);
+        w.setEpochLength(0); // disable allowed
+        w.setEpochLength(64); // >= 64 allowed
+    }
+
+    // pr-daemon Medium (coverage): the discriminating look-ahead test. A node registered AFTER the
+    // set was frozen for the epoch (i.e. not in setRoot[e-1]) must be rejected even though it is
+    // currently registered and would pass sortition. Deleting the look-ahead (using setRoot[e]) flips
+    // this to accept. Uses getMerkleProof against the CURRENT tree, so the frozen vs live divergence
+    // is genuinely exercised.
+    function test_validate_lookahead_rejects_post_freeze_registrant() public {
+        bytes32[] memory ids = _registerNodes(3);
+        _rollAndSnapshot(1, bytes32(uint256(0xAA))); // setRoot[1] frozen with exactly these 3 nodes
+
+        // Capture a valid frozen-member payload NOW, while the live tree still equals setRoot[1].
+        bytes32[] memory frozen = new bytes32[](2);
+        frozen[0] = ids[0];
+        frozen[1] = ids[1];
+        bytes memory frozenPayload = _payload(ACCOUNT, frozen);
+
+        // Register a 4th node AFTER the freeze: it enters the live tree (root changes) but NOT setRoot[1].
+        vm.roll(EPOCH_LEN + 5);
+        bytes32 late = keccak256("late-node");
+        v.registerPublicKey(late, DUMMY_KEY);
+        _rollAndSnapshot(2, bytes32(uint256(0xBB))); // seed[2]; epoch-2 committees use setRoot[1]
+
+        // The pre-captured frozen payload still validates (setRoot[1] is immutable).
+        assertEq(v.validate(keccak256("op"), frozenPayload), 0, "frozen members remain valid");
+
+        // The late node is currently registered and passes whole-set sortition, but ANY proof for it
+        // (built against the live root) cannot match setRoot[1] -> rejected. This is the discriminator:
+        // deleting the look-ahead (validating against setRoot[e]) would ACCEPT it.
+        bytes32[] memory withLate = new bytes32[](2);
+        withLate[0] = ids[0] < late ? ids[0] : late;
+        withLate[1] = ids[0] < late ? late : ids[0];
+        assertEq(
+            v.validate(keccak256("op"), _payload(ACCOUNT, withLate)),
+            1,
+            "post-freeze registrant must not be a valid committee member"
+        );
+    }
+
+    // pr-daemon B3: setOversample must bump configVersion so it cannot retroactively relax the
+    // sortition gate on an already-pinned epoch (setOversample(5,1) collapses T to max otherwise).
+    function test_setOversample_invalidates_pinned_epochs() public {
+        bytes32[] memory ids = _registerNodes(3);
+        _rollAndSnapshot(1, bytes32(uint256(0xAA)));
+        _rollAndSnapshot(2, bytes32(uint256(0xBB)));
+        bytes32[] memory signers = new bytes32[](2);
+        signers[0] = ids[0];
+        signers[1] = ids[1];
+        bytes memory payload = _payload(ACCOUNT, signers);
+        assertEq(v.validate(keccak256("op"), payload), 0, "valid before oversample change");
+
+        v.setOversample(5, 1); // would collapse the gate — must instead invalidate pinned epochs
+        assertEq(v.validate(keccak256("op"), payload), 1, "pinned epochs fail-closed after oversample change");
+    }
+
+    // pr-daemon Medium: a set mutation in the same block as the freeze is rejected, so syncNode
+    // evictions cannot be atomically composed with snapshotEpoch to depress epochSetCount.
+    function test_snapshot_rejects_same_block_mutation() public {
+        _registerNodes(3);
+        vm.roll(EPOCH_LEN + 1);
+        vm.setBlockhash(EPOCH_LEN, bytes32(uint256(0xAA)));
+        // Mutate the set in THIS block, then try to freeze in the same block.
+        v.registerPublicKey(keccak256("same-block"), DUMMY_KEY);
+        vm.expectRevert("set mutated this block");
+        v.snapshotEpoch();
     }
 
     // Medium: unbounded oversample would overflow _thresholdOf and turn fail-closed into a revert.

--- a/contracts/test/AAStarCommitteeValidator.t.sol
+++ b/contracts/test/AAStarCommitteeValidator.t.sol
@@ -194,30 +194,33 @@ contract AAStarCommitteeValidatorTest is Test {
 
     // ---- committee math ------------------------------------------------------------------------
 
-    // DSR-locked curve (9a9f47c9): m_e = N for N<=8; else clamp(ceil(N/5), 17, 86).
+    // Two-tail curve (B5): m_e = N for N<=8; else clamp(ceil(N/5), 30, 86).
     function test_expectedCommittee_curve() public view {
         assertEq(v.expectedCommittee(3), 3); // bootstrap: whole set
         assertEq(v.expectedCommittee(8), 8);
-        assertEq(v.expectedCommittee(9), 9); // floor 17 > n => capped to n (whole set)
-        assertEq(v.expectedCommittee(16), 16); // still capped at n
-        assertEq(v.expectedCommittee(17), 17); // floor 17
-        assertEq(v.expectedCommittee(20), 17); // ceil(20/5)=4 -> floor 17
-        assertEq(v.expectedCommittee(81), 17); // ceil(81/5)=17
-        assertEq(v.expectedCommittee(100), 20); // ceil(100/5)=20
+        assertEq(v.expectedCommittee(9), 9); // floor 30 > n => capped to n (whole set)
+        assertEq(v.expectedCommittee(29), 29); // still capped at n
+        assertEq(v.expectedCommittee(30), 30); // floor 30
+        assertEq(v.expectedCommittee(100), 30); // ceil(100/5)=20 -> floor 30
         assertEq(v.expectedCommittee(150), 30); // ceil(150/5)=30
+        assertEq(v.expectedCommittee(155), 31); // ceil(155/5)=31
         assertEq(v.expectedCommittee(300), 60); // ceil(300/5)=60
         assertEq(v.expectedCommittee(430), 86); // ceil(430/5)=86 = cap
         assertEq(v.expectedCommittee(1000), 86); // cap
     }
 
-    // pr-daemon B1 discriminators: (a) the on-chain (m_e, requiredQuorum) triple matches DSR's ε table
-    // rows, and (b) m_e is monotonic non-decreasing in N (=> the Poisson tail ε is non-increasing in N,
-    // closing the "security gets worse as the pool grows" finding).
-    function test_B1_curve_matches_DSR_table() public view {
-        // (N, m_e, requiredQuorum=ceil(2*m_e/3)) from DSR 9a9f47c9.
+    // pr-daemon B5 discriminator: the table must assert BOTH tails, not just forgery. On-chain we assert
+    // the (m_e, requiredQuorum) pair AND the deterministic liveness precondition the low liveness tail
+    // rests on — E[committee] = ceil(1.25*m_e) clears requiredQuorum with margin. Offline exact tails
+    // (oversample=1.25, verified by a full Binom/Poisson scan over n in [9,20000]):
+    //   N=40   m_e=30 req=20  forgery @β10% ~4.4e-9   liveness ~1.6e-4
+    //   N=150  m_e=30 req=20  forgery ~4.4e-9         liveness ~1.6e-4 (worst liveness point ~n=160)
+    //   N=300  m_e=60 req=40  forgery ~1e-16          liveness ~1e-8
+    //   N=430  m_e=86 req=58  forgery ~1e-24          liveness ~0
+    function test_B5_curve_two_tail_table() public view {
         uint256[3][6] memory rows = [
-            [uint256(20), 17, 12],
-            [uint256(100), 20, 14],
+            [uint256(40), 30, 20],
+            [uint256(100), 30, 20],
             [uint256(150), 30, 20],
             [uint256(300), 60, 40],
             [uint256(430), 86, 58],
@@ -225,9 +228,20 @@ contract AAStarCommitteeValidatorTest is Test {
         ];
         for (uint256 i = 0; i < rows.length; i++) {
             uint256 me = v.expectedCommittee(rows[i][0]);
-            assertEq(me, rows[i][1], "m_e mismatch vs DSR table");
-            assertEq((2 * me + 2) / 3, rows[i][2], "requiredQuorum mismatch vs DSR table");
+            uint256 req = (2 * me + 2) / 3;
+            assertEq(me, rows[i][1], "m_e mismatch");
+            assertEq(req, rows[i][2], "requiredQuorum mismatch");
+            // Liveness precondition: the oversampled mean committee must exceed requiredQuorum.
+            uint256 target = (v.oversampleNum() * me + v.oversampleDen() - 1) / v.oversampleDen();
+            assertGt(target, req, "E[committee] must clear requiredQuorum (liveness margin)");
         }
+    }
+
+    // The whole two-tail argument rests on oversample=1.25; pin the constructor default (a prior-round
+    // surviving mutant flipped it back to 1/1 with all-green tests).
+    function test_constructor_oversample() public view {
+        assertEq(v.oversampleNum(), 5);
+        assertEq(v.oversampleDen(), 4);
     }
 
     function test_B1_curve_monotonic() public view {
@@ -501,7 +515,9 @@ contract AAStarCommitteeValidatorTest is Test {
         bytes memory bad = good;
         uint256 highBit = 1 << 160;
         bytes32 tainted = bytes32(uint256(uint160(ACCOUNT)) | highBit);
-        for (uint256 b = 0; b < 32; b++) bad[b] = tainted[b];
+        for (uint256 b = 0; b < 32; b++) {
+            bad[b] = tainted[b];
+        }
         assertEq(v.validate(keccak256("op"), bad), 1, "non-canonical accountId must fail");
     }
 
@@ -517,7 +533,9 @@ contract AAStarCommitteeValidatorTest is Test {
         uint256 base = uint256(uint160(ACCOUNT));
         for (uint256 g = 1; g <= 300; g++) {
             bytes32 tainted = bytes32(base | (g << 160)); // vary only the high 96 bits
-            for (uint256 b = 0; b < 32; b++) p[b] = tainted[b];
+            for (uint256 b = 0; b < 32; b++) {
+                p[b] = tainted[b];
+            }
             assertEq(v.validate(keccak256("op"), p), 1, "no high-bit grind may be accepted");
         }
     }
@@ -545,16 +563,30 @@ contract AAStarCommitteeValidatorTest is Test {
         assertEq(v.validate(keccak256("op"), payload), 1, "pinned epochs fail-closed after oversample change");
     }
 
-    // pr-daemon Medium: a set mutation in the same block as the freeze is rejected, so syncNode
-    // evictions cannot be atomically composed with snapshotEpoch to depress epochSetCount.
-    function test_snapshot_rejects_same_block_mutation() public {
+    // pr-daemon round-2 High: snapshotEpoch no longer reverts on a same-block mutation (that revert was
+    // a migration-boundary DoS). Instead it freezes the BLOCK-START state, so an atomic evict-then-freeze
+    // cannot depress epochSetCount. Here: 3 nodes, then a same-block registration, then freeze in that
+    // block -> the snapshot must pin count 3 (pre-mutation), not 4, and NOT revert.
+    function test_snapshot_freezes_block_start_state() public {
         _registerNodes(3);
+        bytes32 rootBefore = v.runningRoot();
         vm.roll(EPOCH_LEN + 1);
         vm.setBlockhash(EPOCH_LEN, bytes32(uint256(0xAA)));
-        // Mutate the set in THIS block, then try to freeze in the same block.
-        v.registerPublicKey(keccak256("same-block"), DUMMY_KEY);
-        vm.expectRevert("set mutated this block");
+        v.registerPublicKey(keccak256("same-block"), DUMMY_KEY); // mutate in the freeze block
+        v.snapshotEpoch(); // must NOT revert
+        assertEq(v.epochSetCount(1), 3, "freezes pre-mutation (block-start) count, not 4");
+        assertEq(v.epochSetRoot(1), rootBefore, "freezes pre-mutation root");
+    }
+
+    // A mutation in an EARLIER block than the freeze is included normally (block-start == current).
+    function test_snapshot_includes_prior_block_mutation() public {
+        _registerNodes(3);
+        vm.roll(EPOCH_LEN - 1);
+        v.registerPublicKey(keccak256("prior-block"), DUMMY_KEY); // 4th node, earlier block
+        vm.roll(EPOCH_LEN + 1);
+        vm.setBlockhash(EPOCH_LEN, bytes32(uint256(0xAA)));
         v.snapshotEpoch();
+        assertEq(v.epochSetCount(1), 4, "prior-block mutation included");
     }
 
     // Medium: unbounded oversample would overflow _thresholdOf and turn fail-closed into a revert.

--- a/contracts/test/AAStarCommitteeValidator.t.sol
+++ b/contracts/test/AAStarCommitteeValidator.t.sol
@@ -484,6 +484,51 @@ contract AAStarCommitteeValidatorTest is Test {
         assertEq(v.validate(keccak256("op"), _payload(address(0xDEAD), signers)), 1, "unenrolled => fail-closed");
     }
 
+    // pr-daemon B4: accountId must be canonical (high 96 bits zero). The enrollment gate reads the low
+    // 160 bits but the draw consumes all 256, so a set high bit would be a free grind surface.
+    function test_validate_rejects_noncanonical_accountId() public {
+        bytes32[] memory ids = _registerNodes(3);
+        _rollAndSnapshot(1, bytes32(uint256(0xAA)));
+        _rollAndSnapshot(2, bytes32(uint256(0xBB)));
+        bytes32[] memory signers = new bytes32[](2);
+        signers[0] = ids[0];
+        signers[1] = ids[1];
+        // Canonical accountId (== ACCOUNT, enrolled) validates.
+        bytes memory good = _payload(ACCOUNT, signers);
+        assertEq(v.validate(keccak256("op"), good), 0, "canonical accountId valid");
+        // Same low 160 bits (ACCOUNT, enrolled) but a high bit set -> must be rejected, not accepted via
+        // the low-160 enrollment match.
+        bytes memory bad = good;
+        uint256 highBit = 1 << 160;
+        bytes32 tainted = bytes32(uint256(uint160(ACCOUNT)) | highBit);
+        for (uint256 b = 0; b < 32; b++) bad[b] = tainted[b];
+        assertEq(v.validate(keccak256("op"), bad), 1, "non-canonical accountId must fail");
+    }
+
+    // Bounded grind on the high 96 bits: none may be accepted (the probe found a low-160 collision fast).
+    function test_validate_highbits_grind_all_rejected() public {
+        bytes32[] memory ids = _registerNodes(3);
+        _rollAndSnapshot(1, bytes32(uint256(0xAA)));
+        _rollAndSnapshot(2, bytes32(uint256(0xBB)));
+        bytes32[] memory signers = new bytes32[](2);
+        signers[0] = ids[0];
+        signers[1] = ids[1];
+        bytes memory p = _payload(ACCOUNT, signers);
+        uint256 base = uint256(uint160(ACCOUNT));
+        for (uint256 g = 1; g <= 300; g++) {
+            bytes32 tainted = bytes32(base | (g << 160)); // vary only the high 96 bits
+            for (uint256 b = 0; b < 32; b++) p[b] = tainted[b];
+            assertEq(v.validate(keccak256("op"), p), 1, "no high-bit grind may be accepted");
+        }
+    }
+
+    // pr-daemon Low: pin the requiredQuorum sentinel (max, NOT 0 which would be fail-open) + the
+    // constructor oversample default (the whole B1 argument rests on it).
+    function test_requiredQuorum_sentinel_is_max_not_zero() public {
+        MockCommitteeValidator w = new MockCommitteeValidator(); // epochLength 0
+        assertEq(w.requiredQuorum(), type(uint256).max, "sentinel must be max (fail-closed), never 0");
+    }
+
     // pr-daemon B3: setOversample must bump configVersion so it cannot retroactively relax the
     // sortition gate on an already-pinned epoch (setOversample(5,1) collapses T to max otherwise).
     function test_setOversample_invalidates_pinned_epochs() public {

--- a/contracts/test/AAStarCommitteeValidator.t.sol
+++ b/contracts/test/AAStarCommitteeValidator.t.sol
@@ -14,20 +14,20 @@ contract MockCommitteeValidator is AAStarCommitteeValidator {
         blsResult = v;
     }
 
-    function _validateBLSSignatureMem(
-        bytes32[] memory,
-        bytes memory,
-        bytes memory
-    ) internal view override returns (bool) {
+    function _validateBLSSignatureMem(bytes32[] memory, bytes memory, bytes memory)
+        internal
+        view
+        override
+        returns (bool)
+    {
         return blsResult;
     }
 
-    function exposedVerifyMerkle(
-        bytes32 root,
-        uint256 slot,
-        bytes32 leaf,
-        bytes calldata proof
-    ) external pure returns (bool) {
+    function exposedVerifyMerkle(bytes32 root, uint256 slot, bytes32 leaf, bytes calldata proof)
+        external
+        pure
+        returns (bool)
+    {
         return _verifyMerkle(root, slot, leaf, proof);
     }
 
@@ -52,8 +52,12 @@ contract AAStarCommitteeValidatorTest is Test {
 
         DUMMY_KEY = new bytes(128);
         DUMMY_SIG = new bytes(256);
-        for (uint256 i = 0; i < 128; i++) DUMMY_KEY[i] = bytes1(uint8(1 + (i % 250)));
-        for (uint256 i = 0; i < 256; i++) DUMMY_SIG[i] = bytes1(uint8(1 + (i % 250)));
+        for (uint256 i = 0; i < 128; i++) {
+            DUMMY_KEY[i] = bytes1(uint8(1 + (i % 250)));
+        }
+        for (uint256 i = 0; i < 256; i++) {
+            DUMMY_SIG[i] = bytes1(uint8(1 + (i % 250)));
+        }
     }
 
     // ---- helpers -------------------------------------------------------------------------------
@@ -86,15 +90,14 @@ contract AAStarCommitteeValidatorTest is Test {
     }
 
     /// @dev Build the committee payload: accountId || [nodeId || proof]... || blsSig.
-    function _payload(
-        address account,
-        bytes32[] memory signers
-    ) internal view returns (bytes memory out) {
+    function _payload(address account, bytes32[] memory signers) internal view returns (bytes memory out) {
         out = abi.encodePacked(bytes32(uint256(uint160(account))));
         for (uint256 i = 0; i < signers.length; i++) {
             (, bytes32[] memory proof) = v.getMerkleProof(signers[i]);
             out = abi.encodePacked(out, signers[i]);
-            for (uint256 j = 0; j < proof.length; j++) out = abi.encodePacked(out, proof[j]);
+            for (uint256 j = 0; j < proof.length; j++) {
+                out = abi.encodePacked(out, proof[j]);
+            }
         }
         out = abi.encodePacked(out, DUMMY_SIG);
     }
@@ -106,16 +109,14 @@ contract AAStarCommitteeValidatorTest is Test {
         for (uint256 i = 0; i < ids.length; i++) {
             (uint256 slot, bytes32[] memory proof) = v.getMerkleProof(ids[i]);
             bytes memory flat;
-            for (uint256 j = 0; j < proof.length; j++) flat = abi.encodePacked(flat, proof[j]);
+            for (uint256 j = 0; j < proof.length; j++) {
+                flat = abi.encodePacked(flat, proof[j]);
+            }
             assertTrue(
-                v.exposedVerifyMerkle(v.runningRoot(), slot, ids[i], flat),
-                "proof must verify against current root"
+                v.exposedVerifyMerkle(v.runningRoot(), slot, ids[i], flat), "proof must verify against current root"
             );
             // A wrong leaf must NOT verify.
-            assertFalse(
-                v.exposedVerifyMerkle(v.runningRoot(), slot, keccak256("wrong"), flat),
-                "wrong leaf must fail"
-            );
+            assertFalse(v.exposedVerifyMerkle(v.runningRoot(), slot, keccak256("wrong"), flat), "wrong leaf must fail");
         }
     }
 
@@ -189,7 +190,9 @@ contract AAStarCommitteeValidatorTest is Test {
         // whole set (m=12), quorum = ceil(2*12/3) = 8. Provide 8 ascending signers.
         assertEq(v.requiredQuorum(), 8);
         bytes32[] memory signers = new bytes32[](8);
-        for (uint256 i = 0; i < 8; i++) signers[i] = ids[i];
+        for (uint256 i = 0; i < 8; i++) {
+            signers[i] = ids[i];
+        }
         assertEq(v.validate(keccak256("op"), _payload(ACCOUNT, signers)), 0, "12-node pool must be satisfiable");
     }
 
@@ -294,7 +297,9 @@ contract AAStarCommitteeValidatorTest is Test {
         bytes32[] memory chosen = new bytes32[](required);
         uint256 c;
         for (uint256 i = 0; i < ids.length && c < required; i++) {
-            uint256 draw = uint256(keccak256(abi.encode(keccak256("CMT_SELECT"), seed, bytes32(uint256(uint160(ACCOUNT))), ids[i])));
+            uint256 draw = uint256(
+                keccak256(abi.encode(keccak256("CMT_SELECT"), seed, bytes32(uint256(uint160(ACCOUNT))), ids[i]))
+            );
             if (draw < T) {
                 chosen[c++] = ids[i];
             }
@@ -308,7 +313,9 @@ contract AAStarCommitteeValidatorTest is Test {
         // sanity: ensure not all `chosen` are also selected for `other` (else the test is vacuous)
         bool someExcluded;
         for (uint256 i = 0; i < chosen.length; i++) {
-            uint256 draw = uint256(keccak256(abi.encode(keccak256("CMT_SELECT"), seed, bytes32(uint256(uint160(other))), chosen[i])));
+            uint256 draw = uint256(
+                keccak256(abi.encode(keccak256("CMT_SELECT"), seed, bytes32(uint256(uint160(other))), chosen[i]))
+            );
             if (draw >= T) someExcluded = true;
         }
         if (someExcluded) {

--- a/contracts/test/AAStarCommitteeValidator.t.sol
+++ b/contracts/test/AAStarCommitteeValidator.t.sol
@@ -351,50 +351,101 @@ contract AAStarCommitteeValidatorTest is Test {
         assertEq(v.validate(keccak256("op"), payload), 1, "tampered proof must fail");
     }
 
-    function test_validate_rejects_wrong_accountId_committee() public {
-        // With a partial-selection pool, the committee is account-specific: proofs valid but the
-        // sortition draw for a DIFFERENT account excludes these signers => fail. Demonstrates the
-        // account-binding of committee membership.
-        bytes32[] memory ids = _registerNodes(40); // n=40 => m=16, target=ceil(1.15*16)=19 < 40 => partial
+    /// @dev Sortition draw for `account`/`nid` matching the contract exactly.
+    function _draw(address account, bytes32 nid, bytes32 seed) internal pure returns (uint256) {
+        return uint256(keccak256(abi.encode(keccak256("CMT_SELECT"), seed, bytes32(uint256(uint160(account))), nid)));
+    }
+
+    /// @dev Partition a registered pool into ACCOUNT's committee vs the rest, for a partial-sampling pool.
+    function _partition(bytes32[] memory ids, address account, bytes32 seed, uint256 T)
+        internal
+        pure
+        returns (bytes32[] memory sel, bytes32[] memory non)
+    {
+        sel = new bytes32[](ids.length);
+        non = new bytes32[](ids.length);
+        uint256 ns;
+        uint256 nn;
+        for (uint256 i = 0; i < ids.length; i++) {
+            if (_draw(account, ids[i], seed) < T) sel[ns++] = ids[i];
+            else non[nn++] = ids[i];
+        }
+        assembly {
+            mstore(sel, ns)
+            mstore(non, nn)
+        }
+    }
+
+    // pr-daemon round-3: the CORE mechanism must have a discriminating regression test. n=100 => m=30,
+    // T with oversample 1.25 => ~38% selected, a clean partial split. Baseline of `required` committee
+    // members validates; swapping ONE for a non-committee node (still registered + Merkle-valid) must be
+    // rejected BY SORTITION. Deleting the draw check flips the second assert 1->0 (verified by mutation).
+    function test_validate_sortition_rejects_noncommittee_signer() public {
+        bytes32[] memory ids = _registerNodes(100);
         _rollAndSnapshot(1, bytes32(uint256(0xAA)));
         _rollAndSnapshot(2, bytes32(uint256(0xBB)));
-
         bytes32 seed = v.epochSeed(2);
-        uint256 n = v.epochSetCount(1);
-        uint256 m = v.expectedCommittee(n);
-        uint256 T = v.exposedThreshold(n, m);
+        uint256 m = v.expectedCommittee(v.epochSetCount(1));
+        uint256 T = v.exposedThreshold(v.epochSetCount(1), m);
+        uint256 required = (2 * m + 2) / 3;
+        assertLt(T, type(uint256).max, "pool must be in partial-sampling regime");
+
+        (bytes32[] memory sel, bytes32[] memory non) = _partition(ids, ACCOUNT, seed, T);
+        require(sel.length >= required && non.length >= 1, "setup: need selected + a non-selected node");
+
+        // Baseline: `required` committee members validate.
+        bytes32[] memory good = new bytes32[](required);
+        for (uint256 i = 0; i < required; i++) {
+            good[i] = sel[i];
+        }
+        _sortAsc(good);
+        assertEq(v.validate(keccak256("op"), _payload(ACCOUNT, good)), 0, "all-committee signers valid");
+
+        // Discriminator: replace one member with a NON-committee node -> sortition must reject.
+        bytes32[] memory mixed = new bytes32[](required);
+        for (uint256 i = 0; i < required - 1; i++) {
+            mixed[i] = sel[i];
+        }
+        mixed[required - 1] = non[0];
+        _sortAsc(mixed);
+        assertEq(
+            v.validate(keccak256("op"), _payload(ACCOUNT, mixed)),
+            1,
+            "a non-committee signer must be rejected by sortition"
+        );
+    }
+
+    // Account-binding: the SAME committee members that pass for ACCOUNT must be rejected for a different
+    // account (different draw). Asserts unconditionally (the prior version guarded the assert behind an
+    // `if (someExcluded)` that was always false — pr-daemon round-3).
+    function test_validate_committee_is_account_bound() public {
+        bytes32[] memory ids = _registerNodes(100);
+        _rollAndSnapshot(1, bytes32(uint256(0xAA)));
+        _rollAndSnapshot(2, bytes32(uint256(0xBB)));
+        bytes32 seed = v.epochSeed(2);
+        uint256 m = v.expectedCommittee(v.epochSetCount(1));
+        uint256 T = v.exposedThreshold(v.epochSetCount(1), m);
         uint256 required = (2 * m + 2) / 3;
 
-        // Collect `required` signers that ARE in ACCOUNT's committee.
+        (bytes32[] memory sel,) = _partition(ids, ACCOUNT, seed, T);
+        require(sel.length >= required, "setup: need enough ACCOUNT committee members");
         bytes32[] memory chosen = new bytes32[](required);
-        uint256 c;
-        for (uint256 i = 0; i < ids.length && c < required; i++) {
-            uint256 draw = uint256(
-                keccak256(abi.encode(keccak256("CMT_SELECT"), seed, bytes32(uint256(uint160(ACCOUNT))), ids[i]))
-            );
-            if (draw < T) {
-                chosen[c++] = ids[i];
-            }
+        for (uint256 i = 0; i < required; i++) {
+            chosen[i] = sel[i];
         }
-        require(c == required, "need enough selected signers for ACCOUNT");
         _sortAsc(chosen);
-        // Valid for ACCOUNT.
-        assertEq(v.validate(keccak256("op"), _payload(ACCOUNT, chosen)), 0, "selected committee valid for its account");
-        // Same signers, DIFFERENT account => at least one is out of that account's committee => fail.
+        assertEq(v.validate(keccak256("op"), _payload(ACCOUNT, chosen)), 0, "valid for its own account");
+
         address other = address(0xB0B);
         vm.prank(other);
-        v.enroll(); // enroll so the rejection below is by committee sortition, not by enrollment
-        // sanity: ensure not all `chosen` are also selected for `other` (else the test is vacuous)
+        v.enroll();
+        // At least one of `chosen` must be outside `other`'s committee (draw >= T) — assert it, don't skip.
         bool someExcluded;
         for (uint256 i = 0; i < chosen.length; i++) {
-            uint256 draw = uint256(
-                keccak256(abi.encode(keccak256("CMT_SELECT"), seed, bytes32(uint256(uint160(other))), chosen[i]))
-            );
-            if (draw >= T) someExcluded = true;
+            if (_draw(other, chosen[i], seed) >= T) someExcluded = true;
         }
-        if (someExcluded) {
-            assertEq(v.validate(keccak256("op"), _payload(other, chosen)), 1, "committee is account-bound");
-        }
+        require(someExcluded, "setup: chosen must not be a full committee for other too");
+        assertEq(v.validate(keccak256("op"), _payload(other, chosen)), 1, "committee is account-bound");
     }
 
     function test_requiredQuorum_view_tracks_lookahead() public {
@@ -496,6 +547,18 @@ contract AAStarCommitteeValidatorTest is Test {
         // An un-enrolled accountId (e.g. a flip-order fabricated prefix) fails closed regardless of the
         // committee/sortition — this blocks the B2 shape-collision path on-chain.
         assertEq(v.validate(keccak256("op"), _payload(address(0xDEAD), signers)), 1, "unenrolled => fail-closed");
+    }
+
+    // pr-daemon round-3 regression: a short signature must fail closed (return 1), NOT revert on an
+    // out-of-bounds calldata slice. Committee mode on, snapshots present so the length guard is reached.
+    function test_validate_short_signature_fails_closed() public {
+        _registerNodes(3);
+        _rollAndSnapshot(1, bytes32(uint256(0xAA)));
+        _rollAndSnapshot(2, bytes32(uint256(0xBB)));
+        assertEq(v.validate(keccak256("op"), hex""), 1, "empty sig => return 1");
+        assertEq(v.validate(keccak256("op"), hex"01020304"), 1, "4-byte sig => return 1");
+        bytes memory b31 = new bytes(31);
+        assertEq(v.validate(keccak256("op"), b31), 1, "31-byte sig => return 1 (no accountId slice revert)");
     }
 
     // pr-daemon B4: accountId must be canonical (high 96 bits zero). The enrollment gate reads the low

--- a/contracts/test/AAStarCommitteeValidator.t.sol
+++ b/contracts/test/AAStarCommitteeValidator.t.sol
@@ -395,4 +395,44 @@ contract AAStarCommitteeValidatorTest is Test {
         assertEq(v.validate(keccak256("op"), payload), 1, "stale snapshots => fail-closed after reconfig");
         assertEq(v.requiredQuorum(), type(uint256).max, "requiredQuorum unusable until re-pinned");
     }
+
+    // Round-2 High: after a configVersion bump, an epoch pinned under the OLD version must be
+    // re-pinnable under the new one (else colliding epoch numbers strand committee mode forever).
+    function test_snapshot_repin_after_reconfig() public {
+        _registerNodes(3);
+        vm.roll(3 * EPOCH_LEN + 1);
+        vm.setBlockhash(3 * EPOCH_LEN, bytes32(uint256(0xCC)));
+        v.snapshotEpoch(); // pinned under configVersion 1
+        assertEq(v.epochConfigVersion(3), 1);
+
+        v.setEpochLength(EPOCH_LEN); // configVersion -> 2
+        // Same epoch/block: the stale pin must be replaceable, not rejected as "already pinned".
+        v.snapshotEpoch();
+        assertEq(v.epochConfigVersion(3), 2, "epoch re-pinned under new configVersion");
+    }
+
+    // Round-2 Low: a non-canonical slot (slot + 2^TREE_DEPTH) must be rejected, not aliased.
+    function test_validate_rejects_noncanonical_slot() public {
+        bytes32[] memory ids = _registerNodes(3);
+        _rollAndSnapshot(1, bytes32(uint256(0xAA)));
+        _rollAndSnapshot(2, bytes32(uint256(0xBB)));
+        bytes32[] memory signers = new bytes32[](2);
+        signers[0] = ids[0];
+        signers[1] = ids[1];
+        bytes memory payload = _payload(ACCOUNT, signers);
+        // Add 2^TREE_DEPTH to signer 0's slot word (offset 64) — same low bits, must be rejected.
+        uint256 aliased = (1 << v.TREE_DEPTH()); // canonical slot is 0 or 1 here; +2^depth aliases it
+        bytes32 slotWord = bytes32(uint256(bytes32(_slice(payload, 64, 32))) + aliased);
+        for (uint256 b = 0; b < 32; b++) {
+            payload[64 + b] = slotWord[b];
+        }
+        assertEq(v.validate(keccak256("op"), payload), 1, "non-canonical slot must be rejected");
+    }
+
+    function _slice(bytes memory data, uint256 start, uint256 len) internal pure returns (bytes memory out) {
+        out = new bytes(len);
+        for (uint256 i = 0; i < len; i++) {
+            out[i] = data[start + i];
+        }
+    }
 }

--- a/contracts/test/AAStarCommitteeValidator.t.sol
+++ b/contracts/test/AAStarCommitteeValidator.t.sol
@@ -194,15 +194,50 @@ contract AAStarCommitteeValidatorTest is Test {
 
     // ---- committee math ------------------------------------------------------------------------
 
+    // DSR-locked curve (9a9f47c9): m_e = N for N<=8; else clamp(ceil(N/5), 17, 86).
     function test_expectedCommittee_curve() public view {
         assertEq(v.expectedCommittee(3), 3); // bootstrap: whole set
         assertEq(v.expectedCommittee(8), 8);
-        assertEq(v.expectedCommittee(9), 9); // floor-16 capped at n (liveness: never sample > pool)
-        assertEq(v.expectedCommittee(15), 15); // still capped at n
-        assertEq(v.expectedCommittee(16), 16); // floor
-        assertEq(v.expectedCommittee(80), 16); // n/5=16
-        assertEq(v.expectedCommittee(100), 20); // n/5
-        assertEq(v.expectedCommittee(1000), 110); // cap
+        assertEq(v.expectedCommittee(9), 9); // floor 17 > n => capped to n (whole set)
+        assertEq(v.expectedCommittee(16), 16); // still capped at n
+        assertEq(v.expectedCommittee(17), 17); // floor 17
+        assertEq(v.expectedCommittee(20), 17); // ceil(20/5)=4 -> floor 17
+        assertEq(v.expectedCommittee(81), 17); // ceil(81/5)=17
+        assertEq(v.expectedCommittee(100), 20); // ceil(100/5)=20
+        assertEq(v.expectedCommittee(150), 30); // ceil(150/5)=30
+        assertEq(v.expectedCommittee(300), 60); // ceil(300/5)=60
+        assertEq(v.expectedCommittee(430), 86); // ceil(430/5)=86 = cap
+        assertEq(v.expectedCommittee(1000), 86); // cap
+    }
+
+    // pr-daemon B1 discriminators: (a) the on-chain (m_e, requiredQuorum) triple matches DSR's ε table
+    // rows, and (b) m_e is monotonic non-decreasing in N (=> the Poisson tail ε is non-increasing in N,
+    // closing the "security gets worse as the pool grows" finding).
+    function test_B1_curve_matches_DSR_table() public view {
+        // (N, m_e, requiredQuorum=ceil(2*m_e/3)) from DSR 9a9f47c9.
+        uint256[3][6] memory rows = [
+            [uint256(20), 17, 12],
+            [uint256(100), 20, 14],
+            [uint256(150), 30, 20],
+            [uint256(300), 60, 40],
+            [uint256(430), 86, 58],
+            [uint256(2000), 86, 58]
+        ];
+        for (uint256 i = 0; i < rows.length; i++) {
+            uint256 me = v.expectedCommittee(rows[i][0]);
+            assertEq(me, rows[i][1], "m_e mismatch vs DSR table");
+            assertEq((2 * me + 2) / 3, rows[i][2], "requiredQuorum mismatch vs DSR table");
+        }
+    }
+
+    function test_B1_curve_monotonic() public view {
+        uint256 prev = 0;
+        for (uint256 n = 9; n <= 3000; n += 7) {
+            uint256 me = v.expectedCommittee(n);
+            assertGe(me, prev, "m_e must be non-decreasing in N (tail non-increasing)");
+            prev = me;
+        }
+        assertEq(prev, 86, "curve tops out at the cap");
     }
 
     /// @dev Regression for the 9..15 pool liveness DoS: quorum must be satisfiable (<= n).


### PR DESCRIPTION
## Status: DRAFT / HELD — two design-level Criticals escalated (CC-98)

pr-daemon (4-round PK) found two blocking issues Codex's 3 rounds missed. Both are design/cross-repo, not unilaterally fixable by dvt — escalated on CC-98, PR held:

- **B1 (Critical)** — the sortition curve never requires an honest signer: an attacker holding β of the pool forges with only its OWN ⌈2m/3⌉ selected nodes. `m ≤ 110` caps the tail at ~6.6e-6 (no `n` reaches 1e-9; worst point n=84 = 3.5e-2). Needs **DSR's written security target + corrected m/T curve**.
- **B2 (Critical)** — `accountId` is calldata-trusted; the account-injection invariant is cross-repo and **airaccount #200 is draft/HOLD** → no interlock (flipping the switch first makes attacker-crafted legacy-shaped payloads parse as valid committee payloads). Needs **airaccount interlock + per-account enrollment**.

Self-contained pr-daemon findings **are fixed** in this branch (B3 setOversample configVersion, requiredQuorum default-config sentinel, syncNode/snapshot atomicity, window floor, slot events, discriminating look-ahead + syncNode coverage tests). 105 tests pass.

---

## What

Production on-chain instantiation of the CC-98 per-proposal random-committee model (airaccount-contract + dvt + DSR). Replaces CC-97's global ⌈2N/3⌉ (unbounded registry → quorum exceeds the single-call node cap → network-wide fail-close).

`AAStarCommitteeValidator is AAStarValidator` — reuses all BLS / RFC-9380 / pairing crypto; adds the committee subsystem: incremental sparse-Merkle active-set commitment (TREE_DEPTH=14), `snapshotEpoch()` double-snapshot with one-epoch look-ahead (set frozen strictly before the seed is revealed → closes register-to-order), per-signer Merkle+sortition in `validate()` (zero extra pairings), DSR m/T curve.

**Wire format** (account prepends accountId; submitter provides the rest):
```
signature = [accountId(32)] [ per signer: nodeId(32) | slot(32) | merkleProof(TREE_DEPTH*32) ]... [ blsSig(256) ]
```
(slot = the node's leaf index in the FROZEN setRoot[e-1], authenticated by the proof.)

## Review trail
- Codex Tier-1 (3 rounds): APPROVED — but missed B1/B2 (soundness/cross-repo).
- pr-daemon (4-round PK, Opus-adjudicated): B1/B2 Critical (escalated), plus self-contained findings (fixed here).
- Self-review (4 rounds): fixed the m_e-cap liveness DoS + whole-set edge.

## Tests
105 total pass (committee suite includes mutation-verified look-ahead + hook discriminators).

## NOT in scope / blocked
- B1 sortition curve → DSR (security target).
- B2 accountId interlock + enrollment → airaccount (#200).
- registerWithProof-path SMT-hook test coverage → post-B1 pass.

cc CC-98.