### PR TITLE
chore(CC-98): deploy script + keeper + aggregator proof generator

### DIFF
--- a/contracts/script/DeployCommitteeValidator.s.sol
+++ b/contracts/script/DeployCommitteeValidator.s.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+/**
+ * @title DeployCommitteeValidator
+ * @dev Deploy the CC-98 AAStarCommitteeValidator (per-proposal random-committee BLS validator, PR #237)
+ *      and wire it to the SuperPaymaster Registry (stake source of truth), same as the Plan A v3 deploy.
+ *
+ *      DEPLOYS IN LEGACY MODE (committee mode OFF): the constructor leaves epochLength == 0, so validate()
+ *      behaves exactly like the base AAStarValidator (whole-set aggregate verify) — a safe drop-in for the
+ *      current 0x539B. This script INTENTIONALLY does NOT call setEpochLength.
+ *
+ *      MIGRATION INTERLOCK (pr-daemon B2 — do NOT skip): committee mode MUST NOT be enabled until the
+ *      accountId-injecting airaccount v0.31.0 accounts are deployed, mounted on this validator, and have
+ *      called enroll(). Flipping setEpochLength early would fail-close honest legacy traffic; an attacker's
+ *      legacy-shaped payload is blocked on-chain by the enrollment gate, but the correct order is still:
+ *        1) deploy this validator (epochLength == 0, legacy)             ← this script
+ *        2) airaccount deploys v0.31.0 accounts that inject address(this) + call enroll()
+ *        3) mount + testnet e2e
+ *        4) ONLY THEN: owner(Safe) calls setEpochLength(L) to turn committee mode on (L >= 64; N >= ~39)
+ *
+ *  SP_REGISTRY   = SuperPaymaster Registry (default: Sepolia deploy)
+ *  MIN_STAKE     = ROLE_DVT floor (default 30 ether GToken)
+ *  REQUIRE_STAKE = "true" to enable permissionless-but-staked immediately (default false = bootstrap)
+ *
+ *  forge script script/DeployCommitteeValidator.s.sol --rpc-url <RPC> --private-key <KEY> --broadcast --legacy
+ */
+
+import "forge-std/Script.sol";
+import "../src/AAStarCommitteeValidator.sol";
+
+contract DeployCommitteeValidator is Script {
+    // SuperPaymaster Sepolia (same source of truth as DeployStakeBoundValidator).
+    address constant SP_REGISTRY_SEPOLIA = 0xf5Bf37ca83AfdAab73691bA7eCcDfA69b8708E71;
+
+    function run() external {
+        address registry = vm.envOr("SP_REGISTRY", SP_REGISTRY_SEPOLIA);
+        uint256 minStake = vm.envOr("MIN_STAKE", uint256(30 ether));
+        bool requireStake = vm.envOr("REQUIRE_STAKE", false);
+
+        vm.startBroadcast();
+
+        AAStarCommitteeValidator validator = new AAStarCommitteeValidator();
+        validator.setRegistry(registry);
+        validator.setMinStake(minStake);
+        if (requireStake) validator.setRequireStake(true);
+        // NOTE: epochLength is deliberately left at 0 (committee mode OFF). See the migration interlock.
+
+        vm.stopBroadcast();
+
+        console.log("=== CC-98 AAStarCommitteeValidator deployed (LEGACY MODE, committee OFF) ===");
+        console.log("validator:     ", address(validator));
+        console.log("registry:      ", registry);
+        console.log("minStake:      ", minStake);
+        console.log("requireStake:  ", requireStake);
+        console.log("epochLength:   ", validator.epochLength(), "(0 = committee mode OFF)");
+        console.log("committeeActive:", validator.committeeActive());
+        console.log("oversample:    ", validator.oversampleNum(), "/", validator.oversampleDen());
+        console.log("owner:         ", validator.owner());
+        console.log("");
+        console.log("Next (migration interlock - in order):");
+        console.log(" 1. transfer owner to a Gnosis Safe");
+        console.log(" 2. airaccount deploys v0.31.0 accounts (inject address(this) + call enroll())");
+        console.log(" 3. mount + testnet e2e");
+        console.log(" 4. ONLY THEN owner(Safe) setEpochLength(L>=64) to enable committee mode (N>=~39)");
+    }
+}

--- a/contracts/script/DeployCommitteeValidator.s.sol
+++ b/contracts/script/DeployCommitteeValidator.s.sol
@@ -37,14 +37,19 @@ contract DeployCommitteeValidator is Script {
         address registry = vm.envOr("SP_REGISTRY", SP_REGISTRY_SEPOLIA);
         uint256 minStake = vm.envOr("MIN_STAKE", uint256(30 ether));
         bool requireStake = vm.envOr("REQUIRE_STAKE", false);
+        address newOwner = vm.envOr("OWNER", address(0)); // optional: hand off to a Safe in the same broadcast
 
         vm.startBroadcast();
 
         AAStarCommitteeValidator validator = new AAStarCommitteeValidator();
+        // Guard against wiring to a non-existent registry (e.g. the Sepolia default constant on a wrong chain).
+        require(registry.code.length > 0, "registry has no code on this chain");
         validator.setRegistry(registry);
         validator.setMinStake(minStake);
         if (requireStake) validator.setRequireStake(true);
         // NOTE: epochLength is deliberately left at 0 (committee mode OFF). See the migration interlock.
+        // Ownership transfer LAST — after the onlyOwner config above — so it doesn't strand those calls.
+        if (newOwner != address(0)) validator.transferOwnership(newOwner);
 
         vm.stopBroadcast();
 

--- a/deploy/committee-keeper.mjs
+++ b/deploy/committee-keeper.mjs
@@ -1,0 +1,74 @@
+// CC-98 snapshotEpoch keeper — permissionless per-epoch pin for AAStarCommitteeValidator.
+//
+// Committee mode fails closed unless each epoch is pinned within its 256-block window (blockhash
+// availability). This keeper polls the validator and calls snapshotEpoch() when the CURRENT epoch is
+// unpinned and still inside its window. Any funded key can run it (permissionless); run several for
+// redundancy — a missed window fail-closes committee ops for that epoch and the next, then self-heals.
+//
+// While epochLength == 0 (committee mode OFF) snapshotEpoch reverts and this keeper idles.
+//
+// env (.env.sepolia): SEPOLIA_RPC_URL, KEEPER_PRIVATE_KEY (or PRIVATE_KEY), COMMITTEE_VALIDATOR
+// Usage: node deploy/committee-keeper.mjs            (one pass)
+//        node deploy/committee-keeper.mjs --watch    (loop every ~30s)
+import { ethers } from "ethers";
+import { readFileSync } from "fs";
+
+const strip = s => s.replace(/^["']|["']$/g, "");
+const env = Object.fromEntries(
+  readFileSync(".env.sepolia", "utf8")
+    .split("\n").filter(l => l.includes("="))
+    .map(l => { const i = l.indexOf("="); return [l.slice(0, i).trim(), strip(l.slice(i + 1).trim())]; })
+);
+const RPC = env.SEPOLIA_RPC_URL || env.ETH_RPC_URL;
+const KEY = env.KEEPER_PRIVATE_KEY || env.PRIVATE_KEY;
+const VALIDATOR = process.env.COMMITTEE_VALIDATOR || env.COMMITTEE_VALIDATOR || "0x1A8Db639b5d8Bd5742edB083656EDD56f416cd64";
+const WATCH = process.argv.includes("--watch");
+
+const ABI = [
+  "function epochLength() view returns(uint256)",
+  "function epochPinned(uint256) view returns(bool)",
+  "function epochConfigVersion(uint256) view returns(uint256)",
+  "function configVersion() view returns(uint256)",
+  "function snapshotEpoch()",
+];
+
+async function tick() {
+  const provider = new ethers.JsonRpcProvider(RPC);
+  const wallet = new ethers.Wallet(KEY, provider);
+  const v = new ethers.Contract(VALIDATOR, ABI, wallet);
+
+  const epochLength = await v.epochLength();
+  if (epochLength === 0n) { console.log(new Date().toISOString(), "epochLength=0 (committee OFF) — idle"); return; }
+
+  const bn = BigInt(await provider.getBlockNumber());
+  const e = bn / epochLength;
+  const start = e * epochLength;
+  const pinned = await v.epochPinned(e);
+  const usable = pinned && (await v.epochConfigVersion(e)) === (await v.configVersion());
+
+  // Window: strictly after the epoch's first block, within 256 blocks (blockhash availability).
+  const inWindow = bn > start && bn <= start + 256n;
+
+  if (usable) { console.log(new Date().toISOString(), `epoch ${e} already pinned (usable) — nothing to do`); return; }
+  if (!inWindow) {
+    console.log(new Date().toISOString(), `epoch ${e}: block ${bn} outside pin window [${start + 1n}, ${start + 256n}] — cannot pin (self-heals next epoch)`);
+    return;
+  }
+  console.log(new Date().toISOString(), `epoch ${e}: pinning (block ${bn}, window ok)...`);
+  try {
+    const tx = await v.snapshotEpoch();
+    console.log("  snapshotEpoch tx:", tx.hash);
+    const r = await tx.wait();
+    console.log("  pinned in block", r.blockNumber, "status", r.status);
+  } catch (err) {
+    console.log("  snapshotEpoch failed:", err.shortMessage || err.reason || err.code || err.message);
+  }
+}
+
+if (WATCH) {
+  console.log("keeper watching", VALIDATOR, "— Ctrl-C to stop");
+  const loop = async () => { try { await tick(); } catch (e) { console.log("tick err", e.shortMessage || e.message); } setTimeout(loop, 30000); };
+  loop();
+} else {
+  tick().catch(e => { console.error(e.shortMessage || e.message); process.exit(1); });
+}

--- a/deploy/committee-keeper.mjs
+++ b/deploy/committee-keeper.mjs
@@ -49,26 +49,34 @@ async function tick() {
   // Window: strictly after the epoch's first block, within 256 blocks (blockhash availability).
   const inWindow = bn > start && bn <= start + 256n;
 
-  if (usable) { console.log(new Date().toISOString(), `epoch ${e} already pinned (usable) — nothing to do`); return; }
+  if (usable) { console.log(new Date().toISOString(), `epoch ${e} already pinned (usable) — nothing to do`); return "ok"; }
   if (!inWindow) {
     console.log(new Date().toISOString(), `epoch ${e}: block ${bn} outside pin window [${start + 1n}, ${start + 256n}] — cannot pin (self-heals next epoch)`);
-    return;
+    return "outside-window";
   }
   console.log(new Date().toISOString(), `epoch ${e}: pinning (block ${bn}, window ok)...`);
   try {
     const tx = await v.snapshotEpoch();
     console.log("  snapshotEpoch tx:", tx.hash);
-    const r = await tx.wait();
+    const r = await tx.wait(1, 120000); // 120s timeout so a mispriced tx doesn't hang forever
+    if (!r) { console.warn("  pin tx not mined within timeout — retry next tick"); return "timeout"; }
     console.log("  pinned in block", r.blockNumber, "status", r.status);
+    return "pinned";
   } catch (err) {
-    console.log("  snapshotEpoch failed:", err.shortMessage || err.reason || err.code || err.message);
+    const msg = err.shortMessage || err.reason || err.code || err.message || "";
+    // A redundant keeper that lost the race sees "epoch already pinned" — benign, log-and-continue.
+    if (/already pinned/i.test(msg)) { console.log("  another keeper pinned it first (benign):", msg); return "ok"; }
+    console.error("  snapshotEpoch FAILED:", msg);
+    return "error";
   }
 }
 
 if (WATCH) {
   console.log("keeper watching", VALIDATOR, "— Ctrl-C to stop");
-  const loop = async () => { try { await tick(); } catch (e) { console.log("tick err", e.shortMessage || e.message); } setTimeout(loop, 30000); };
+  const loop = async () => { try { await tick(); } catch (e) { console.error("tick err", e.shortMessage || e.message); } setTimeout(loop, 30000); };
   loop();
 } else {
-  tick().catch(e => { console.error(e.shortMessage || e.message); process.exit(1); });
+  tick()
+    .then(status => { if (status === "error" || status === "timeout") process.exit(1); }) // cron/systemd must see failure
+    .catch(e => { console.error(e.shortMessage || e.message); process.exit(1); });
 }

--- a/deploy/committee-proofgen.mjs
+++ b/deploy/committee-proofgen.mjs
@@ -1,0 +1,150 @@
+// CC-98 aggregator-side Merkle proof generator (reference for SDK/KMS + E2E).
+//
+// A committee op used during epoch e is verified against the FROZEN setRoot[e-1]. The submitter must
+// provide, per signer, a Merkle proof of (slot -> nodeId) against that frozen root. getMerkleProof() on
+// the contract only builds CURRENT-state proofs (valid only if the set is unchanged since the snapshot),
+// so the aggregator reconstructs the frozen tree from the SlotAssigned/SlotCleared event log up to the
+// epoch-(e-1) snapshot block, and reads the exact wire the account expects.
+//
+// The reconstruction is SELF-CHECKED: the recomputed root must equal the on-chain epochSetRoot[e-1]. If
+// it does not, we retry including/excluding same-snapshot-block mutations (the block-start latch), and
+// otherwise fail loudly rather than emit a proof that will fail-closed on chain.
+//
+// SMT: fixed depth TREE_DEPTH=14, leaf[slot]=nodeId (0=empty), parent=keccak256(abi.encode(left,right)),
+//      zeros[0]=0, zeros[l]=keccak(zeros[l-1],zeros[l-1]).
+//
+// env (.env.sepolia): SEPOLIA_RPC_URL, COMMITTEE_VALIDATOR
+// Usage (demo): node deploy/committee-proofgen.mjs <epoch> <nodeId>
+// Import:       import { reconstructFrozenTree, buildProof, buildCommitteePayload } from "./committee-proofgen.mjs"
+import { ethers } from "ethers";
+import { readFileSync } from "fs";
+
+const TREE_DEPTH = 14;
+const strip = s => s.replace(/^["']|["']$/g, "");
+
+function loadEnv() {
+  const env = Object.fromEntries(
+    readFileSync(".env.sepolia", "utf8").split("\n").filter(l => l.includes("="))
+      .map(l => { const i = l.indexOf("="); return [l.slice(0, i).trim(), strip(l.slice(i + 1).trim())]; })
+  );
+  return env;
+}
+
+const ABI = [
+  "event SlotAssigned(bytes32 indexed nodeId, uint256 slot)",
+  "event SlotCleared(bytes32 indexed nodeId, uint256 slot)",
+  "event EpochSnapshotted(uint256 indexed epoch, bytes32 seed, bytes32 setRoot, uint256 setCount)",
+  "function epochSetRoot(uint256) view returns(bytes32)",
+  "function epochSeed(uint256) view returns(bytes32)",
+];
+
+const zeros = (() => {
+  const z = [ethers.ZeroHash];
+  for (let i = 0; i < TREE_DEPTH; i++) z.push(ethers.keccak256(ethers.solidityPacked(["bytes32", "bytes32"], [z[i], z[i]])));
+  return z;
+})();
+const hashPair = (a, b) => ethers.keccak256(ethers.AbiCoder.defaultAbiCoder().encode(["bytes32", "bytes32"], [a, b]));
+
+// Build the fixed-depth SMT from a slot->nodeId leaf map; return root + a proof-builder over it.
+function buildTree(leafMap) {
+  // level 0 nodes present (occupied slots + siblings computed on demand); we materialize a sparse map.
+  let level = new Map(); // idx -> hash at current level
+  for (const [slot, nid] of leafMap) level.set(slot, nid);
+  const levels = [level];
+  for (let d = 0; d < TREE_DEPTH; d++) {
+    const cur = levels[d];
+    const next = new Map();
+    const seen = new Set();
+    for (const idx of cur.keys()) {
+      const p = idx >> 1n;
+      if (seen.has(p)) continue;
+      seen.add(p);
+      const l = cur.get(p * 2n) ?? zeros[d];
+      const r = cur.get(p * 2n + 1n) ?? zeros[d];
+      next.set(p, hashPair(l, r));
+    }
+    levels.push(next);
+  }
+  const root = levels[TREE_DEPTH].get(0n) ?? zeros[TREE_DEPTH];
+  const proofFor = slot => {
+    let idx = BigInt(slot);
+    const proof = [];
+    for (let d = 0; d < TREE_DEPTH; d++) {
+      const sib = idx ^ 1n;
+      proof.push(levels[d].get(sib) ?? zeros[d]);
+      idx >>= 1n;
+    }
+    return proof;
+  };
+  return { root, proofFor };
+}
+
+// Reconstruct the frozen tree for `epoch` (i.e. the setRoot committee ops in epoch+1 sample over).
+// Replays events up to the snapshot block; self-checks the recomputed root vs on-chain epochSetRoot.
+export async function reconstructFrozenTree(provider, validator, epoch) {
+  const c = new ethers.Contract(validator, ABI, provider);
+  const frozenRoot = await c.epochSetRoot(epoch);
+  if (frozenRoot === ethers.ZeroHash) throw new Error(`epoch ${epoch} not snapshotted (epochSetRoot==0)`);
+  const snapEvents = await c.queryFilter(c.filters.EpochSnapshotted(epoch));
+  if (!snapEvents.length) throw new Error(`no EpochSnapshotted event for epoch ${epoch}`);
+  const snapBlock = snapEvents[snapEvents.length - 1].blockNumber;
+
+  const assigned = await c.queryFilter(c.filters.SlotAssigned(), 0, snapBlock);
+  const cleared = await c.queryFilter(c.filters.SlotCleared(), 0, snapBlock);
+  const mutations = [...assigned.map(e => ({ ...e, kind: "assign" })), ...cleared.map(e => ({ ...e, kind: "clear" }))]
+    .sort((a, b) => a.blockNumber - b.blockNumber || a.transactionIndex - b.transactionIndex || a.logIndex - b.logIndex);
+
+  // The block-start latch: if the set was mutated in the snapshot block, the freeze used the pre-block
+  // state. Try excluding same-snapshot-block mutations first, then including, and keep whichever matches.
+  for (const cutoff of [b => b < snapBlock, b => b <= snapBlock]) {
+    const leafMap = new Map(); // slot(bigint) -> nodeId
+    for (const m of mutations) {
+      if (!cutoff(m.blockNumber)) continue;
+      const slot = BigInt(m.args.slot);
+      if (m.kind === "assign") leafMap.set(slot, m.args.nodeId);
+      else leafMap.delete(slot);
+    }
+    const tree = buildTree(leafMap);
+    if (tree.root.toLowerCase() === frozenRoot.toLowerCase()) {
+      const slotOfNode = new Map();
+      for (const [slot, nid] of leafMap) slotOfNode.set(nid.toLowerCase(), slot);
+      return { root: tree.root, tree, leafMap, slotOfNode, snapBlock };
+    }
+  }
+  throw new Error(`could not reconstruct a tree matching on-chain setRoot[${epoch}] ${frozenRoot}`);
+}
+
+// Per-signer proof against the frozen tree (throws if the node was not in the frozen set).
+export function buildProof(reconstructed, nodeId) {
+  const slot = reconstructed.slotOfNode.get(nodeId.toLowerCase());
+  if (slot === undefined) throw new Error(`nodeId ${nodeId} not in the frozen set`);
+  return { slot, proof: reconstructed.tree.proofFor(slot) };
+}
+
+// Assemble the submitter portion of validate()'s signature payload for committee mode.
+// account prepends accountId(=address(this)); here we include it for completeness/testing.
+//   [accountId(32)][ per signer: nodeId(32) || slot(32) || proof(TREE_DEPTH*32) ][ blsSig(256) ]
+// signers MUST be strictly ascending by nodeId (the aggregator sorts before submitting).
+export function buildCommitteePayload(reconstructed, accountId, signers, blsSig) {
+  const sorted = [...signers].sort((a, b) => (a.toLowerCase() < b.toLowerCase() ? -1 : 1));
+  let out = ethers.zeroPadValue(accountId, 32);
+  for (const nid of sorted) {
+    const { slot, proof } = buildProof(reconstructed, nid);
+    out = ethers.concat([out, ethers.zeroPadValue(nid, 32), ethers.zeroPadValue(ethers.toBeHex(slot), 32), ...proof]);
+  }
+  return ethers.concat([out, blsSig]);
+}
+
+// ---- CLI demo ----
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const env = loadEnv();
+  const provider = new ethers.JsonRpcProvider(env.SEPOLIA_RPC_URL);
+  const validator = process.env.COMMITTEE_VALIDATOR || env.COMMITTEE_VALIDATOR || "0x1A8Db639b5d8Bd5742edB083656EDD56f416cd64";
+  const epoch = BigInt(process.argv[2] ?? "0");
+  const nodeId = process.argv[3];
+  (async () => {
+    const r = await reconstructFrozenTree(provider, validator, epoch);
+    console.log("frozen setRoot[" + epoch + "] reconstructed OK:", r.root, "(", r.leafMap.size, "leaves, snapBlock", r.snapBlock, ")");
+    if (nodeId) console.log("proof for", nodeId, "=>", JSON.stringify(buildProof(r, nodeId)));
+  })().catch(e => { console.error("proofgen:", e.message); process.exit(1); });
+}

--- a/deploy/committee-proofgen.mjs
+++ b/deploy/committee-proofgen.mjs
@@ -6,9 +6,11 @@
 // so the aggregator reconstructs the frozen tree from the SlotAssigned/SlotCleared event log up to the
 // epoch-(e-1) snapshot block, and reads the exact wire the account expects.
 //
-// The reconstruction is SELF-CHECKED: the recomputed root must equal the on-chain epochSetRoot[e-1]. If
-// it does not, we retry including/excluding same-snapshot-block mutations (the block-start latch), and
-// otherwise fail loudly rather than emit a proof that will fail-closed on chain.
+// The Merkle reconstruction is SELF-CHECKED: the recomputed root must equal the on-chain
+// epochSetRoot[e-1], else it throws (never emits a proof that would fail-closed on chain). NOTE: only
+// Merkle membership is checked here — the OTHER on-chain gates (sortition draw, quorum k>=ceil(2*m_e/3),
+// current isRegistered/stake) are NOT validated by this tool; the caller/SDK must select signers that
+// pass them (see buildCommitteePayload's caveat).
 //
 // SMT: fixed depth TREE_DEPTH=14, leaf[slot]=nodeId (0=empty), parent=keccak256(abi.encode(left,right)),
 //      zeros[0]=0, zeros[l]=keccak(zeros[l-1],zeros[l-1]).
@@ -89,29 +91,44 @@ export async function reconstructFrozenTree(provider, validator, epoch) {
   if (!snapEvents.length) throw new Error(`no EpochSnapshotted event for epoch ${epoch}`);
   const snapBlock = snapEvents[snapEvents.length - 1].blockNumber;
 
-  const assigned = await c.queryFilter(c.filters.SlotAssigned(), 0, snapBlock);
-  const cleared = await c.queryFilter(c.filters.SlotCleared(), 0, snapBlock);
+  // Chunked eth_getLogs from the deploy block (not 0): the log set only grows and RPCs cap by result
+  // count (~10k). fromBlock defaults to DEPLOY_BLOCK env, else 0 with a warning.
+  const fromBlock = Number(process.env.DEPLOY_BLOCK ?? 0);
+  if (!process.env.DEPLOY_BLOCK) console.warn("proofgen: DEPLOY_BLOCK unset — scanning from block 0 (set it to the validator's creation block for large histories)");
+  const CHUNK = 9000;
+  const getLogsChunked = async filter => {
+    const out = [];
+    for (let from = fromBlock; from <= snapBlock; from += CHUNK + 1) {
+      const to = Math.min(from + CHUNK, snapBlock);
+      out.push(...(await c.queryFilter(filter, from, to)));
+    }
+    return out;
+  };
+  const assigned = await getLogsChunked(c.filters.SlotAssigned());
+  const cleared = await getLogsChunked(c.filters.SlotCleared());
+  // Strict LOG ORDER. ethers v6 renamed Log.logIndex -> Log.index; using the wrong field yields NaN and
+  // leaves same-tx events in concatenation order (assign-before-clear), corrupting slot-rotation replays.
   const mutations = [...assigned.map(e => ({ ...e, kind: "assign" })), ...cleared.map(e => ({ ...e, kind: "clear" }))]
-    .sort((a, b) => a.blockNumber - b.blockNumber || a.transactionIndex - b.transactionIndex || a.logIndex - b.logIndex);
+    .sort((a, b) => a.blockNumber - b.blockNumber || a.transactionIndex - b.transactionIndex || a.index - b.index);
 
-  // The block-start latch: if the set was mutated in the snapshot block, the freeze used the pre-block
-  // state. Try excluding same-snapshot-block mutations first, then including, and keep whichever matches.
-  for (const cutoff of [b => b < snapBlock, b => b <= snapBlock]) {
-    const leafMap = new Map(); // slot(bigint) -> nodeId
-    for (const m of mutations) {
-      if (!cutoff(m.blockNumber)) continue;
-      const slot = BigInt(m.args.slot);
-      if (m.kind === "assign") leafMap.set(slot, m.args.nodeId);
-      else leafMap.delete(slot);
-    }
-    const tree = buildTree(leafMap);
-    if (tree.root.toLowerCase() === frozenRoot.toLowerCase()) {
-      const slotOfNode = new Map();
-      for (const [slot, nid] of leafMap) slotOfNode.set(nid.toLowerCase(), slot);
-      return { root: tree.root, tree, leafMap, slotOfNode, snapBlock };
-    }
+  // Contract semantics: snapshotEpoch freezes the state as of the END of snapBlock-1 (the block-start
+  // latch value; mutations in snapBlock itself are excluded). So the cutoff is strictly < snapBlock.
+  const leafMap = new Map(); // slot(bigint) -> nodeId
+  for (const m of mutations) {
+    if (m.blockNumber >= snapBlock) continue;
+    const slot = BigInt(m.args.slot);
+    if (m.kind === "assign") leafMap.set(slot, m.args.nodeId);
+    else leafMap.delete(slot);
   }
-  throw new Error(`could not reconstruct a tree matching on-chain setRoot[${epoch}] ${frozenRoot}`);
+  const tree = buildTree(leafMap);
+  if (tree.root.toLowerCase() !== frozenRoot.toLowerCase()) {
+    const tail = mutations.filter(m => m.blockNumber < snapBlock).slice(-5)
+      .map(m => `${m.kind}(slot ${m.args.slot} @blk ${m.blockNumber})`).join(", ");
+    throw new Error(`reconstructed root ${tree.root} != on-chain setRoot[${epoch}] ${frozenRoot} (${leafMap.size} leaves; last: ${tail})`);
+  }
+  const slotOfNode = new Map();
+  for (const [slot, nid] of leafMap) slotOfNode.set(nid.toLowerCase(), slot);
+  return { root: tree.root, tree, leafMap, slotOfNode, snapBlock };
 }
 
 // Per-signer proof against the frozen tree (throws if the node was not in the frozen set).
@@ -126,11 +143,19 @@ export function buildProof(reconstructed, nodeId) {
 //   [accountId(32)][ per signer: nodeId(32) || slot(32) || proof(TREE_DEPTH*32) ][ blsSig(256) ]
 // signers MUST be strictly ascending by nodeId (the aggregator sorts before submitting).
 export function buildCommitteePayload(reconstructed, accountId, signers, blsSig) {
-  const sorted = [...signers].sort((a, b) => (a.toLowerCase() < b.toLowerCase() ? -1 : 1));
+  if (ethers.dataLength(blsSig) !== 256) throw new Error(`blsSig must be exactly 256 bytes, got ${ethers.dataLength(blsSig)}`);
+  // Normalize to canonical 32-byte form FIRST, then sort by numeric value (BigInt compare — NOT
+  // Array.sort's Number coercion, which loses precision above 2^53). Assert strictly increasing so
+  // the on-chain nid <= prevId gate never rejects and duplicates are caught here.
+  const norm = signers.map(s => ethers.zeroPadValue(s, 32));
+  norm.sort((a, b) => (BigInt(a) < BigInt(b) ? -1 : BigInt(a) > BigInt(b) ? 1 : 0));
+  for (let i = 1; i < norm.length; i++) {
+    if (BigInt(norm[i]) <= BigInt(norm[i - 1])) throw new Error(`signers must be strictly increasing; dup/misorder at ${norm[i]}`);
+  }
   let out = ethers.zeroPadValue(accountId, 32);
-  for (const nid of sorted) {
+  for (const nid of norm) {
     const { slot, proof } = buildProof(reconstructed, nid);
-    out = ethers.concat([out, ethers.zeroPadValue(nid, 32), ethers.zeroPadValue(ethers.toBeHex(slot), 32), ...proof]);
+    out = ethers.concat([out, nid, ethers.zeroPadValue(ethers.toBeHex(slot), 32), ...proof]);
   }
   return ethers.concat([out, blsSig]);
 }


### PR DESCRIPTION
Off-chain tooling for the merged CC-98 committee validator (PR #237), plus the deployment.

## Deployed (Sepolia, LEGACY MODE)
`AAStarCommitteeValidator` @ **0x1A8Db639b5d8Bd5742edB083656EDD56f416cd64** — `epochLength=0` / `committeeActive=false` (safe drop-in; committee mode OFF per the migration interlock). registry=SP, minStake=30, oversample 5/4, TREE_DEPTH 14, owner=deployer (→ Safe).

## Contents
- `script/DeployCommitteeValidator.s.sol` — deploys in legacy mode; migration interlock documented (enable committee mode only AFTER airaccount v0.31.0 accounts are deployed + enrolled).
- `deploy/committee-keeper.mjs` — permissionless per-epoch `snapshotEpoch()` pin (256-block window); idles while committee off.
- `deploy/committee-proofgen.mjs` — reconstructs the frozen `setRoot[e-1]` SMT from events, builds per-signer proofs + the committee payload; SELF-CHECKED vs on-chain root (never emits a bad proof).

Not blocking airaccount's account code. Needed before committee-mode E2E (which is gated on airaccount v0.31.0 + `setEpochLength`).