### PR TITLE
chore(CC-104): local testnet-local DVT stack config + mesh overlay

### DIFF
--- a/deploy/sdk-dvt-config.testnet.json
+++ b/deploy/sdk-dvt-config.testnet.json
@@ -109,6 +109,53 @@
         }
       }
     },
+    "testnet-local": {
+      "network": "testnet-local",
+      "chainId": 11155111,
+      "status": "LOCAL MIRROR of `sepolia` — same on-chain setup (validator 0x539B, same account, same 3 registered nodeIds), only dvtNodes urls point at a local docker stack (127.0.0.1:3001-3003) so composite-T3 E2E runs even when the dvt1/2/3.aastar.io Cloudflare tunnel is down (HTTP 530). Select via AASTAR_DVT_ENV=testnet-local (do NOT change `active`). Start the stack: docker compose --env-file deploy/.env.testnet -f docker-compose.testnet.yml -f docker-compose.local-mesh.yml up -d dvt-node-1 dvt-node-2 dvt-node-3. Keys = deploy/node{1,2,3}/node_state.json (already registered on 0x539B; NEVER regenerate).",
+      "validator": "0x539B9681aFd5BFbCaa655Fe4c6BdcFe1fa7864bC",
+      "validatorVersion": "YetAnotherAA-Validator AAStarValidator (Plan A v3 stake-bound; validate() algId 0x01 + registerWithProof + on-chain RFC-9380). Mounted in airaccount v0.27.0 ValidatorRouter 0xe68d6A7Bb60DA4caE62ceC2439722fc5eEF87a5c (getAlgorithm(0x01)==this). Supersedes airaccount-contract v0.20.0 AAStarBLSAlgorithm 0xAF525A… for new integrations.",
+      "entryPoint": "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+      "entryPointVersion": "v0.7",
+      "e2eAccount": "0x92EA8b02D34A4D5d10f0Db9Ea894e8bC72e292e8",
+      "e2eAccountNote": "airaccount-contract AAStarAirAccountV7 v0.27.0 implementing isValidOwnerAuth->0xa0cf00cf (CC-22). owner = 0xb5600060e6de5E11D3636731964218E53caadf0E (dvt1 operator). Source: airaccount-contract, NOT DVT-owned — see docs/INTERFACES.md §2.",
+      "conventions": {
+        "userOpHash": "EntryPoint.getUserOpHash(PackedUserOp) — node derives it; never send a bare hash",
+        "ownerAuth": "account.isValidOwnerAuth(userOpHash, ownerAuth) eth_call → success magic 0xa0cf00cf, fail 0xffffffff. The account is the single source of truth (k1 ECDSA / P256 passkey / future); DVT forwards ownerAuth verbatim and never verifies locally. ownerAuth = 1-byte tag ‖ payload: 0x01 = owner ECDSA k1 (65-byte personal_sign(userOpHash), EIP-191); 0x02 = owner WebAuthn passkey (authenticatorData‖clientDataJSON‖…). A bare signature with no tag returns 0xffffffff → 403. Requires an account implementing isValidOwnerAuth(bytes32,bytes) (AAStarAirAccountV7).",
+        "proofWire": "EIP-2537 G1/G2 (matches src/utils/bls.util.ts)",
+        "failClosed": "POST /signature/sign returns 403 for every rejected request (never 400)",
+        "mandatoryBlsAccount": "guard-enabled + approvedAlgIds=[0x01] (excludes 0x02 ECDSA)"
+      },
+      "dvtNodes": [
+        {
+          "url": "http://127.0.0.1:3001",
+          "nodeId": "0x1f5e41c69465733eeb19341d95853ee6d9295a9e6698f5398d70e509be8f326d",
+          "pubkey": "0x8067dfd1f98fd1258c0eed3886d234f81eea9371b595a1a278a49c71f8f5eda74639fa043948f7fc0ee3e6b8ec9b8555"
+        },
+        {
+          "url": "http://127.0.0.1:3002",
+          "nodeId": "0xe3a4a3af3973b65bc95dd962e767e17592dfb331f3544209676271b188fd9f80",
+          "pubkey": "0xb2fcf33a6ee467e9945734bbaadfd85574d98bb5a3bb75c9a78e68807290883a1e90d3b75b911b9ebc19db0bd2db9173"
+        },
+        {
+          "url": "http://127.0.0.1:3003",
+          "nodeId": "0x96d64ba8240694153c757707732a11ff175380065ddacb6406094c9d5fa5cfce",
+          "pubkey": "0x89ffc557d29bc3a11caf3bb3ae8fb6bbd17c60a8e26e9b6be6dbaf8b5f33a3ef8a3d29e765a53f436b3b7dddd3ce8fac"
+        }
+      ],
+      "capabilities": {
+        "dvtSigning": {
+          "endpoints": {
+            "sign": "POST {url}/signature/sign  body: {userOp:PackedUserOp(v0.7), ownerAuth} -> {nodeId, signature(EIP-2537), publicKey}",
+            "aggregate": "POST {url}/signature/aggregate",
+            "verify": "POST {url}/signature/verify",
+            "info": "GET {url}/node/info -> {nodeId, publicKey, ...}",
+            "openapi": "GET {url}/api"
+          }
+        },
+        "health": "GET {url}/health -> {status:'ok', capabilities:[{name,enabled}]}"
+      }
+    },
     "mainnet": {
       "network": "mainnet",
       "chainId": 1,

--- a/docker-compose.local-mesh.yml
+++ b/docker-compose.local-mesh.yml
@@ -1,0 +1,25 @@
+# Local-only overlay — wires the 3 nodes into a gossip mesh over the docker network,
+# so the local stack works for BOTH aggregation models:
+#   • coordinator-driven (SDK collects each /sign, then one node /signature/aggregate) — needs no mesh
+#   • self-discovery (nodes gossip-discover peers) — needs this mesh
+#
+# Tunnel-independent local composite-T3 testing. Use ALONGSIDE docker-compose.testnet.yml:
+#   docker compose --env-file deploy/.env.testnet \
+#     -f docker-compose.testnet.yml -f docker-compose.local-mesh.yml \
+#     up -d dvt-node-1 dvt-node-2 dvt-node-3
+#
+# Each node must ALSO advertise a docker-reachable GOSSIP_PUBLIC_URL (not the default
+# ws://localhost:PORT/ws), or peers exchange localhost endpoints they cannot dial back.
+services:
+  dvt-node-1:
+    environment:
+      GOSSIP_PUBLIC_URL: ws://dvt-node-1:3001/ws
+      GOSSIP_BOOTSTRAP_PEERS: ws://dvt-node-2:3002/ws,ws://dvt-node-3:3003/ws
+  dvt-node-2:
+    environment:
+      GOSSIP_PUBLIC_URL: ws://dvt-node-2:3002/ws
+      GOSSIP_BOOTSTRAP_PEERS: ws://dvt-node-1:3001/ws,ws://dvt-node-3:3003/ws
+  dvt-node-3:
+    environment:
+      GOSSIP_PUBLIC_URL: ws://dvt-node-3:3003/ws
+      GOSSIP_BOOTSTRAP_PEERS: ws://dvt-node-1:3001/ws,ws://dvt-node-2:3002/ws

--- a/docs/DVT_OPERATIONS.md
+++ b/docs/DVT_OPERATIONS.md
@@ -1,0 +1,56 @@
+# DVT 运营手册（AAStarValidator / AAStarCommitteeValidator）
+
+> BLS 门限签名验证器 —— 为 ERC-4337 账户的 tier-2/3 授权提供去中心化联签 + 质押问责。
+> Sepolia：legacy `0x539B9681…` · committee `0x1A8Db639…`。账户 router `getAlgorithm(0x01)` 挂其一。
+
+## 核心价值
+账户把 tier-2/3 的 BLS 验证委托给链上 validator。DVT 提供的不是"多签"，是**去中心化门限**：
+- **no single node forges a quorum** —— 严格递增 nodeId（防单节点重复凑数）+ 质押绑定 + pubkey 唯一性。
+- **签名绑定 `userOpHash`**（EntryPoint 已绑 sender/chainId/nonce）→ 防跨账户 oracle；`accountId` 绝不进签名。
+- **质押问责** —— `registerWithProof` 绑 ROLE_DVT 质押，可 slash。
+
+## 两种模式（同一验证器，owner 手动开关，非自动）
+| | Legacy（whole-set） | Committee（per-proposal） |
+|---|---|---|
+| 开关 | `epochLength=0`（默认） | `setEpochLength(N≠0)` |
+| 签名集 | 提交的 nodeId（账户 tier 定最小数） | per-proposal 抽样委员会 |
+| quorum | 账户 tier 要求 | `requiredQuorum()=⌈2·m_e/3⌉` |
+| 抽样 | 无 | `H(CMT_SELECT, seed, accountId, nodeId) < T` |
+| 前置 | 节点注册 | 节点注册 + 账户 `enrollInCommitteeValidator()` + keeper |
+
+**降级规则**：legacy↔committee 手动切；committee 模式**内**委员会大小随 N 自动伸缩（下表）。committee 不需要 17/30 个节点才能用 —— N=3 即可（退化 whole-set）。
+
+## 安全阈值表（链上 `expectedCommittee`/`requiredQuorum` 实测）
+| N 活跃节点 | 委员会 m_e | quorum | 安全模型 |
+|---|---|---|---|
+| 3 | 3 | 2 | whole-set 2-of-3（机制验证，非抽样安全）|
+| 8 / 17 | =N | 6 / 12 | whole-set |
+| 30 | 30 | 20 | whole-set 边界 |
+| 31–150 | 30（floor） | 20 | **抽样开始**（m_e<N）|
+| 200 | 40 | 27 | 抽样 ⌈N/5⌉ |
+| ≥430 | 86（cap） | 58 | 抽样上限 |
+
+**安全系数**：forgery `P ≤ 1e-6 @ β≤10%`（敌手持 ≤10% 全网质押）；liveness `P(失败) ≤ 1e-3`；oversample `1.25×`。**floor 30 是抽样安全下限** —— N<30 走 whole-set BFT 2/3，没有抽样界。cap 86 控 calldata/gas。
+
+## 部署依赖（顺序）
+1. validator 合约部署（committee 版 = `#237` AAStarCommitteeValidator）
+2. 账户 router `registerAlgorithm(0x01, validator)`（set-once + finalized，不可改指）
+3. 节点注册到该 validator：`registerWithProof`（生产，质押 30 ETH + PoP）或 `batchRegisterPublicKeys`（bootstrap，owner，仅测试/受信）
+4. committee 模式还需：账户 `enrollInCommitteeValidator()` → **迁移联锁：enroll 必须在 setEpochLength 之前**（否则未 enroll 账户 self-brick）
+
+## 运营
+- **翻转（两步，不可逆治理）**：`setEpochLength(N)` + `snapshotEpoch()`，然后**等跨过一个 epoch 边界**（~N 块）`requiredQuorum()` 才从哨兵 `type(uint256).max` 变真值 → 读回确认非哨兵再宣布可用。回 legacy = `setEpochLength(0)`。
+- **keeper**（`deploy/committee-keeper.mjs --watch`）：committee ON 时**必须常驻**，每 epoch 在首块后 256 块窗口内 `snapshotEpoch()` pin。漏 pin → 该 epoch + 下个 fail-close，自愈。permissionless，建议 ≥2 冗余。
+- **proofgen**（`deploy/committee-proofgen.mjs`）：aggregator 对冻结树 `setRoot[e-1]` 重建 per-signer Merkle 证明。
+- ⚠️ **别把同一把 pubkey 注册成两个 nodeId**（owner 误配缺口，能让 1 个签名者凑假 quorum）——注册前查 pubkey 未占用。
+
+## 验证过程（`validate(userOpHash, payload)`）
+1. `messagePoint = hashToG2(userOpHash)`（RFC-9380，DST=`BLS_SIG_..._POP_`，链上/节点/KMS 三方逐字节一致）
+2. 逐 signer：nodeId 严格递增 + `isRegistered` +（committee：Merkle proof ∈ `setRoot[e-1]` + sortition 命中）
+3. Σpubkey 聚合 + EIP-2537 pairing 验 Σsig（k=2 每对 102,900 gas）
+4. `k ≥ requiredQuorum`
+5. 全过 → `return 0`（accept）；任一不过 → `return 1`（**fail-closed**）
+
+## 节点侧（signer 服务）核心
+- `POST /signature/sign` **fail-closed**：必须带完整 PackedUserOp + owner ECDSA 授权（节点自派生 userOpHash 再验 `isValidOwnerAuth`），任何失败一律 **403**。防未授权调用方，不防 owner 私钥泄露（那靠链上 guard 限额）。
+- 密钥：`node_state.json`（BLS 私钥，git-ignored）或 KMS-TEE 托管（`RUST_SIGNER_URL`）。

--- a/docs/DVT_OPERATIONS.md
+++ b/docs/DVT_OPERATIONS.md
@@ -12,11 +12,11 @@
 ## 两种模式（同一验证器，owner 手动开关，非自动）
 | | Legacy（whole-set） | Committee（per-proposal） |
 |---|---|---|
-| 开关 | `epochLength=0`（默认） | `setEpochLength(N≠0)` |
+| 开关 | `epochLength=0`（默认） | `setEpochLength(N≥64)`（约束 `==0 \|\| >=64`，N=1..63 revert） |
 | 签名集 | 提交的 nodeId（账户 tier 定最小数） | per-proposal 抽样委员会 |
 | quorum | 账户 tier 要求 | `requiredQuorum()=⌈2·m_e/3⌉` |
 | 抽样 | 无 | `H(CMT_SELECT, seed, accountId, nodeId) < T` |
-| 前置 | 节点注册 | 节点注册 + 账户 `enrollInCommitteeValidator()` + keeper |
+| 前置 | 节点注册 | 节点注册 + 账户 `enroll()`（airaccount 侧封装 `enrollInCommitteeValidator()`）+ keeper |
 
 **降级规则**：legacy↔committee 手动切；committee 模式**内**委员会大小随 N 自动伸缩（下表）。committee 不需要 17/30 个节点才能用 —— N=3 即可（退化 whole-set）。
 
@@ -36,7 +36,7 @@
 1. validator 合约部署（committee 版 = `#237` AAStarCommitteeValidator）
 2. 账户 router `registerAlgorithm(0x01, validator)`（set-once + finalized，不可改指）
 3. 节点注册到该 validator：`registerWithProof`（生产，质押 30 ETH + PoP）或 `batchRegisterPublicKeys`（bootstrap，owner，仅测试/受信）
-4. committee 模式还需：账户 `enrollInCommitteeValidator()` → **迁移联锁：enroll 必须在 setEpochLength 之前**（否则未 enroll 账户 self-brick）
+4. committee 模式还需：账户 self-enroll 调验证器 `enroll()`（本仓 `AAStarCommitteeValidator.sol:323`，selector `0xe65f2a7e`，msg.sender=账户；airaccount 侧封装为 `enrollInCommitteeValidator()`）→ **迁移联锁：enroll 必须在 setEpochLength 之前**（否则未 enroll 账户 self-brick）
 
 ## 运营
 - **翻转（两步，不可逆治理）**：`setEpochLength(N)` + `snapshotEpoch()`，然后**等跨过一个 epoch 边界**（~N 块）`requiredQuorum()` 才从哨兵 `type(uint256).max` 变真值 → 读回确认非哨兵再宣布可用。回 legacy = `setEpochLength(0)`。

--- a/docs/DVT_OPERATIONS.md
+++ b/docs/DVT_OPERATIONS.md
@@ -1,56 +1,87 @@
 # DVT 运营手册（AAStarValidator / AAStarCommitteeValidator）
 
-> BLS 门限签名验证器 —— 为 ERC-4337 账户的 tier-2/3 授权提供去中心化联签 + 质押问责。
-> Sepolia：legacy `0x539B9681…` · committee `0x1A8Db639…`。账户 router `getAlgorithm(0x01)` 挂其一。
+> BLS 门限签名验证器 —— 为 ERC-4337 账户的 tier-2/3 授权提供去中心化联签 + 质押问责。Sepolia：legacy
+> `0x539B9681…` · committee `0x1A8Db639…`。账户 router `getAlgorithm(0x01)`
+> 挂其一。
 
 ## 核心价值
+
 账户把 tier-2/3 的 BLS 验证委托给链上 validator。DVT 提供的不是"多签"，是**去中心化门限**：
-- **no single node forges a quorum** —— 严格递增 nodeId（防单节点重复凑数）+ 质押绑定 + pubkey 唯一性。
-- **签名绑定 `userOpHash`**（EntryPoint 已绑 sender/chainId/nonce）→ 防跨账户 oracle；`accountId` 绝不进签名。
+
+- **no single node forges a quorum**
+  —— 严格递增 nodeId（防单节点重复凑数）+ 质押绑定 + pubkey 唯一性。
+- **签名绑定
+  `userOpHash`**（EntryPoint 已绑 sender/chainId/nonce）→ 防跨账户 oracle；`accountId`
+  绝不进签名。
 - **质押问责** —— `registerWithProof` 绑 ROLE_DVT 质押，可 slash。
 
 ## 两种模式（同一验证器，owner 手动开关，非自动）
-| | Legacy（whole-set） | Committee（per-proposal） |
-|---|---|---|
-| 开关 | `epochLength=0`（默认） | `setEpochLength(N≥64)`（约束 `==0 \|\| >=64`，N=1..63 revert） |
-| 签名集 | 提交的 nodeId（账户 tier 定最小数） | per-proposal 抽样委员会 |
-| quorum | 账户 tier 要求 | `requiredQuorum()=⌈2·m_e/3⌉` |
-| 抽样 | 无 | `H(CMT_SELECT, seed, accountId, nodeId) < T` |
-| 前置 | 节点注册 | 节点注册 + 账户 `enroll()`（airaccount 侧封装 `enrollInCommitteeValidator()`）+ keeper |
 
-**降级规则**：legacy↔committee 手动切；committee 模式**内**委员会大小随 N 自动伸缩（下表）。committee 不需要 17/30 个节点才能用 —— N=3 即可（退化 whole-set）。
+|        | Legacy（whole-set）                 | Committee（per-proposal）                                                              |
+| ------ | ----------------------------------- | -------------------------------------------------------------------------------------- |
+| 开关   | `epochLength=0`（默认）             | `setEpochLength(N≥64)`（约束 `==0 \|\| >=64`，N=1..63 revert）                         |
+| 签名集 | 提交的 nodeId（账户 tier 定最小数） | per-proposal 抽样委员会                                                                |
+| quorum | 账户 tier 要求                      | `requiredQuorum()=⌈2·m_e/3⌉`                                                           |
+| 抽样   | 无                                  | `H(CMT_SELECT, seed, accountId, nodeId) < T`                                           |
+| 前置   | 节点注册                            | 节点注册 + 账户 `enroll()`（airaccount 侧封装 `enrollInCommitteeValidator()`）+ keeper |
+
+**降级规则**：legacy↔committee 手动切；committee 模式**内**委员会大小随 N 自动伸缩（下表）。committee 不需要 17/30 个节点才能用 ——
+N=3 即可（退化 whole-set）。
 
 ## 安全阈值表（链上 `expectedCommittee`/`requiredQuorum` 实测）
-| N 活跃节点 | 委员会 m_e | quorum | 安全模型 |
-|---|---|---|---|
-| 3 | 3 | 2 | whole-set 2-of-3（机制验证，非抽样安全）|
-| 8 / 17 | =N | 6 / 12 | whole-set |
-| 30 | 30 | 20 | whole-set 边界 |
-| 31–150 | 30（floor） | 20 | **抽样开始**（m_e<N）|
-| 200 | 40 | 27 | 抽样 ⌈N/5⌉ |
-| ≥430 | 86（cap） | 58 | 抽样上限 |
 
-**安全系数**：forgery `P ≤ 1e-6 @ β≤10%`（敌手持 ≤10% 全网质押）；liveness `P(失败) ≤ 1e-3`；oversample `1.25×`。**floor 30 是抽样安全下限** —— N<30 走 whole-set BFT 2/3，没有抽样界。cap 86 控 calldata/gas。
+| N 活跃节点 | 委员会 m_e  | quorum | 安全模型                                 |
+| ---------- | ----------- | ------ | ---------------------------------------- |
+| 3          | 3           | 2      | whole-set 2-of-3（机制验证，非抽样安全） |
+| 8 / 17     | =N          | 6 / 12 | whole-set                                |
+| 30         | 30          | 20     | whole-set 边界                           |
+| 31–150     | 30（floor） | 20     | **抽样开始**（m_e<N）                    |
+| 200        | 40          | 27     | 抽样 ⌈N/5⌉                               |
+| ≥430       | 86（cap）   | 58     | 抽样上限                                 |
+
+**安全系数**：forgery `P ≤ 1e-6 @ β≤10%`（敌手持 ≤10% 全网质押）；liveness
+`P(失败) ≤ 1e-3`；oversample `1.25×`。**floor 30 是抽样安全下限** ——
+N<30 走 whole-set BFT 2/3，没有抽样界。cap 86 控 calldata/gas。
 
 ## 部署依赖（顺序）
+
 1. validator 合约部署（committee 版 = `#237` AAStarCommitteeValidator）
-2. 账户 router `registerAlgorithm(0x01, validator)`（set-once + finalized，不可改指）
-3. 节点注册到该 validator：`registerWithProof`（生产，质押 30 ETH + PoP）或 `batchRegisterPublicKeys`（bootstrap，owner，仅测试/受信）
-4. committee 模式还需：账户 self-enroll 调验证器 `enroll()`（本仓 `AAStarCommitteeValidator.sol:323`，selector `0xe65f2a7e`，msg.sender=账户；airaccount 侧封装为 `enrollInCommitteeValidator()`）→ **迁移联锁：enroll 必须在 setEpochLength 之前**（否则未 enroll 账户 self-brick）
+2. 账户 router `registerAlgorithm(0x01, validator)`（set-once +
+   finalized，不可改指）
+3. 节点注册到该 validator：`registerWithProof`（生产，质押 30 ETH + PoP）或
+   `batchRegisterPublicKeys`（bootstrap，owner，仅测试/受信）
+4. committee 模式还需：账户 self-enroll 调验证器 `enroll()`（本仓
+   `AAStarCommitteeValidator.sol:323`，selector
+   `0xe65f2a7e`，msg.sender=账户；airaccount 侧封装为
+   `enrollInCommitteeValidator()`）→
+   **迁移联锁：enroll 必须在 setEpochLength 之前**（否则未 enroll 账户 self-brick）
 
 ## 运营
-- **翻转（两步，不可逆治理）**：`setEpochLength(N)` + `snapshotEpoch()`，然后**等跨过一个 epoch 边界**（~N 块）`requiredQuorum()` 才从哨兵 `type(uint256).max` 变真值 → 读回确认非哨兵再宣布可用。回 legacy = `setEpochLength(0)`。
-- **keeper**（`deploy/committee-keeper.mjs --watch`）：committee ON 时**必须常驻**，每 epoch 在首块后 256 块窗口内 `snapshotEpoch()` pin。漏 pin → 该 epoch + 下个 fail-close，自愈。permissionless，建议 ≥2 冗余。
-- **proofgen**（`deploy/committee-proofgen.mjs`）：aggregator 对冻结树 `setRoot[e-1]` 重建 per-signer Merkle 证明。
-- ⚠️ **别把同一把 pubkey 注册成两个 nodeId**（owner 误配缺口，能让 1 个签名者凑假 quorum）——注册前查 pubkey 未占用。
+
+- **翻转（两步，不可逆治理）**：`setEpochLength(N)` +
+  `snapshotEpoch()`，然后**等跨过一个 epoch 边界**（~N 块）`requiredQuorum()`
+  才从哨兵 `type(uint256).max` 变真值 → 读回确认非哨兵再宣布可用。回 legacy =
+  `setEpochLength(0)`。
+- **keeper**（`deploy/committee-keeper.mjs --watch`）：committee
+  ON 时**必须常驻**，每 epoch 在首块后 256 块窗口内 `snapshotEpoch()`
+  pin。漏 pin → 该 epoch + 下个 fail-close，自愈。permissionless，建议 ≥2 冗余。
+- **proofgen**（`deploy/committee-proofgen.mjs`）：aggregator 对冻结树
+  `setRoot[e-1]` 重建 per-signer Merkle 证明。
+- ⚠️
+  **别把同一把 pubkey 注册成两个 nodeId**（owner 误配缺口，能让 1 个签名者凑假 quorum）——注册前查 pubkey 未占用。
 
 ## 验证过程（`validate(userOpHash, payload)`）
+
 1. `messagePoint = hashToG2(userOpHash)`（RFC-9380，DST=`BLS_SIG_..._POP_`，链上/节点/KMS 三方逐字节一致）
-2. 逐 signer：nodeId 严格递增 + `isRegistered` +（committee：Merkle proof ∈ `setRoot[e-1]` + sortition 命中）
+2. 逐 signer：nodeId 严格递增 + `isRegistered` +（committee：Merkle proof ∈
+   `setRoot[e-1]` + sortition 命中）
 3. Σpubkey 聚合 + EIP-2537 pairing 验 Σsig（k=2 每对 102,900 gas）
 4. `k ≥ requiredQuorum`
 5. 全过 → `return 0`（accept）；任一不过 → `return 1`（**fail-closed**）
 
 ## 节点侧（signer 服务）核心
-- `POST /signature/sign` **fail-closed**：必须带完整 PackedUserOp + owner ECDSA 授权（节点自派生 userOpHash 再验 `isValidOwnerAuth`），任何失败一律 **403**。防未授权调用方，不防 owner 私钥泄露（那靠链上 guard 限额）。
+
+- `POST /signature/sign` **fail-closed**：必须带完整 PackedUserOp + owner
+  ECDSA 授权（节点自派生 userOpHash 再验 `isValidOwnerAuth`），任何失败一律
+  **403**。防未授权调用方，不防 owner 私钥泄露（那靠链上 guard 限额）。
 - 密钥：`node_state.json`（BLS 私钥，git-ignored）或 KMS-TEE 托管（`RUST_SIGNER_URL`）。


### PR DESCRIPTION
Local 3-node DVT test stack for SDK composite-T3 gate (tunnel-independent).

- `deploy/sdk-dvt-config.testnet.json`: `testnet-local` env (same registered nodeIds as sepolia, urls -> 127.0.0.1:3001-3003). Mirrors aastar-sdk `DVT_CONFIG.environments.testnet-local` to prevent config drift.
- `docker-compose.local-mesh.yml`: local-only overlay wiring the 3 nodes into a gossip mesh (GOSSIP_BOOTSTRAP_PEERS + GOSSIP_PUBLIC_URL) — serves both coordinator-driven and self-discovery aggregation.

Context: CC-104 committee E2E + SDK composite-T3 (dvt1/2/3.aastar.io 530 workaround).